### PR TITLE
Execute P0 task output through the harness workspace pipeline

### DIFF
--- a/services/local-service/internal/bootstrap/bootstrap.go
+++ b/services/local-service/internal/bootstrap/bootstrap.go
@@ -3,12 +3,15 @@ package bootstrap
 
 import (
 	"context"
+	"os"
+	"strings"
 
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/audit"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/checkpoint"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/config"
 	contextsvc "github.com/cialloclaw/cialloclaw/services/local-service/internal/context"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/delivery"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/execution"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/intent"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/memory"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/model"
@@ -38,20 +41,36 @@ func New(cfg config.Config) (*App, error) {
 	_ = audit.NewService()
 	_ = checkpoint.NewService()
 	storageService := storage.NewService(platform.NewLocalStorageAdapter(cfg.DatabasePath))
-	_ = platform.NewLocalFileSystemAdapter(pathPolicy)
+	fileSystem := platform.NewLocalFileSystemAdapter(pathPolicy)
 	_ = platform.LocalExecutionBackend{}
+
+	modelService := model.NewService(cfg.Model)
+	apiKey := strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+	if apiKey != "" {
+		if configuredModelService, err := model.NewServiceFromConfig(model.ServiceConfig{
+			ModelConfig: cfg.Model,
+			APIKey:      apiKey,
+		}); err == nil {
+			modelService = configuredModelService
+		}
+	}
+
+	deliveryService := delivery.NewService()
+	toolRegistry := tools.NewRegistry()
+	pluginService := plugin.NewService()
+	executionService := execution.NewService(fileSystem, modelService, deliveryService, toolRegistry, pluginService)
 
 	orchestratorService := orchestrator.NewService(
 		contextsvc.NewService(),
 		intent.NewService(),
 		runengine.NewEngine(),
-		delivery.NewService(),
+		deliveryService,
 		memory.NewServiceFromStorage(storageService.MemoryStore(), storageService.Capabilities().MemoryRetrievalBackend),
 		risk.NewService(),
-		model.NewService(cfg.Model),
-		tools.NewRegistry(),
-		plugin.NewService(),
-	)
+		modelService,
+		toolRegistry,
+		pluginService,
+	).WithExecutor(executionService)
 
 	return &App{server: rpc.NewServer(cfg.RPC, orchestratorService), storage: storageService}, nil
 }

--- a/services/local-service/internal/delivery/service.go
+++ b/services/local-service/internal/delivery/service.go
@@ -87,6 +87,11 @@ func (s *Service) BuildBubbleMessage(taskID, bubbleType, text, createdAt string)
 // BuildDeliveryResult 生成对外返回的 delivery_result。
 // 当交付类型是 workspace_document 时，这里还会同步约定 workspace 内的相对输出路径。
 func (s *Service) BuildDeliveryResult(taskID, deliveryType, title, previewText string) map[string]any {
+	return s.BuildDeliveryResultWithTargetPath(taskID, deliveryType, title, previewText, "")
+}
+
+// BuildDeliveryResultWithTargetPath 生成带显式输出路径的 delivery_result。
+func (s *Service) BuildDeliveryResultWithTargetPath(taskID, deliveryType, title, previewText, targetPath string) map[string]any {
 	payload := map[string]any{
 		"path":    nil,
 		"url":     nil,
@@ -94,7 +99,7 @@ func (s *Service) BuildDeliveryResult(taskID, deliveryType, title, previewText s
 	}
 
 	if deliveryType == "workspace_document" {
-		payload["path"] = path.Join(defaultWorkspaceRoot, fmt.Sprintf("%s.md", slugify(title, taskID)))
+		payload["path"] = resolveWorkspaceTargetPath(targetPath, fmt.Sprintf("%s.md", slugify(title, taskID)))
 	}
 
 	return map[string]any{
@@ -125,7 +130,7 @@ func (s *Service) BuildArtifact(taskID, title string, deliveryResult map[string]
 			"artifact_id":   fmt.Sprintf("art_%s", taskID),
 			"task_id":       taskID,
 			"artifact_type": "generated_doc",
-			"title":         fmt.Sprintf("%s.md", title),
+			"title":         artifactTitle(path, title),
 			"path":          path,
 			"mime_type":     "text/markdown",
 		},
@@ -235,4 +240,37 @@ func slugify(title, fallback string) string {
 	}
 
 	return trimmed
+}
+
+func resolveWorkspaceTargetPath(targetPath, fallbackName string) string {
+	normalized := strings.TrimSpace(strings.ReplaceAll(targetPath, "\\", "/"))
+	if normalized == "" {
+		return path.Join(defaultWorkspaceRoot, fallbackName)
+	}
+
+	cleaned := path.Clean(normalized)
+	switch cleaned {
+	case ".", "/", "":
+		return path.Join(defaultWorkspaceRoot, fallbackName)
+	}
+
+	if strings.HasPrefix(cleaned, "../") {
+		return path.Join(defaultWorkspaceRoot, fallbackName)
+	}
+	if cleaned == defaultWorkspaceRoot {
+		return path.Join(defaultWorkspaceRoot, fallbackName)
+	}
+	if strings.HasPrefix(cleaned, defaultWorkspaceRoot+"/") {
+		return cleaned
+	}
+
+	return path.Join(defaultWorkspaceRoot, cleaned)
+}
+
+func artifactTitle(targetPath, fallbackTitle string) string {
+	if trimmed := strings.TrimSpace(targetPath); trimmed != "" {
+		return path.Base(trimmed)
+	}
+
+	return fmt.Sprintf("%s.md", fallbackTitle)
 }

--- a/services/local-service/internal/delivery/service_test.go
+++ b/services/local-service/internal/delivery/service_test.go
@@ -25,3 +25,28 @@ func TestBuildStorageAndArtifactPlans(t *testing.T) {
 		t.Fatalf("expected one artifact persist plan, got %d", len(artifactPlans))
 	}
 }
+
+// TestBuildDeliveryResultWithTargetPath 验证显式输出路径会进入 delivery_result 和 artifact。
+func TestBuildDeliveryResultWithTargetPath(t *testing.T) {
+	service := NewService()
+	deliveryResult := service.BuildDeliveryResultWithTargetPath(
+		"task_001",
+		"workspace_document",
+		"文件写入结果",
+		"已为你写入文档并打开",
+		"notes/output.md",
+	)
+
+	payload := deliveryResult["payload"].(map[string]any)
+	if payload["path"] != "workspace/notes/output.md" {
+		t.Fatalf("expected explicit target path to be normalized into workspace, got %v", payload["path"])
+	}
+
+	artifacts := service.BuildArtifact("task_001", "文件写入结果", deliveryResult)
+	if len(artifacts) != 1 {
+		t.Fatalf("expected one artifact, got %d", len(artifacts))
+	}
+	if artifacts[0]["title"] != "output.md" {
+		t.Fatalf("expected artifact title to follow target path base name, got %v", artifacts[0]["title"])
+	}
+}

--- a/services/local-service/internal/execution/service.go
+++ b/services/local-service/internal/execution/service.go
@@ -1,0 +1,410 @@
+// 该文件负责主链路最小真实执行链路：收集输入、生成内容、写入 workspace 并返回交付结果。
+package execution
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	contextsvc "github.com/cialloclaw/cialloclaw/services/local-service/internal/context"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/delivery"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/model"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/platform"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/plugin"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/tools"
+)
+
+// Service 负责在当前仓库代码范围内完成一条可运行的最小执行链路。
+type Service struct {
+	fileSystem platform.FileSystemAdapter
+	model      *model.Service
+	delivery   *delivery.Service
+	tools      *tools.Registry
+	plugin     *plugin.Service
+}
+
+// Request 描述一次任务执行所需的最小输入。
+type Request struct {
+	TaskID       string
+	RunID        string
+	Title        string
+	Intent       map[string]any
+	Snapshot     contextsvc.TaskContextSnapshot
+	DeliveryType string
+	ResultTitle  string
+}
+
+// Result 描述执行完成后需要回填给 orchestrator 的交付与痕迹。
+type Result struct {
+	Content        string
+	DeliveryResult map[string]any
+	Artifacts      []map[string]any
+	BubbleText     string
+	ToolName       string
+	ToolInput      map[string]any
+	ToolOutput     map[string]any
+	DurationMS     int64
+}
+
+// NewService 创建执行服务。
+func NewService(
+	fileSystem platform.FileSystemAdapter,
+	modelService *model.Service,
+	deliveryService *delivery.Service,
+	toolRegistry *tools.Registry,
+	pluginService *plugin.Service,
+) *Service {
+	return &Service{
+		fileSystem: fileSystem,
+		model:      modelService,
+		delivery:   deliveryService,
+		tools:      toolRegistry,
+		plugin:     pluginService,
+	}
+}
+
+// Execute 执行当前任务的最小内容生成与落盘链路。
+func (s *Service) Execute(ctx context.Context, request Request) (Result, error) {
+	startedAt := time.Now()
+	inputText := s.buildExecutionInput(request.Snapshot)
+	outputText := s.generateOutput(ctx, request, inputText)
+	deliveryType := firstNonEmpty(request.DeliveryType, "workspace_document")
+	targetPath := targetPathFromIntent(request.Intent)
+	previewText := previewTextForOutput(outputText, deliveryType)
+	deliveryResult := s.delivery.BuildDeliveryResultWithTargetPath(request.TaskID, deliveryType, request.ResultTitle, previewText, targetPath)
+
+	result := Result{
+		Content:        outputText,
+		DeliveryResult: deliveryResult,
+		DurationMS:     time.Since(startedAt).Milliseconds(),
+		ToolInput: map[string]any{
+			"intent_name":     stringValue(request.Intent, "name", "summarize"),
+			"delivery_type":   deliveryType,
+			"input_preview":   truncateText(inputText, 96),
+			"available_tools": s.availableToolNames(),
+			"workers":         s.availableWorkers(),
+		},
+	}
+
+	if deliveryType == "workspace_document" {
+		documentContent := workspaceDocumentContent(request.ResultTitle, outputText)
+		targetPath = deliveryPayloadPath(deliveryResult)
+		if targetPath == "" {
+			return Result{}, fmt.Errorf("workspace delivery requires payload path")
+		}
+		writePath := workspaceFSPath(targetPath)
+		if writePath == "" {
+			return Result{}, fmt.Errorf("workspace delivery requires writable workspace path")
+		}
+		if s.fileSystem == nil {
+			return Result{}, fmt.Errorf("workspace delivery requires file system adapter")
+		}
+		if err := s.fileSystem.WriteFile(writePath, []byte(documentContent)); err != nil {
+			return Result{}, fmt.Errorf("write workspace output: %w", err)
+		}
+
+		result.Content = documentContent
+		result.Artifacts = s.delivery.BuildArtifact(request.TaskID, request.ResultTitle, deliveryResult)
+		result.BubbleText = fmt.Sprintf("结果已写入 %s，可直接查看。", targetPath)
+		result.ToolName = "write_file"
+		result.ToolOutput = map[string]any{
+			"path":           targetPath,
+			"artifact_count": len(result.Artifacts),
+			"content_bytes":  len(documentContent),
+		}
+		return result, nil
+	}
+
+	result.BubbleText = truncateBubbleText(outputText)
+	result.ToolName = "generate_text"
+	result.ToolOutput = map[string]any{
+		"preview_text": previewText,
+		"content_size": len(outputText),
+	}
+	return result, nil
+}
+
+func (s *Service) buildExecutionInput(snapshot contextsvc.TaskContextSnapshot) string {
+	sections := make([]string, 0, 6)
+	if snapshot.SelectionText != "" {
+		sections = append(sections, "选中文本:\n"+strings.TrimSpace(snapshot.SelectionText))
+	}
+	if snapshot.Text != "" {
+		sections = append(sections, "输入文本:\n"+strings.TrimSpace(snapshot.Text))
+	}
+	if snapshot.ErrorText != "" {
+		sections = append(sections, "错误信息:\n"+strings.TrimSpace(snapshot.ErrorText))
+	}
+	if len(snapshot.Files) > 0 {
+		for _, filePath := range snapshot.Files {
+			sections = append(sections, s.fileSection(filePath))
+		}
+	}
+	if snapshot.PageTitle != "" || snapshot.PageURL != "" || snapshot.AppName != "" {
+		sections = append(sections, fmt.Sprintf(
+			"页面上下文:\n标题: %s\nURL: %s\n应用: %s",
+			strings.TrimSpace(snapshot.PageTitle),
+			strings.TrimSpace(snapshot.PageURL),
+			strings.TrimSpace(snapshot.AppName),
+		))
+	}
+	if len(sections) == 0 {
+		return "无可用输入"
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+func (s *Service) fileSection(filePath string) string {
+	trimmedPath := strings.TrimSpace(filePath)
+	if trimmedPath == "" {
+		return "文件: <empty>"
+	}
+	if s.fileSystem == nil {
+		return fmt.Sprintf("文件: %s", trimmedPath)
+	}
+
+	workspacePath := workspaceFSPath(trimmedPath)
+	if workspacePath == "" {
+		return fmt.Sprintf("文件: %s", trimmedPath)
+	}
+
+	content, err := s.fileSystem.ReadFile(workspacePath)
+	if err != nil {
+		return fmt.Sprintf("文件: %s\n读取失败: %v", trimmedPath, err)
+	}
+
+	return fmt.Sprintf("文件 %s 内容:\n%s", trimmedPath, truncateText(string(content), 1600))
+}
+
+func (s *Service) generateOutput(ctx context.Context, request Request, inputText string) string {
+	prompt := buildPrompt(request, inputText)
+	if s.model != nil {
+		response, err := s.model.GenerateText(ctx, model.GenerateTextRequest{
+			TaskID: request.TaskID,
+			RunID:  request.RunID,
+			Input:  prompt,
+		})
+		if err == nil {
+			if outputText := strings.TrimSpace(response.OutputText); outputText != "" {
+				return outputText
+			}
+		}
+	}
+
+	return fallbackOutput(request, inputText)
+}
+
+func buildPrompt(request Request, inputText string) string {
+	intentName := stringValue(request.Intent, "name", "summarize")
+	targetLanguage := stringValue(mapValue(request.Intent, "arguments"), "target_language", "中文")
+
+	instruction := "请整理以下内容并给出结果。"
+	switch intentName {
+	case "rewrite":
+		instruction = "请保留原意并以更清晰、可直接使用的中文改写以下内容。"
+	case "translate":
+		instruction = fmt.Sprintf("请将以下内容翻译成%s，并直接输出翻译结果。", targetLanguage)
+	case "explain":
+		instruction = "请用简洁中文解释以下内容，突出重点和结论。"
+	case "write_file":
+		instruction = "请根据以下输入生成一份可直接保存为文档的中文内容，使用清晰标题和小节。"
+	case "summarize":
+		instruction = "请总结以下内容，输出结构清晰的中文摘要。"
+	}
+
+	return strings.TrimSpace(instruction) + "\n\n输入内容:\n" + strings.TrimSpace(inputText)
+}
+
+func fallbackOutput(request Request, inputText string) string {
+	intentName := stringValue(request.Intent, "name", "summarize")
+	normalized := normalizeWhitespace(inputText)
+	if normalized == "" {
+		normalized = "无可用输入"
+	}
+
+	switch intentName {
+	case "rewrite":
+		return "改写结果：\n" + normalized
+	case "translate":
+		targetLanguage := stringValue(mapValue(request.Intent, "arguments"), "target_language", "中文")
+		return fmt.Sprintf("翻译结果（回退模式，目标语言：%s）：\n%s", targetLanguage, normalized)
+	case "explain":
+		return "解释结果：\n" + firstNonEmpty(firstSentence(normalized), normalized)
+	case "write_file":
+		fallthrough
+	case "summarize":
+		highlights := extractHighlights(normalized, 3)
+		if len(highlights) == 0 {
+			return "总结结果：\n- 暂无可总结内容"
+		}
+
+		lines := []string{"总结结果："}
+		for _, highlight := range highlights {
+			lines = append(lines, "- "+highlight)
+		}
+		return strings.Join(lines, "\n")
+	default:
+		return normalized
+	}
+}
+
+func workspaceDocumentContent(title, outputText string) string {
+	trimmed := strings.TrimSpace(outputText)
+	if trimmed == "" {
+		trimmed = "暂无内容"
+	}
+	if strings.HasPrefix(trimmed, "#") {
+		return trimmed + "\n"
+	}
+	return fmt.Sprintf("# %s\n\n%s\n", firstNonEmpty(strings.TrimSpace(title), "处理结果"), trimmed)
+}
+
+func previewTextForOutput(outputText, deliveryType string) string {
+	preview := truncateText(normalizeWhitespace(outputText), 96)
+	if preview == "" {
+		preview = "结果已生成"
+	}
+	if deliveryType == "workspace_document" {
+		return "已生成正式文档：" + preview
+	}
+	return preview
+}
+
+func truncateBubbleText(outputText string) string {
+	trimmed := strings.TrimSpace(outputText)
+	if trimmed == "" {
+		return "结果已生成。"
+	}
+	return truncateText(trimmed, 480)
+}
+
+func deliveryPayloadPath(deliveryResult map[string]any) string {
+	payload, ok := deliveryResult["payload"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	return stringValue(payload, "path", "")
+}
+
+func targetPathFromIntent(taskIntent map[string]any) string {
+	targetPath := stringValue(mapValue(taskIntent, "arguments"), "target_path", "")
+	switch targetPath {
+	case "", "workspace_document", "bubble", "result_page", "task_detail", "open_file", "reveal_in_folder":
+		return ""
+	default:
+		return targetPath
+	}
+}
+
+func workspaceFSPath(filePath string) string {
+	normalized := strings.TrimSpace(strings.ReplaceAll(filePath, "\\", "/"))
+	if normalized == "" {
+		return ""
+	}
+	normalized = strings.TrimPrefix(normalized, "./")
+	normalized = strings.TrimPrefix(normalized, "/")
+	if normalized == "workspace" {
+		return "."
+	}
+	if strings.HasPrefix(normalized, "workspace/") {
+		normalized = strings.TrimPrefix(normalized, "workspace/")
+	}
+	cleaned := path.Clean(normalized)
+	if cleaned == "." {
+		return "."
+	}
+	if strings.HasPrefix(cleaned, "../") {
+		return ""
+	}
+	return cleaned
+}
+
+func extractHighlights(inputText string, limit int) []string {
+	fields := strings.FieldsFunc(inputText, func(r rune) bool {
+		switch r {
+		case '\n', '\r', '。', '！', '？', '.', '!', '?', ';', '；':
+			return true
+		default:
+			return false
+		}
+	})
+
+	highlights := make([]string, 0, limit)
+	for _, field := range fields {
+		trimmed := strings.TrimSpace(field)
+		if trimmed == "" {
+			continue
+		}
+		highlights = append(highlights, truncateText(trimmed, 80))
+		if len(highlights) == limit {
+			break
+		}
+	}
+	return highlights
+}
+
+func firstSentence(inputText string) string {
+	highlights := extractHighlights(inputText, 1)
+	if len(highlights) == 0 {
+		return ""
+	}
+	return highlights[0]
+}
+
+func normalizeWhitespace(inputText string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(inputText)), " ")
+}
+
+func truncateText(inputText string, maxLength int) string {
+	if maxLength <= 0 || len(inputText) <= maxLength {
+		return inputText
+	}
+	return inputText[:maxLength] + "..."
+}
+
+func mapValue(values map[string]any, key string) map[string]any {
+	rawValue, ok := values[key]
+	if !ok {
+		return map[string]any{}
+	}
+	value, ok := rawValue.(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	return value
+}
+
+func stringValue(values map[string]any, key, fallback string) string {
+	rawValue, ok := values[key]
+	if !ok {
+		return fallback
+	}
+	value, ok := rawValue.(string)
+	if !ok || strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func firstNonEmpty(primary, fallback string) string {
+	if strings.TrimSpace(primary) != "" {
+		return primary
+	}
+	return fallback
+}
+
+func (s *Service) availableToolNames() []string {
+	if s.tools == nil {
+		return nil
+	}
+	return s.tools.Names()
+}
+
+func (s *Service) availableWorkers() []string {
+	if s.plugin == nil {
+		return nil
+	}
+	return s.plugin.Workers()
+}

--- a/services/local-service/internal/execution/service_test.go
+++ b/services/local-service/internal/execution/service_test.go
@@ -1,0 +1,116 @@
+package execution
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	serviceconfig "github.com/cialloclaw/cialloclaw/services/local-service/internal/config"
+	contextsvc "github.com/cialloclaw/cialloclaw/services/local-service/internal/context"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/delivery"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/model"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/platform"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/plugin"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/tools"
+)
+
+type stubModelClient struct {
+	output string
+}
+
+func (s stubModelClient) GenerateText(_ context.Context, request model.GenerateTextRequest) (model.GenerateTextResponse, error) {
+	return model.GenerateTextResponse{
+		TaskID:     request.TaskID,
+		RunID:      request.RunID,
+		RequestID:  "req_test",
+		Provider:   "openai_responses",
+		ModelID:    "gpt-5.4",
+		OutputText: s.output,
+	}, nil
+}
+
+func newTestExecutionService(t *testing.T, output string) (*Service, string) {
+	t.Helper()
+
+	workspaceRoot := filepath.Join(t.TempDir(), "workspace")
+	pathPolicy, err := platform.NewLocalPathPolicy(workspaceRoot)
+	if err != nil {
+		t.Fatalf("new local path policy: %v", err)
+	}
+
+	return NewService(
+		platform.NewLocalFileSystemAdapter(pathPolicy),
+		model.NewService(serviceconfig.ModelConfig{}, stubModelClient{output: output}),
+		delivery.NewService(),
+		tools.NewRegistry(),
+		plugin.NewService(),
+	), workspaceRoot
+}
+
+func TestExecuteWorkspaceDocumentWritesFile(t *testing.T) {
+	service, workspaceRoot := newTestExecutionService(t, "第一点\n第二点\n第三点")
+
+	result, err := service.Execute(context.Background(), Request{
+		TaskID:       "task_001",
+		RunID:        "run_001",
+		Title:        "生成文档",
+		Intent:       map[string]any{"name": "write_file", "arguments": map[string]any{"target_path": "notes/output.md"}},
+		Snapshot:     contextsvc.TaskContextSnapshot{InputType: "text", Text: "请整理成文档"},
+		DeliveryType: "workspace_document",
+		ResultTitle:  "文件写入结果",
+	})
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	if result.ToolName != "write_file" {
+		t.Fatalf("expected write_file tool, got %s", result.ToolName)
+	}
+	if len(result.Artifacts) != 1 {
+		t.Fatalf("expected one artifact, got %d", len(result.Artifacts))
+	}
+	if deliveryPayloadPath(result.DeliveryResult) != "workspace/notes/output.md" {
+		t.Fatalf("expected explicit workspace output path, got %v", deliveryPayloadPath(result.DeliveryResult))
+	}
+
+	writtenPath := filepath.Join(workspaceRoot, "notes", "output.md")
+	content, err := os.ReadFile(writtenPath)
+	if err != nil {
+		t.Fatalf("read written document: %v", err)
+	}
+	if !strings.Contains(string(content), "# 文件写入结果") {
+		t.Fatalf("expected written document to contain title header, got %s", string(content))
+	}
+	if !strings.Contains(string(content), "第一点") {
+		t.Fatalf("expected written document to contain generated content, got %s", string(content))
+	}
+}
+
+func TestExecuteBubbleReturnsGeneratedText(t *testing.T) {
+	service, _ := newTestExecutionService(t, "这段内容主要在解释当前问题的原因和处理方向。")
+
+	result, err := service.Execute(context.Background(), Request{
+		TaskID:       "task_002",
+		RunID:        "run_002",
+		Title:        "解释内容",
+		Intent:       map[string]any{"name": "explain", "arguments": map[string]any{}},
+		Snapshot:     contextsvc.TaskContextSnapshot{InputType: "text_selection", SelectionText: "需要解释的文本"},
+		DeliveryType: "bubble",
+		ResultTitle:  "解释结果",
+	})
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	if result.ToolName != "generate_text" {
+		t.Fatalf("expected generate_text tool, got %s", result.ToolName)
+	}
+	if result.BubbleText != "这段内容主要在解释当前问题的原因和处理方向。" {
+		t.Fatalf("expected bubble text to use generated output, got %s", result.BubbleText)
+	}
+	if len(result.Artifacts) != 0 {
+		t.Fatalf("expected bubble delivery not to create artifacts, got %d", len(result.Artifacts))
+	}
+}

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -468,32 +468,36 @@ func (s *Service) NotepadConvertToTask(params map[string]any) (map[string]any, e
 // DashboardOverviewGet 处理 agent.dashboard.overview.get。
 func (s *Service) DashboardOverviewGet(params map[string]any) (map[string]any, error) {
 	_ = params
-	tasks, _ := s.runEngine.ListTasks("unfinished", "updated_at", "desc", 1, 0)
-	_, pendingTotal := s.runEngine.PendingApprovalRequests(20, 0)
+	unfinishedTasks, _ := s.runEngine.ListTasks("unfinished", "updated_at", "desc", 0, 0)
+	finishedTasks, _ := s.runEngine.ListTasks("finished", "finished_at", "desc", 0, 0)
+	pendingApprovals, pendingTotal := s.runEngine.PendingApprovalRequests(20, 0)
+
+	focusTask, hasFocusTask := focusTaskForOverview(unfinishedTasks, finishedTasks)
 	var focusSummary map[string]any
-	if len(tasks) > 0 {
+	if hasFocusTask {
 		focusSummary = map[string]any{
-			"task_id":      tasks[0].TaskID,
-			"title":        tasks[0].Title,
-			"status":       tasks[0].Status,
-			"current_step": tasks[0].CurrentStep,
-			"next_action":  "等待用户查看结果",
-			"updated_at":   tasks[0].UpdatedAt.Format(dateTimeLayout),
+			"task_id":      focusTask.TaskID,
+			"title":        focusTask.Title,
+			"status":       focusTask.Status,
+			"current_step": focusTask.CurrentStep,
+			"next_action":  nextActionForTask(focusTask),
+			"updated_at":   focusTask.UpdatedAt.Format(dateTimeLayout),
 		}
 	}
 
+	allTasks := append(append([]runengine.TaskRecord{}, unfinishedTasks...), finishedTasks...)
 	return map[string]any{
 		"overview": map[string]any{
 			"focus_summary": focusSummary,
 			"trust_summary": map[string]any{
-				"risk_level":             s.risk.DefaultLevel(),
+				"risk_level":             aggregateRiskLevel(allTasks, pendingApprovals, s.risk.DefaultLevel()),
 				"pending_authorizations": pendingTotal,
-				"has_restore_point":      len(tasks) > 0 && tasks[0].SecuritySummary["latest_restore_point"] != nil,
+				"has_restore_point":      latestRestorePointFromTasks(allTasks) != nil,
 				"workspace_path":         workspacePathFromSettings(s.runEngine.Settings()),
 			},
-			"quick_actions":     []string{"打开任务详情", "查看最近结果"},
+			"quick_actions":     buildDashboardQuickActions(hasFocusTask, pendingTotal, len(finishedTasks)),
 			"global_state":      s.Snapshot(),
-			"high_value_signal": []string{"主链路 task/run 映射已进入内存态运行。"},
+			"high_value_signal": buildDashboardSignals(unfinishedTasks, finishedTasks, pendingApprovals),
 		},
 	}, nil
 }
@@ -504,17 +508,19 @@ func (s *Service) DashboardOverviewGet(params map[string]any) (map[string]any, e
 func (s *Service) DashboardModuleGet(params map[string]any) (map[string]any, error) {
 	module := stringValue(params, "module", "mirror")
 	tab := stringValue(params, "tab", "daily_summary")
-	tasks, _ := s.runEngine.ListTasks("finished", "finished_at", "desc", 20, 0)
+	finishedTasks, _ := s.runEngine.ListTasks("finished", "finished_at", "desc", 0, 0)
+	unfinishedTasks, _ := s.runEngine.ListTasks("unfinished", "updated_at", "desc", 0, 0)
+	_, pendingTotal := s.runEngine.PendingApprovalRequests(20, 0)
 	return map[string]any{
 		"module": module,
 		"tab":    tab,
 		"summary": map[string]any{
-			"completed_tasks":     len(tasks),
-			"generated_outputs":   len(tasks),
-			"authorizations_used": 0,
-			"exceptions":          0,
+			"completed_tasks":     len(finishedTasks),
+			"generated_outputs":   countGeneratedOutputs(finishedTasks),
+			"authorizations_used": countAuthorizedTasks(unfinishedTasks, finishedTasks),
+			"exceptions":          countExceptionTasks(unfinishedTasks, finishedTasks),
 		},
-		"highlights": []string{"主链路核心接口已通过同一 orchestrator 收口。"},
+		"highlights": buildDashboardModuleHighlights(unfinishedTasks, finishedTasks, pendingTotal),
 	}, nil
 }
 
@@ -523,24 +529,17 @@ func (s *Service) DashboardModuleGet(params map[string]any) (map[string]any, err
 // MirrorOverviewGet 处理 agent.mirror.overview.get。
 func (s *Service) MirrorOverviewGet(params map[string]any) (map[string]any, error) {
 	_ = params
-	tasks, _ := s.runEngine.ListTasks("finished", "finished_at", "desc", 20, 0)
-	completedCount := len(tasks)
-	if completedCount == 0 {
-		completedCount = 1
-	}
+	finishedTasks, _ := s.runEngine.ListTasks("finished", "finished_at", "desc", 0, 0)
+	memoryReferences := collectMirrorReferences(finishedTasks)
 	return map[string]any{
-		"history_summary": []string{"最近任务以文档总结与解释类需求为主。", "系统已经开始围绕 task 主对象组织返回。"},
+		"history_summary": buildMirrorHistorySummary(finishedTasks, memoryReferences),
 		"daily_summary": map[string]any{
 			"date":              time.Now().Format("2006-01-02"),
-			"completed_tasks":   completedCount,
-			"generated_outputs": completedCount,
+			"completed_tasks":   len(finishedTasks),
+			"generated_outputs": countGeneratedOutputs(finishedTasks),
 		},
-		"profile": map[string]any{
-			"work_style":       "偏好结构化输出",
-			"preferred_output": "3点摘要",
-			"active_hours":     "10-12h",
-		},
-		"memory_references": []map[string]any{defaultMirrorReference()},
+		"profile":           buildMirrorProfile(finishedTasks),
+		"memory_references": memoryReferences,
 	}, nil
 }
 
@@ -548,24 +547,24 @@ func (s *Service) MirrorOverviewGet(params map[string]any) (map[string]any, erro
 
 // SecuritySummaryGet 处理 agent.security.summary.get。
 func (s *Service) SecuritySummaryGet() (map[string]any, error) {
-	pendingApprovals, pendingTotal := s.runEngine.PendingApprovalRequests(20, 0)
-	securityStatus := "normal"
-	if pendingTotal > 0 {
-		securityStatus = "pending_confirmation"
-	}
+	_, pendingTotal := s.runEngine.PendingApprovalRequests(20, 0)
+	unfinishedTasks, _ := s.runEngine.ListTasks("unfinished", "updated_at", "desc", 0, 0)
+	finishedTasks, _ := s.runEngine.ListTasks("finished", "finished_at", "desc", 0, 0)
+	allTasks := append(append([]runengine.TaskRecord{}, unfinishedTasks...), finishedTasks...)
+	dataLogSettings := mapValue(s.runEngine.Settings(), "data_log")
 	return map[string]any{
 		"summary": map[string]any{
-			"security_status":        securityStatus,
+			"security_status":        aggregateSecurityStatus(allTasks, pendingTotal),
 			"pending_authorizations": pendingTotal,
-			"latest_restore_point":   latestRestorePointFromApprovals(pendingApprovals),
+			"latest_restore_point":   latestRestorePointFromTasks(allTasks),
 			"token_cost_summary": map[string]any{
-				"current_task_tokens":   2847,
-				"current_task_cost":     0.12,
-				"today_tokens":          9321,
-				"today_cost":            0.46,
-				"single_task_limit":     10.0,
-				"daily_limit":           50.0,
-				"budget_auto_downgrade": true,
+				"current_task_tokens":   0,
+				"current_task_cost":     0.0,
+				"today_tokens":          0,
+				"today_cost":            0.0,
+				"single_task_limit":     0.0,
+				"daily_limit":           0.0,
+				"budget_auto_downgrade": boolValue(dataLogSettings, "budget_auto_downgrade", true),
 			},
 		},
 	}, nil
@@ -648,7 +647,12 @@ func (s *Service) SecurityRespond(params map[string]any) (map[string]any, error)
 		"operator":                "user",
 		"created_at":              time.Now().Format(dateTimeLayout),
 	}
-	impactScope := buildImpactScope()
+	pendingExecution, ok := s.runEngine.PendingExecutionPlan(task.TaskID)
+	if !ok {
+		pendingExecution = s.buildPendingExecution(task, task.Intent)
+	}
+	pendingExecution = s.applyResolvedDeliveryToPlan(task, pendingExecution, task.Intent)
+	impactScope := s.buildImpactScope(task, pendingExecution)
 	if decision == "deny_once" {
 		bubble := s.delivery.BuildBubbleMessage(task.TaskID, "status", "已拒绝本次操作，任务已取消。", task.UpdatedAt.Format(dateTimeLayout))
 		updatedTask, ok := s.runEngine.DenyAfterApproval(task.TaskID, authorizationRecord, impactScope, bubble)
@@ -668,12 +672,6 @@ func (s *Service) SecurityRespond(params map[string]any) (map[string]any, error)
 	if !ok {
 		return nil, ErrTaskNotFound
 	}
-
-	pendingExecution, ok := s.runEngine.PendingExecutionPlan(task.TaskID)
-	if !ok {
-		pendingExecution = s.buildPendingExecution(task, task.Intent)
-	}
-	pendingExecution = s.applyResolvedDeliveryToPlan(task, pendingExecution, task.Intent)
 
 	resultTitle := stringValue(pendingExecution, "result_title", "处理结果")
 	resultPreview := stringValue(pendingExecution, "preview_text", "已为你写入文档并打开")
@@ -918,6 +916,371 @@ func defaultMirrorReference() map[string]any {
 	}
 }
 
+func focusTaskForOverview(unfinishedTasks, finishedTasks []runengine.TaskRecord) (runengine.TaskRecord, bool) {
+	if len(unfinishedTasks) > 0 {
+		return unfinishedTasks[0], true
+	}
+	if len(finishedTasks) > 0 {
+		return finishedTasks[0], true
+	}
+	return runengine.TaskRecord{}, false
+}
+
+func nextActionForTask(task runengine.TaskRecord) string {
+	switch task.Status {
+	case "confirming_intent":
+		return "确认当前意图"
+	case "waiting_auth":
+		return "处理待授权操作"
+	case "waiting_input":
+		return "补充输入内容"
+	case "processing":
+		return "等待处理完成"
+	case "completed":
+		return "查看交付结果"
+	default:
+		return "打开任务详情"
+	}
+}
+
+func buildDashboardQuickActions(hasFocusTask bool, pendingTotal, finishedCount int) []string {
+	actions := make([]string, 0, 3)
+	if pendingTotal > 0 {
+		actions = append(actions, "处理待授权操作")
+	}
+	if hasFocusTask {
+		actions = append(actions, "打开任务详情")
+	}
+	if finishedCount > 0 {
+		actions = append(actions, "查看最近结果")
+	}
+	if len(actions) == 0 {
+		actions = append(actions, "等待新任务")
+	}
+	return actions
+}
+
+func buildDashboardSignals(unfinishedTasks, finishedTasks []runengine.TaskRecord, pendingApprovals []map[string]any) []string {
+	signals := make([]string, 0, 3)
+	if len(unfinishedTasks) > 0 {
+		signals = append(signals, fmt.Sprintf("当前有 %d 个未完成任务处于 runtime 管控中。", len(unfinishedTasks)))
+	}
+	if len(pendingApprovals) > 0 {
+		signals = append(signals, fmt.Sprintf("当前有 %d 个待授权操作等待用户确认。", len(pendingApprovals)))
+	}
+	if latestRestorePointFromTasks(finishedTasks) != nil {
+		signals = append(signals, "最近一次正式交付已经生成可回放的恢复点。")
+	}
+	if len(signals) == 0 {
+		signals = append(signals, "主链路当前暂无活跃任务。")
+	}
+	return signals
+}
+
+func buildDashboardModuleHighlights(unfinishedTasks, finishedTasks []runengine.TaskRecord, pendingTotal int) []string {
+	highlights := make([]string, 0, 4)
+	if latestOutputPath := latestOutputPathFromTasks(finishedTasks); latestOutputPath != "" {
+		highlights = append(highlights, fmt.Sprintf("最近正式交付已落到 %s。", latestOutputPath))
+	}
+	if pendingTotal > 0 {
+		highlights = append(highlights, fmt.Sprintf("当前仍有 %d 个待授权任务等待处理。", pendingTotal))
+	}
+	if restorePoint := latestRestorePointFromTasks(finishedTasks); restorePoint != nil {
+		highlights = append(highlights, fmt.Sprintf("最近恢复点 %s 已可用于安全回显。", stringValue(restorePoint, "recovery_point_id", "latest")))
+	}
+	if len(unfinishedTasks) > 0 {
+		highlights = append(highlights, fmt.Sprintf("最近活跃任务状态为 %s。", unfinishedTasks[0].Status))
+	}
+	if len(highlights) == 0 {
+		highlights = append(highlights, "当前模块视图已切换为 runtime 聚合结果。")
+	}
+	return highlights
+}
+
+func countGeneratedOutputs(tasks []runengine.TaskRecord) int {
+	total := 0
+	for _, task := range tasks {
+		if len(task.DeliveryResult) > 0 || len(task.Artifacts) > 0 {
+			total++
+		}
+	}
+	return total
+}
+
+func countAuthorizedTasks(taskGroups ...[]runengine.TaskRecord) int {
+	total := 0
+	for _, tasks := range taskGroups {
+		for _, task := range tasks {
+			if len(task.Authorization) > 0 {
+				total++
+			}
+		}
+	}
+	return total
+}
+
+func countExceptionTasks(taskGroups ...[]runengine.TaskRecord) int {
+	total := 0
+	for _, tasks := range taskGroups {
+		for _, task := range tasks {
+			switch task.Status {
+			case "failed", "cancelled", "blocked", "ended_unfinished":
+				total++
+			}
+		}
+	}
+	return total
+}
+
+func collectMirrorReferences(tasks []runengine.TaskRecord) []map[string]any {
+	references := make([]map[string]any, 0)
+	seen := map[string]struct{}{}
+	for _, task := range tasks {
+		for _, reference := range task.MirrorReferences {
+			memoryID := stringValue(reference, "memory_id", "")
+			if memoryID == "" {
+				continue
+			}
+			if _, ok := seen[memoryID]; ok {
+				continue
+			}
+			seen[memoryID] = struct{}{}
+			references = append(references, cloneMap(reference))
+		}
+	}
+	return references
+}
+
+func buildMirrorHistorySummary(tasks []runengine.TaskRecord, memoryReferences []map[string]any) []string {
+	if len(tasks) == 0 {
+		return []string{"当前还没有完成任务，镜像概览会在首个正式交付后生成。"}
+	}
+
+	summaries := []string{
+		fmt.Sprintf("最近已完成 %d 个任务，其中 %d 个产出了正式交付。", len(tasks), countGeneratedOutputs(tasks)),
+	}
+	if len(memoryReferences) > 0 {
+		summaries = append(summaries, fmt.Sprintf("当前累计挂接了 %d 条记忆引用，可供 task detail 与 mirror 回显复用。", len(memoryReferences)))
+	}
+	if latestOutputPath := latestOutputPathFromTasks(tasks); latestOutputPath != "" {
+		summaries = append(summaries, fmt.Sprintf("最近一次落盘结果位于 %s。", latestOutputPath))
+	}
+	return summaries
+}
+
+func buildMirrorProfile(tasks []runengine.TaskRecord) map[string]any {
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	documentCount := 0
+	bubbleCount := 0
+	earliestHour := 24
+	latestHour := -1
+	for _, task := range tasks {
+		switch stringValue(task.DeliveryResult, "type", "") {
+		case "workspace_document":
+			documentCount++
+		case "bubble":
+			bubbleCount++
+		}
+		hour := task.StartedAt.Hour()
+		if hour < earliestHour {
+			earliestHour = hour
+		}
+		if hour > latestHour {
+			latestHour = hour
+		}
+	}
+
+	workStyle := "偏好即时结果回显"
+	preferredOutput := "bubble"
+	if documentCount >= bubbleCount {
+		workStyle = "偏好结构化落盘输出"
+		preferredOutput = "workspace_document"
+	}
+	if earliestHour == 24 || latestHour == -1 {
+		earliestHour = 0
+		latestHour = 0
+	}
+
+	return map[string]any{
+		"work_style":       workStyle,
+		"preferred_output": preferredOutput,
+		"active_hours":     fmt.Sprintf("%02d-%02dh", earliestHour, latestHour+1),
+	}
+}
+
+func aggregateRiskLevel(tasks []runengine.TaskRecord, pendingApprovals []map[string]any, fallback string) string {
+	if len(pendingApprovals) > 0 {
+		return "red"
+	}
+	result := fallback
+	for _, task := range tasks {
+		switch task.RiskLevel {
+		case "red":
+			return "red"
+		case "yellow":
+			result = "yellow"
+		case "green":
+			if result == "" {
+				result = "green"
+			}
+		}
+	}
+	if result == "" {
+		return "green"
+	}
+	return result
+}
+
+func aggregateSecurityStatus(tasks []runengine.TaskRecord, pendingTotal int) string {
+	if pendingTotal > 0 {
+		return "pending_confirmation"
+	}
+	for _, task := range tasks {
+		status := stringValue(task.SecuritySummary, "security_status", "")
+		if status != "" && status != "normal" {
+			return status
+		}
+	}
+	return "normal"
+}
+
+func latestRestorePointFromTasks(tasks []runengine.TaskRecord) map[string]any {
+	for _, task := range tasks {
+		restorePoint, ok := task.SecuritySummary["latest_restore_point"].(map[string]any)
+		if ok && len(restorePoint) > 0 {
+			return cloneMap(restorePoint)
+		}
+	}
+	return nil
+}
+
+func latestOutputPathFromTasks(tasks []runengine.TaskRecord) string {
+	for _, task := range tasks {
+		if outputPath := pathFromDeliveryResult(task.DeliveryResult); outputPath != "" {
+			return outputPath
+		}
+		if outputPath := stringValue(task.StorageWritePlan, "target_path", ""); outputPath != "" {
+			return outputPath
+		}
+	}
+	return ""
+}
+
+func (s *Service) refreshMirrorReferences(taskID string) {
+	task, ok := s.runEngine.GetTask(taskID)
+	if !ok {
+		return
+	}
+	_, _ = s.runEngine.SetMirrorReferences(taskID, buildTaskMirrorReferences(task))
+}
+
+func buildTaskMirrorReferences(task runengine.TaskRecord) []map[string]any {
+	references := make([]map[string]any, 0, len(task.MemoryReadPlans)+len(task.MemoryWritePlans))
+	for index, plan := range task.MemoryReadPlans {
+		query := firstNonEmptyString(
+			stringValue(plan, "query", ""),
+			stringValue(plan, "selection_text", ""),
+		)
+		query = firstNonEmptyString(query, stringValue(plan, "input_text", ""))
+		query = firstNonEmptyString(query, task.Title)
+		references = append(references, map[string]any{
+			"memory_id": fmt.Sprintf("mem_read_%s_%d", task.TaskID, index+1),
+			"reason":    firstNonEmptyString(stringValue(plan, "reason", ""), "任务开始前准备记忆召回"),
+			"summary":   fmt.Sprintf("召回查询：%s", truncateText(query, 48)),
+		})
+	}
+	for index, plan := range task.MemoryWritePlans {
+		summary := firstNonEmptyString(stringValue(plan, "summary", ""), task.Title)
+		references = append(references, map[string]any{
+			"memory_id": fmt.Sprintf("mem_write_%s_%d", task.TaskID, index+1),
+			"reason":    firstNonEmptyString(stringValue(plan, "reason", ""), "任务完成后准备写入记忆摘要"),
+			"summary":   truncateText(summary, 64),
+		})
+	}
+	return references
+}
+
+func deriveImpactScopeFiles(task runengine.TaskRecord, pendingExecution map[string]any, deliveryService *delivery.Service) []string {
+	files := make([]string, 0, 4)
+	files = appendImpactScopePath(files, stringValue(task.StorageWritePlan, "target_path", ""))
+	for _, artifactPlan := range task.ArtifactPlans {
+		files = appendImpactScopePath(files, stringValue(artifactPlan, "path", ""))
+	}
+	files = appendImpactScopePath(files, pathFromDeliveryResult(task.DeliveryResult))
+	files = appendImpactScopePath(files, pathFromPendingExecution(task.TaskID, pendingExecution, deliveryService))
+	files = appendImpactScopePath(files, targetPathFromIntent(task.Intent))
+	return files
+}
+
+func appendImpactScopePath(files []string, candidate string) []string {
+	candidate = strings.TrimSpace(strings.ReplaceAll(candidate, "\\", "/"))
+	if candidate == "" {
+		return files
+	}
+	candidate = path.Clean(candidate)
+	if candidate == "." {
+		return files
+	}
+	for _, existing := range files {
+		if existing == candidate {
+			return files
+		}
+	}
+	return append(files, candidate)
+}
+
+func pathFromPendingExecution(taskID string, pendingExecution map[string]any, deliveryService *delivery.Service) string {
+	if len(pendingExecution) == 0 {
+		return ""
+	}
+	deliveryType := stringValue(pendingExecution, "delivery_type", "")
+	if deliveryType != "workspace_document" {
+		return ""
+	}
+	resultTitle := stringValue(pendingExecution, "result_title", "处理结果")
+	previewText := stringValue(pendingExecution, "preview_text", "")
+	deliveryResult := deliveryService.BuildDeliveryResult(taskID, deliveryType, resultTitle, previewText)
+	return pathFromDeliveryResult(deliveryResult)
+}
+
+func pathFromDeliveryResult(deliveryResult map[string]any) string {
+	payload, ok := deliveryResult["payload"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	return stringValue(payload, "path", "")
+}
+
+func targetPathFromIntent(taskIntent map[string]any) string {
+	targetPath := stringValue(mapValue(taskIntent, "arguments"), "target_path", "")
+	switch targetPath {
+	case "", "workspace_document", "bubble", "result_page", "task_detail", "open_file", "reveal_in_folder":
+		return ""
+	default:
+		return targetPath
+	}
+}
+
+func isWorkspaceRelativePath(filePath, workspaceRoot string) bool {
+	normalizedRoot := strings.Trim(strings.ReplaceAll(workspaceRoot, "\\", "/"), "/")
+	normalizedPath := strings.Trim(strings.ReplaceAll(filePath, "\\", "/"), "/")
+	if normalizedRoot == "" {
+		normalizedRoot = "workspace"
+	}
+	return normalizedPath == normalizedRoot || strings.HasPrefix(normalizedPath, normalizedRoot+"/")
+}
+
+func hasOverwriteOrDeleteRisk(taskIntent map[string]any) bool {
+	if stringValue(taskIntent, "name", "") == "write_file" {
+		return true
+	}
+	arguments := mapValue(taskIntent, "arguments")
+	return boolValue(arguments, "overwrite", false) || boolValue(arguments, "delete", false)
+}
+
 // attachMemoryReadPlans 处理当前模块的相关逻辑。
 
 // attachMemoryReadPlans 在任务启动或确认后挂接 memory 读取计划。
@@ -938,6 +1301,7 @@ func (s *Service) attachMemoryReadPlans(taskID, runID string, snapshot contextsv
 	}
 
 	_, _ = s.runEngine.SetMemoryPlans(taskID, readPlans, nil)
+	s.refreshMirrorReferences(taskID)
 }
 
 // attachPostDeliveryHandoffs 处理当前模块的相关逻辑。
@@ -956,6 +1320,7 @@ func (s *Service) attachPostDeliveryHandoffs(taskID, runID string, snapshot cont
 		},
 	}
 	_, _ = s.runEngine.SetMemoryPlans(taskID, nil, writePlans)
+	s.refreshMirrorReferences(taskID)
 
 	storageWritePlan := s.delivery.BuildStorageWritePlan(taskID, deliveryResult)
 	artifactPlans := s.delivery.BuildArtifactPersistPlans(taskID, artifacts)
@@ -1003,13 +1368,23 @@ func buildApprovalRequest(taskID string, taskIntent map[string]any, riskLevel st
 // buildImpactScope 处理当前模块的相关逻辑。
 
 // buildImpactScope 构造最小影响范围摘要，用于授权结果回传和安全面板展示。
-func buildImpactScope() map[string]any {
+func (s *Service) buildImpactScope(task runengine.TaskRecord, pendingExecution map[string]any) map[string]any {
+	files := deriveImpactScopeFiles(task, pendingExecution, s.delivery)
+	workspacePath := workspacePathFromSettings(s.runEngine.Settings())
+	outOfWorkspace := false
+	for _, filePath := range files {
+		if !isWorkspaceRelativePath(filePath, workspacePath) {
+			outOfWorkspace = true
+			break
+		}
+	}
+
 	return map[string]any{
-		"files":                    []string{path.Join("workspace", "report.md")},
+		"files":                    files,
 		"webpages":                 []string{},
 		"apps":                     []string{},
-		"out_of_workspace":         false,
-		"overwrite_or_delete_risk": false,
+		"out_of_workspace":         outOfWorkspace,
+		"overwrite_or_delete_risk": hasOverwriteOrDeleteRisk(task.Intent),
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -22,7 +22,11 @@ import (
 // ErrTaskNotFound 定义当前模块的基础变量。
 
 // ErrTaskNotFound 表示调用方给出的 task_id 在当前运行态中不存在。
-var ErrTaskNotFound = errors.New("task not found")
+var (
+	ErrTaskNotFound        = errors.New("task not found")
+	ErrTaskStatusInvalid   = errors.New("task status invalid")
+	ErrTaskAlreadyFinished = errors.New("task already finished")
+)
 
 // Service 提供当前模块的服务能力。
 
@@ -381,10 +385,22 @@ func (s *Service) TaskDetailGet(params map[string]any) (map[string]any, error) {
 func (s *Service) TaskControl(params map[string]any) (map[string]any, error) {
 	taskID := stringValue(params, "task_id", "")
 	action := stringValue(params, "action", "pause")
+	if !isSupportedTaskControlAction(action) {
+		return nil, fmt.Errorf("unsupported task control action: %s", action)
+	}
 	bubble := s.delivery.BuildBubbleMessage(taskID, "status", controlBubbleText(action), currentTimeFromTask(s.runEngine, taskID))
-	updatedTask, ok := s.runEngine.ControlTask(taskID, action, bubble)
-	if !ok {
-		return nil, ErrTaskNotFound
+	updatedTask, err := s.runEngine.ControlTask(taskID, action, bubble)
+	if err != nil {
+		switch {
+		case errors.Is(err, runengine.ErrTaskNotFound):
+			return nil, ErrTaskNotFound
+		case errors.Is(err, runengine.ErrTaskStatusInvalid):
+			return nil, ErrTaskStatusInvalid
+		case errors.Is(err, runengine.ErrTaskAlreadyFinished):
+			return nil, ErrTaskAlreadyFinished
+		default:
+			return nil, err
+		}
 	}
 
 	return map[string]any{
@@ -863,6 +879,15 @@ func controlBubbleText(action string) string {
 		return "任务已重新开始"
 	default:
 		return "任务状态已更新"
+	}
+}
+
+func isSupportedTaskControlAction(action string) bool {
+	switch action {
+	case "pause", "resume", "cancel", "restart":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -2,6 +2,7 @@
 package orchestrator
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path"
@@ -10,6 +11,7 @@ import (
 
 	contextsvc "github.com/cialloclaw/cialloclaw/services/local-service/internal/context"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/delivery"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/execution"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/intent"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/memory"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/model"
@@ -42,6 +44,7 @@ type Service struct {
 	model     *model.Service
 	tools     *tools.Registry
 	plugin    *plugin.Service
+	executor  *execution.Service
 }
 
 // NewService 创建并返回Service。
@@ -69,6 +72,12 @@ func NewService(
 		tools:     tools,
 		plugin:    plugin,
 	}
+}
+
+// WithExecutor 把真实执行服务挂入 orchestrator。
+func (s *Service) WithExecutor(executorService *execution.Service) *Service {
+	s.executor = executorService
+	return s
 }
 
 // Snapshot 处理当前模块的相关逻辑。
@@ -143,7 +152,6 @@ func (s *Service) SubmitInput(params map[string]any) (map[string]any, error) {
 
 	bubble := s.delivery.BuildBubbleMessage(task.TaskID, bubbleTypeForSuggestion(suggestion.RequiresConfirm), bubbleTextForInput(suggestion), task.StartedAt.Format(dateTimeLayout))
 	deliveryResult := map[string]any(nil)
-	artifacts := []map[string]any(nil)
 	if !suggestion.RequiresConfirm {
 		if requiresAuthorization(suggestion.Intent) {
 			pendingExecution := s.buildPendingExecution(task, suggestion.Intent)
@@ -157,13 +165,11 @@ func (s *Service) SubmitInput(params map[string]any) (map[string]any, error) {
 				"bubble_message": bubble,
 			}, nil
 		}
-		deliveryType := resolveTaskDeliveryType(task, suggestion.Intent)
-		deliveryResult = s.delivery.BuildDeliveryResult(task.TaskID, deliveryType, suggestion.ResultTitle, previewTextForDeliveryType(deliveryType))
-		artifacts = s.delivery.BuildArtifact(task.TaskID, suggestion.ResultTitle, deliveryResult)
-		if _, ok := s.runEngine.CompleteTask(task.TaskID, deliveryResult, bubble, artifacts); ok {
-			task, _ = s.runEngine.GetTask(task.TaskID)
+		var err error
+		task, bubble, deliveryResult, _, err = s.executeTask(task, snapshot, suggestion.Intent)
+		if err != nil {
+			return nil, err
 		}
-		s.attachPostDeliveryHandoffs(task.TaskID, task.RunID, snapshot, suggestion.Intent, deliveryResult, artifacts)
 	} else {
 		if _, ok := s.runEngine.SetPresentation(task.TaskID, bubble, nil, nil); ok {
 			task, _ = s.runEngine.GetTask(task.TaskID)
@@ -232,14 +238,13 @@ func (s *Service) StartTask(params map[string]any) (map[string]any, error) {
 		return response, nil
 	}
 
-	deliveryType := resolveTaskDeliveryType(task, suggestion.Intent)
-	deliveryResult := s.delivery.BuildDeliveryResult(task.TaskID, deliveryType, suggestion.ResultTitle, previewTextForDeliveryType(deliveryType))
-	artifacts := s.delivery.BuildArtifact(task.TaskID, suggestion.ResultTitle, deliveryResult)
-	if _, ok := s.runEngine.CompleteTask(task.TaskID, deliveryResult, bubble, artifacts); ok {
-		task, _ = s.runEngine.GetTask(task.TaskID)
-		response["task"] = taskMap(task)
+	var err error
+	task, bubble, deliveryResult, _, err := s.executeTask(task, snapshot, suggestion.Intent)
+	if err != nil {
+		return nil, err
 	}
-	s.attachPostDeliveryHandoffs(task.TaskID, task.RunID, snapshot, suggestion.Intent, deliveryResult, artifacts)
+	response["task"] = taskMap(task)
+	response["bubble_message"] = bubble
 	response["delivery_result"] = deliveryResult
 	return response, nil
 }
@@ -289,17 +294,10 @@ func (s *Service) ConfirmTask(params map[string]any) (map[string]any, error) {
 	snapshot := snapshotFromTask(updatedTask)
 	s.attachMemoryReadPlans(updatedTask.TaskID, updatedTask.RunID, snapshot, intentValue)
 
-	resultTitle, resultPreview, resultBubbleText := resultSpecFromIntent(intentValue)
-	deliveryType := resolveTaskDeliveryType(updatedTask, intentValue)
-	resultPreview = previewTextForDeliveryType(deliveryType)
-	deliveryResult := s.delivery.BuildDeliveryResult(updatedTask.TaskID, deliveryType, resultTitle, resultPreview)
-	artifacts := s.delivery.BuildArtifact(updatedTask.TaskID, resultTitle, deliveryResult)
-	resultBubble := s.delivery.BuildBubbleMessage(updatedTask.TaskID, "result", resultBubbleText, updatedTask.UpdatedAt.Format(dateTimeLayout))
-	updatedTask, ok = s.runEngine.CompleteTask(updatedTask.TaskID, deliveryResult, resultBubble, artifacts)
-	if !ok {
-		return nil, ErrTaskNotFound
+	updatedTask, resultBubble, deliveryResult, _, err := s.executeTask(updatedTask, snapshot, intentValue)
+	if err != nil {
+		return nil, err
 	}
-	s.attachPostDeliveryHandoffs(updatedTask.TaskID, updatedTask.RunID, snapshot, intentValue, deliveryResult, artifacts)
 
 	return map[string]any{
 		"task":            taskMap(updatedTask),
@@ -695,20 +693,18 @@ func (s *Service) SecurityRespond(params map[string]any) (map[string]any, error)
 	deliveryType := stringValue(pendingExecution, "delivery_type", deliveryTypeFromIntent(task.Intent))
 	deliveryType = resolveTaskDeliveryType(task, task.Intent)
 	resultPreview = previewTextForDeliveryType(deliveryType)
-	deliveryResult := s.delivery.BuildDeliveryResult(task.TaskID, deliveryType, resultTitle, resultPreview)
-	artifacts := s.delivery.BuildArtifact(task.TaskID, resultTitle, deliveryResult)
-	resultBubble := s.delivery.BuildBubbleMessage(task.TaskID, "result", resultBubbleText, processingTask.UpdatedAt.Format(dateTimeLayout))
-	updatedTask, ok := s.runEngine.CompleteTask(task.TaskID, deliveryResult, resultBubble, artifacts)
-	if !ok {
-		return nil, ErrTaskNotFound
+	_, _, _, _ = resultTitle, resultPreview, resultBubbleText, deliveryType
+	updatedTask, resultBubble, deliveryResult, _, err := s.executeTask(processingTask, snapshotFromTask(processingTask), processingTask.Intent)
+	if err != nil {
+		return nil, err
 	}
 	updatedTask, _ = s.runEngine.ResolveAuthorization(task.TaskID, authorizationRecord, impactScope)
-	s.attachPostDeliveryHandoffs(updatedTask.TaskID, updatedTask.RunID, snapshotFromTask(updatedTask), updatedTask.Intent, deliveryResult, artifacts)
 
 	return map[string]any{
 		"authorization_record": authorizationRecord,
 		"task":                 taskMap(updatedTask),
 		"bubble_message":       resultBubble,
+		"delivery_result":      deliveryResult,
 		"impact_scope":         impactScope,
 	}, nil
 }
@@ -810,7 +806,7 @@ func currentStepForSuggestion(requiresConfirm bool) string {
 	if requiresConfirm {
 		return "intent_confirmation"
 	}
-	return "return_result"
+	return "generate_output"
 }
 
 // bubbleTypeForSuggestion 处理当前模块的相关逻辑。
@@ -1687,4 +1683,70 @@ func truncateText(value string, maxLength int) string {
 }
 
 // dateTimeLayout 定义当前模块的基础变量。
+func (s *Service) executeTask(task runengine.TaskRecord, snapshot contextsvc.TaskContextSnapshot, taskIntent map[string]any) (runengine.TaskRecord, map[string]any, map[string]any, []map[string]any, error) {
+	processingTask, ok := s.runEngine.BeginExecution(task.TaskID, "generate_output", "开始生成正式结果")
+	if !ok {
+		return runengine.TaskRecord{}, nil, nil, nil, ErrTaskNotFound
+	}
+
+	resultTitle, _, resultBubbleText := resultSpecFromIntent(taskIntent)
+	deliveryType := resolveTaskDeliveryType(processingTask, taskIntent)
+
+	if s.executor == nil {
+		deliveryResult := s.delivery.BuildDeliveryResultWithTargetPath(
+			processingTask.TaskID,
+			deliveryType,
+			resultTitle,
+			previewTextForDeliveryType(deliveryType),
+			targetPathFromIntent(taskIntent),
+		)
+		artifacts := s.delivery.BuildArtifact(processingTask.TaskID, resultTitle, deliveryResult)
+		resultBubble := s.delivery.BuildBubbleMessage(processingTask.TaskID, "result", resultBubbleText, processingTask.UpdatedAt.Format(dateTimeLayout))
+		updatedTask, ok := s.runEngine.CompleteTask(processingTask.TaskID, deliveryResult, resultBubble, artifacts)
+		if !ok {
+			return runengine.TaskRecord{}, nil, nil, nil, ErrTaskNotFound
+		}
+		s.attachPostDeliveryHandoffs(updatedTask.TaskID, updatedTask.RunID, snapshot, taskIntent, deliveryResult, artifacts)
+		return updatedTask, resultBubble, deliveryResult, artifacts, nil
+	}
+
+	executionResult, err := s.executor.Execute(context.Background(), execution.Request{
+		TaskID:       processingTask.TaskID,
+		RunID:        processingTask.RunID,
+		Title:        processingTask.Title,
+		Intent:       taskIntent,
+		Snapshot:     snapshot,
+		DeliveryType: deliveryType,
+		ResultTitle:  resultTitle,
+	})
+	if err != nil {
+		return runengine.TaskRecord{}, nil, nil, nil, fmt.Errorf("execute task %s: %w", processingTask.TaskID, err)
+	}
+
+	if executionResult.ToolName != "" {
+		if recordedTask, ok := s.runEngine.RecordToolCall(
+			processingTask.TaskID,
+			executionResult.ToolName,
+			executionResult.ToolInput,
+			executionResult.ToolOutput,
+			executionResult.DurationMS,
+		); ok {
+			processingTask = recordedTask
+		}
+	}
+
+	resultBubble := s.delivery.BuildBubbleMessage(
+		processingTask.TaskID,
+		"result",
+		firstNonEmptyString(executionResult.BubbleText, resultBubbleText),
+		processingTask.UpdatedAt.Format(dateTimeLayout),
+	)
+	updatedTask, ok := s.runEngine.CompleteTask(processingTask.TaskID, executionResult.DeliveryResult, resultBubble, executionResult.Artifacts)
+	if !ok {
+		return runengine.TaskRecord{}, nil, nil, nil, ErrTaskNotFound
+	}
+	s.attachPostDeliveryHandoffs(updatedTask.TaskID, updatedTask.RunID, snapshot, taskIntent, executionResult.DeliveryResult, executionResult.Artifacts)
+	return updatedTask, resultBubble, executionResult.DeliveryResult, executionResult.Artifacts, nil
+}
+
 const dateTimeLayout = time.RFC3339

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -2,6 +2,7 @@
 package orchestrator
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -557,7 +558,7 @@ func TestServiceSecurityRespondAllowOnceResumesAndCompletes(t *testing.T) {
 	}
 	impactScope := respondResult["impact_scope"].(map[string]any)
 	files := impactScope["files"].([]string)
-	if len(files) != 1 || files[0] != "workspace/report.md" {
+	if len(files) != 1 || files[0] != "workspace/文件写入结果.md" {
 		t.Fatalf("expected impact scope files to stay within workspace-relative paths, got %v", files)
 	}
 
@@ -788,6 +789,209 @@ func TestServiceTaskListSupportsSortParams(t *testing.T) {
 	secondTaskID := secondResult["task"].(map[string]any)["task_id"].(string)
 	if items[0]["task_id"] != firstTaskID || items[1]["task_id"] != secondTaskID {
 		t.Fatalf("expected started_at asc order %s -> %s, got %v -> %v", firstTaskID, secondTaskID, items[0]["task_id"], items[1]["task_id"])
+	}
+}
+
+func TestServiceDashboardOverviewUsesRuntimeAggregation(t *testing.T) {
+	service := newTestService()
+
+	completedResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_demo",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "completed task for dashboard overview",
+		},
+		"intent": map[string]any{
+			"name": "summarize",
+			"arguments": map[string]any{
+				"style": "key_points",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start completed task failed: %v", err)
+	}
+
+	waitingResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_demo",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "waiting authorization task for dashboard overview",
+		},
+		"intent": map[string]any{
+			"name": "write_file",
+			"arguments": map[string]any{
+				"require_authorization": true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start waiting auth task failed: %v", err)
+	}
+
+	result, err := service.DashboardOverviewGet(map[string]any{})
+	if err != nil {
+		t.Fatalf("dashboard overview failed: %v", err)
+	}
+
+	overview := result["overview"].(map[string]any)
+	focusSummary := overview["focus_summary"].(map[string]any)
+	waitingTaskID := waitingResult["task"].(map[string]any)["task_id"].(string)
+	if focusSummary["task_id"] != waitingTaskID {
+		t.Fatalf("expected focus summary to point at latest unfinished task %s, got %v", waitingTaskID, focusSummary["task_id"])
+	}
+	if focusSummary["status"] != "waiting_auth" {
+		t.Fatalf("expected focus summary status waiting_auth, got %v", focusSummary["status"])
+	}
+
+	trustSummary := overview["trust_summary"].(map[string]any)
+	if trustSummary["pending_authorizations"] != 1 {
+		t.Fatalf("expected one pending authorization, got %v", trustSummary["pending_authorizations"])
+	}
+	if trustSummary["has_restore_point"] != true {
+		t.Fatalf("expected completed task to provide restore point, got %v", trustSummary["has_restore_point"])
+	}
+	if trustSummary["workspace_path"] != "workspace" {
+		t.Fatalf("expected workspace-relative path in trust summary, got %v", trustSummary["workspace_path"])
+	}
+
+	quickActions := overview["quick_actions"].([]string)
+	if len(quickActions) == 0 || quickActions[0] != "处理待授权操作" {
+		t.Fatalf("expected dashboard quick actions to prioritize authorization handling, got %v", quickActions)
+	}
+
+	highValueSignals := overview["high_value_signal"].([]string)
+	if len(highValueSignals) == 0 {
+		t.Fatal("expected runtime-derived high value signals")
+	}
+
+	completedTaskID := completedResult["task"].(map[string]any)["task_id"].(string)
+	if completedTaskID == waitingTaskID {
+		t.Fatal("expected completed and waiting tasks to be distinct runtime records")
+	}
+}
+
+func TestServiceMirrorOverviewUsesRuntimeMirrorReferences(t *testing.T) {
+	service := newTestService()
+
+	_, err := service.StartTask(map[string]any{
+		"session_id": "sess_demo",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "mirror overview should reuse runtime memory plans",
+		},
+		"intent": map[string]any{
+			"name": "summarize",
+			"arguments": map[string]any{
+				"style": "key_points",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+
+	result, err := service.MirrorOverviewGet(map[string]any{})
+	if err != nil {
+		t.Fatalf("mirror overview failed: %v", err)
+	}
+
+	memoryReferences := result["memory_references"].([]map[string]any)
+	if len(memoryReferences) == 0 {
+		t.Fatal("expected runtime-derived mirror references")
+	}
+	if !strings.HasPrefix(memoryReferences[0]["memory_id"].(string), "mem_") {
+		t.Fatalf("expected memory reference to come from runtime plans, got %v", memoryReferences[0]["memory_id"])
+	}
+
+	historySummary := result["history_summary"].([]string)
+	if len(historySummary) == 0 {
+		t.Fatal("expected history summary to be derived from runtime tasks")
+	}
+
+	profile := result["profile"].(map[string]any)
+	if profile["preferred_output"] != "workspace_document" {
+		t.Fatalf("expected profile to infer workspace_document preference, got %v", profile["preferred_output"])
+	}
+}
+
+func TestServiceSecuritySummaryUsesRuntimeTaskState(t *testing.T) {
+	service := newTestService()
+
+	_, err := service.StartTask(map[string]any{
+		"session_id": "sess_demo",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "completed task for security summary restore point",
+		},
+		"intent": map[string]any{
+			"name": "summarize",
+			"arguments": map[string]any{
+				"style": "key_points",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start completed task failed: %v", err)
+	}
+
+	waitingResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_demo",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "security summary intercepted task",
+		},
+		"intent": map[string]any{
+			"name": "write_file",
+			"arguments": map[string]any{
+				"require_authorization": true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start intercepted task failed: %v", err)
+	}
+
+	waitingTaskID := waitingResult["task"].(map[string]any)["task_id"].(string)
+	_, err = service.SecurityRespond(map[string]any{
+		"task_id":       waitingTaskID,
+		"approval_id":   "appr_001",
+		"decision":      "deny_once",
+		"remember_rule": false,
+	})
+	if err != nil {
+		t.Fatalf("security respond failed: %v", err)
+	}
+
+	result, err := service.SecuritySummaryGet()
+	if err != nil {
+		t.Fatalf("security summary failed: %v", err)
+	}
+
+	summary := result["summary"].(map[string]any)
+	if summary["security_status"] != "intercepted" {
+		t.Fatalf("expected intercepted security status from runtime task state, got %v", summary["security_status"])
+	}
+	if summary["pending_authorizations"] != 0 {
+		t.Fatalf("expected no pending authorizations after denial, got %v", summary["pending_authorizations"])
+	}
+	if summary["latest_restore_point"] == nil {
+		t.Fatal("expected latest restore point to come from completed runtime task")
+	}
+
+	tokenCostSummary := summary["token_cost_summary"].(map[string]any)
+	if tokenCostSummary["budget_auto_downgrade"] != true {
+		t.Fatalf("expected token summary to reflect settings snapshot, got %v", tokenCostSummary["budget_auto_downgrade"])
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -2,7 +2,10 @@
 package orchestrator
 
 import (
+	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -10,9 +13,11 @@ import (
 	serviceconfig "github.com/cialloclaw/cialloclaw/services/local-service/internal/config"
 	contextsvc "github.com/cialloclaw/cialloclaw/services/local-service/internal/context"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/delivery"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/execution"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/intent"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/memory"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/model"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/platform"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/plugin"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/risk"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/runengine"
@@ -20,6 +25,51 @@ import (
 )
 
 // TestServiceStartTaskAndConfirmFlow 验证确认后的普通任务会继续执行并完成交付。
+type stubModelClient struct {
+	output string
+}
+
+func (s stubModelClient) GenerateText(_ context.Context, request model.GenerateTextRequest) (model.GenerateTextResponse, error) {
+	return model.GenerateTextResponse{
+		TaskID:     request.TaskID,
+		RunID:      request.RunID,
+		RequestID:  "req_test",
+		Provider:   "openai_responses",
+		ModelID:    "gpt-5.4",
+		OutputText: s.output,
+	}, nil
+}
+
+func newTestServiceWithExecution(t *testing.T, modelOutput string) (*Service, string) {
+	t.Helper()
+
+	workspaceRoot := filepath.Join(t.TempDir(), "workspace")
+	pathPolicy, err := platform.NewLocalPathPolicy(workspaceRoot)
+	if err != nil {
+		t.Fatalf("new local path policy: %v", err)
+	}
+
+	modelService := model.NewService(modelConfig(), stubModelClient{output: modelOutput})
+	deliveryService := delivery.NewService()
+	toolRegistry := tools.NewRegistry()
+	pluginService := plugin.NewService()
+	executor := execution.NewService(platform.NewLocalFileSystemAdapter(pathPolicy), modelService, deliveryService, toolRegistry, pluginService)
+
+	service := NewService(
+		contextsvc.NewService(),
+		intent.NewService(),
+		runengine.NewEngine(),
+		deliveryService,
+		memory.NewService(),
+		risk.NewService(),
+		modelService,
+		toolRegistry,
+		pluginService,
+	).WithExecutor(executor)
+
+	return service, workspaceRoot
+}
+
 func newTestService() *Service {
 	return NewService(
 		contextsvc.NewService(),
@@ -1051,6 +1101,88 @@ func TestServiceTaskControlRejectsFinishedTaskOperations(t *testing.T) {
 	})
 	if !errors.Is(err, ErrTaskAlreadyFinished) {
 		t.Fatalf("expected cancel on completed task to return ErrTaskAlreadyFinished, got %v", err)
+	}
+}
+
+func TestServiceStartTaskWithExecutorWritesWorkspaceDocument(t *testing.T) {
+	service, workspaceRoot := newTestServiceWithExecution(t, "第一点\n第二点\n第三点")
+
+	result, err := service.StartTask(map[string]any{
+		"session_id": "sess_exec",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "请整理成文档",
+		},
+		"intent": map[string]any{
+			"name": "summarize",
+			"arguments": map[string]any{
+				"style": "key_points",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+
+	deliveryResult := result["delivery_result"].(map[string]any)
+	payload := deliveryResult["payload"].(map[string]any)
+	outputPath := payload["path"].(string)
+	if outputPath == "" {
+		t.Fatal("expected workspace document delivery to carry a payload path")
+	}
+
+	content, err := os.ReadFile(filepath.Join(workspaceRoot, strings.TrimPrefix(outputPath, "workspace/")))
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if !strings.Contains(string(content), "# 处理结果") {
+		t.Fatalf("expected written file to contain title header, got %s", string(content))
+	}
+
+	taskID := result["task"].(map[string]any)["task_id"].(string)
+	record, ok := service.runEngine.GetTask(taskID)
+	if !ok {
+		t.Fatal("expected task to remain in runtime")
+	}
+	if record.LatestToolCall["tool_name"] != "write_file" {
+		t.Fatalf("expected runtime task to record write_file tool call, got %v", record.LatestToolCall["tool_name"])
+	}
+}
+
+func TestServiceStartTaskWithExecutorReturnsGeneratedBubble(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "这段内容主要在解释当前问题的原因和处理方向。")
+
+	result, err := service.StartTask(map[string]any{
+		"session_id": "sess_exec",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "请解释这段内容",
+		},
+		"intent": map[string]any{
+			"name":      "explain",
+			"arguments": map[string]any{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+
+	bubble := result["bubble_message"].(map[string]any)
+	if bubble["text"] != "这段内容主要在解释当前问题的原因和处理方向。" {
+		t.Fatalf("expected bubble text to use generated output, got %v", bubble["text"])
+	}
+
+	taskID := result["task"].(map[string]any)["task_id"].(string)
+	record, ok := service.runEngine.GetTask(taskID)
+	if !ok {
+		t.Fatal("expected task to remain in runtime")
+	}
+	if record.LatestToolCall["tool_name"] != "generate_text" {
+		t.Fatalf("expected runtime task to record generate_text tool call, got %v", record.LatestToolCall["tool_name"])
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -2,6 +2,7 @@
 package orchestrator
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -992,6 +993,64 @@ func TestServiceSecuritySummaryUsesRuntimeTaskState(t *testing.T) {
 	tokenCostSummary := summary["token_cost_summary"].(map[string]any)
 	if tokenCostSummary["budget_auto_downgrade"] != true {
 		t.Fatalf("expected token summary to reflect settings snapshot, got %v", tokenCostSummary["budget_auto_downgrade"])
+	}
+}
+
+func TestServiceTaskControlRejectsInvalidStatusTransition(t *testing.T) {
+	service := newTestService()
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_demo",
+		"source":     "floating_ball",
+		"trigger":    "text_selected_click",
+		"input": map[string]any{
+			"type": "text_selection",
+			"text": "this task still requires confirmation",
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	_, err = service.TaskControl(map[string]any{
+		"task_id": taskID,
+		"action":  "pause",
+	})
+	if !errors.Is(err, ErrTaskStatusInvalid) {
+		t.Fatalf("expected pause from confirming_intent to return ErrTaskStatusInvalid, got %v", err)
+	}
+}
+
+func TestServiceTaskControlRejectsFinishedTaskOperations(t *testing.T) {
+	service := newTestService()
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_demo",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "completed task for task control error mapping",
+		},
+		"intent": map[string]any{
+			"name": "summarize",
+			"arguments": map[string]any{
+				"style": "key_points",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	_, err = service.TaskControl(map[string]any{
+		"task_id": taskID,
+		"action":  "cancel",
+	})
+	if !errors.Is(err, ErrTaskAlreadyFinished) {
+		t.Fatalf("expected cancel on completed task to return ErrTaskAlreadyFinished, got %v", err)
 	}
 }
 

--- a/services/local-service/internal/rpc/handlers.go
+++ b/services/local-service/internal/rpc/handlers.go
@@ -224,6 +224,22 @@ func wrapOrchestratorResult(data any, err error) (any, *rpcError) {
 			TraceID: "trace_task_not_found",
 		}
 	}
+	if errors.Is(err, orchestrator.ErrTaskStatusInvalid) {
+		return nil, &rpcError{
+			Code:    1001004,
+			Message: "TASK_STATUS_INVALID",
+			Detail:  err.Error(),
+			TraceID: "trace_task_status_invalid",
+		}
+	}
+	if errors.Is(err, orchestrator.ErrTaskAlreadyFinished) {
+		return nil, &rpcError{
+			Code:    1001005,
+			Message: "TASK_ALREADY_FINISHED",
+			Detail:  err.Error(),
+			TraceID: "trace_task_already_finished",
+		}
+	}
 
 	return nil, &rpcError{
 		Code:    errInvalidParams,

--- a/services/local-service/internal/rpc/server_test.go
+++ b/services/local-service/internal/rpc/server_test.go
@@ -131,6 +131,120 @@ func TestHandleDebugEventsReturnsQueuedNotifications(t *testing.T) {
 }
 
 // newTestServer 处理当前模块的相关逻辑。
+func TestDispatchMapsTaskControlStatusErrors(t *testing.T) {
+	server := newTestServer()
+
+	startResult, err := server.orchestrator.StartTask(map[string]any{
+		"session_id": "sess_demo",
+		"source":     "floating_ball",
+		"trigger":    "text_selected_click",
+		"input": map[string]any{
+			"type": "text_selection",
+			"text": "still waiting for intent confirmation",
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task: %v", err)
+	}
+
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	response := server.dispatch(requestEnvelope{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`"req-task-control-invalid"`),
+		Method:  "agent.task.control",
+		Params: mustMarshal(t, map[string]any{
+			"task_id": taskID,
+			"action":  "pause",
+		}),
+	})
+
+	errEnvelope, ok := response.(errorEnvelope)
+	if !ok {
+		t.Fatalf("expected error response envelope, got %#v", response)
+	}
+	if errEnvelope.Error.Code != 1001004 || errEnvelope.Error.Message != "TASK_STATUS_INVALID" {
+		t.Fatalf("expected TASK_STATUS_INVALID mapping, got code=%d message=%s", errEnvelope.Error.Code, errEnvelope.Error.Message)
+	}
+}
+
+func TestDispatchMapsTaskControlFinishedErrors(t *testing.T) {
+	server := newTestServer()
+
+	startResult, err := server.orchestrator.StartTask(map[string]any{
+		"session_id": "sess_demo",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "completed task for rpc error mapping",
+		},
+		"intent": map[string]any{
+			"name": "summarize",
+			"arguments": map[string]any{
+				"style": "key_points",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task: %v", err)
+	}
+
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	response := server.dispatch(requestEnvelope{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`"req-task-control-finished"`),
+		Method:  "agent.task.control",
+		Params: mustMarshal(t, map[string]any{
+			"task_id": taskID,
+			"action":  "cancel",
+		}),
+	})
+
+	errEnvelope, ok := response.(errorEnvelope)
+	if !ok {
+		t.Fatalf("expected error response envelope, got %#v", response)
+	}
+	if errEnvelope.Error.Code != 1001005 || errEnvelope.Error.Message != "TASK_ALREADY_FINISHED" {
+		t.Fatalf("expected TASK_ALREADY_FINISHED mapping, got code=%d message=%s", errEnvelope.Error.Code, errEnvelope.Error.Message)
+	}
+}
+
+func TestDispatchMapsTaskControlInvalidActionToInvalidParams(t *testing.T) {
+	server := newTestServer()
+
+	startResult, err := server.orchestrator.StartTask(map[string]any{
+		"session_id": "sess_demo",
+		"source":     "floating_ball",
+		"trigger":    "text_selected_click",
+		"input": map[string]any{
+			"type": "text_selection",
+			"text": "task for invalid action",
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task: %v", err)
+	}
+
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	response := server.dispatch(requestEnvelope{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`"req-task-control-invalid-action"`),
+		Method:  "agent.task.control",
+		Params: mustMarshal(t, map[string]any{
+			"task_id": taskID,
+			"action":  "skip",
+		}),
+	})
+
+	errEnvelope, ok := response.(errorEnvelope)
+	if !ok {
+		t.Fatalf("expected error response envelope, got %#v", response)
+	}
+	if errEnvelope.Error.Code != 1002001 || errEnvelope.Error.Message != "INVALID_PARAMS" {
+		t.Fatalf("expected INVALID_PARAMS mapping for unsupported action, got code=%d message=%s", errEnvelope.Error.Code, errEnvelope.Error.Message)
+	}
+}
+
 func newTestServer() *Server {
 	orch := orchestrator.NewService(
 		contextsvc.NewService(),

--- a/services/local-service/internal/runengine/engine.go
+++ b/services/local-service/internal/runengine/engine.go
@@ -238,7 +238,6 @@ func (e *Engine) CreateTask(input CreateTaskInput) TaskRecord {
 	}
 
 	record.LatestEvent = e.buildEvent(record, "task.updated")
-	record.LatestToolCall = e.buildToolCall(record, "read_file")
 	record.queueNotification("task.updated", map[string]any{
 		"task_id": taskID,
 		"status":  record.Status,
@@ -328,6 +327,30 @@ func (e *Engine) ConfirmTask(taskID string, intent map[string]any, bubbleMessage
 	return record.clone(), true
 }
 
+// BeginExecution 把任务推进到真实执行步骤，并刷新 timeline 与事件。
+func (e *Engine) BeginExecution(taskID, stepName, outputSummary string) (TaskRecord, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	record, ok := e.tasks[taskID]
+	if !ok {
+		return TaskRecord{}, false
+	}
+
+	record.Status = "processing"
+	record.CurrentStep = firstNonEmpty(stepName, "generate_output")
+	record.UpdatedAt = e.now()
+	record.Timeline = advanceTimeline(record.Timeline, record.CurrentStep, "running", outputSummary)
+	record.CurrentStepStatus = currentTimelineStatus(record.Timeline)
+	record.LatestEvent = e.buildEvent(record, "task.updated")
+	record.queueNotification("task.updated", map[string]any{
+		"task_id": record.TaskID,
+		"status":  record.Status,
+	})
+
+	return record.clone(), true
+}
+
 // UpdateIntent 更新Task当前生效意图。
 
 // UpdateIntent 在不改变整体任务身份的前提下覆盖当前生效意图。
@@ -385,6 +408,30 @@ func (e *Engine) SetPresentation(taskID string, bubbleMessage map[string]any, de
 			"delivery_result": cloneMap(record.DeliveryResult),
 		})
 	}
+
+	return record.clone(), true
+}
+
+// RecordToolCall 记录主链路最近一次完成的 tool_call 兼容层快照。
+func (e *Engine) RecordToolCall(taskID, toolName string, input, output map[string]any, durationMS int64) (TaskRecord, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	record, ok := e.tasks[taskID]
+	if !ok {
+		return TaskRecord{}, false
+	}
+
+	record.UpdatedAt = e.now()
+	record.LatestToolCall = e.buildToolCallRecord(record, toolName, input, output, durationMS, nil)
+	record.LatestEvent = e.buildEventWithPayload(record, "tool_call.completed", map[string]any{
+		"status":    record.Status,
+		"tool_name": toolName,
+	})
+	record.queueNotification("task.updated", map[string]any{
+		"task_id": record.TaskID,
+		"status":  record.Status,
+	})
 
 	return record.clone(), true
 }
@@ -921,6 +968,10 @@ func (e *Engine) NotepadItems(group string, limit, offset int) ([]map[string]any
 
 // buildEvent 为当前任务生成一条兼容层 Event 记录。
 func (e *Engine) buildEvent(record *TaskRecord, eventType string) map[string]any {
+	return e.buildEventWithPayload(record, eventType, map[string]any{"status": record.Status})
+}
+
+func (e *Engine) buildEventWithPayload(record *TaskRecord, eventType string, payload map[string]any) map[string]any {
 	return map[string]any{
 		"event_id":   e.nextIdentifier("evt"),
 		"run_id":     record.RunID,
@@ -928,7 +979,7 @@ func (e *Engine) buildEvent(record *TaskRecord, eventType string) map[string]any
 		"step_id":    timelineCurrentStepID(record.Timeline),
 		"type":       eventType,
 		"level":      "info",
-		"payload":    map[string]any{"status": record.Status},
+		"payload":    cloneMap(payload),
 		"created_at": e.now().Format(time.RFC3339),
 	}
 }
@@ -937,6 +988,14 @@ func (e *Engine) buildEvent(record *TaskRecord, eventType string) map[string]any
 
 // buildToolCall 为当前任务生成一条兼容层 ToolCall 记录。
 func (e *Engine) buildToolCall(record *TaskRecord, toolName string) map[string]any {
+	return e.buildToolCallRecord(record, toolName, map[string]any{}, map[string]any{}, 120, nil)
+}
+
+func (e *Engine) buildToolCallRecord(record *TaskRecord, toolName string, input, output map[string]any, durationMS int64, errorCode any) map[string]any {
+	if durationMS <= 0 {
+		durationMS = 1
+	}
+
 	return map[string]any{
 		"tool_call_id": e.nextIdentifier("tool"),
 		"run_id":       record.RunID,
@@ -944,10 +1003,10 @@ func (e *Engine) buildToolCall(record *TaskRecord, toolName string) map[string]a
 		"step_id":      timelineCurrentStepID(record.Timeline),
 		"tool_name":    toolName,
 		"status":       "succeeded",
-		"input":        map[string]any{},
-		"output":       map[string]any{},
-		"error_code":   nil,
-		"duration_ms":  120,
+		"input":        cloneMap(input),
+		"output":       cloneMap(output),
+		"error_code":   errorCode,
+		"duration_ms":  durationMS,
 	}
 }
 

--- a/services/local-service/internal/runengine/engine.go
+++ b/services/local-service/internal/runengine/engine.go
@@ -2,6 +2,7 @@
 package runengine
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -12,6 +13,12 @@ const (
 	defaultWorkspaceRoot   = "workspace"
 	defaultTaskSourcePath  = "workspace/todos"
 	defaultRecoveryPathObj = "workspace/temp.md"
+)
+
+var (
+	ErrTaskNotFound        = errors.New("task not found")
+	ErrTaskStatusInvalid   = errors.New("task status invalid")
+	ErrTaskAlreadyFinished = errors.New("task already finished")
 )
 
 // TaskRecord 描述当前模块记录。
@@ -421,38 +428,79 @@ func (e *Engine) CompleteTask(taskID string, deliveryResult map[string]any, bubb
 // ControlTask 控制Task。
 
 // ControlTask 处理 pause/resume/cancel/restart 等用户控制动作。
-func (e *Engine) ControlTask(taskID, action string, bubbleMessage map[string]any) (TaskRecord, bool) {
+func (e *Engine) ControlTask(taskID, action string, bubbleMessage map[string]any) (TaskRecord, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	record, ok := e.tasks[taskID]
 	if !ok {
-		return TaskRecord{}, false
+		return TaskRecord{}, ErrTaskNotFound
 	}
 
 	now := e.now()
 	switch action {
 	case "pause":
+		if record.isFinished() {
+			return TaskRecord{}, ErrTaskAlreadyFinished
+		}
+		if record.Status != "processing" {
+			return TaskRecord{}, ErrTaskStatusInvalid
+		}
 		record.Status = "paused"
 	case "resume":
+		if record.isFinished() {
+			return TaskRecord{}, ErrTaskAlreadyFinished
+		}
+		if record.Status != "paused" {
+			return TaskRecord{}, ErrTaskStatusInvalid
+		}
 		record.Status = "processing"
 	case "cancel":
+		if record.isFinished() {
+			return TaskRecord{}, ErrTaskAlreadyFinished
+		}
 		record.Status = "cancelled"
 		record.FinishedAt = &now
+		record.ApprovalRequest = nil
+		record.PendingExecution = nil
+		record.SecuritySummary = buildSecuritySummary(record.RiskLevel, latestRestorePointFromSummary(record.SecuritySummary))
+		record.Timeline = advanceTimeline(record.Timeline, "task_cancelled", "cancelled", "任务已取消")
+		record.CurrentStep = "task_cancelled"
 	case "restart":
+		if !record.isFinished() {
+			return TaskRecord{}, ErrTaskStatusInvalid
+		}
 		record.Status = "processing"
 		record.FinishedAt = nil
+		record.CurrentStep = "generate_output"
+		record.DeliveryResult = nil
+		record.Artifacts = nil
+		record.BubbleMessage = nil
+		record.ApprovalRequest = nil
+		record.PendingExecution = nil
+		record.Authorization = nil
+		record.ImpactScope = nil
+		record.StorageWritePlan = nil
+		record.ArtifactPlans = nil
+		record.MemoryReadPlans = nil
+		record.MemoryWritePlans = nil
+		record.MirrorReferences = nil
+		record.SecuritySummary = buildSecuritySummary(record.RiskLevel, latestRestorePointFromSummary(record.SecuritySummary))
+		record.Timeline = advanceTimeline(record.Timeline, "generate_output", "running", "任务已重新开始")
+	default:
+		return TaskRecord{}, ErrTaskStatusInvalid
 	}
 
 	record.UpdatedAt = now
 	record.BubbleMessage = cloneMap(bubbleMessage)
+	record.CurrentStepStatus = currentTimelineStatus(record.Timeline)
 	record.LatestEvent = e.buildEvent(record, "task.updated")
 	record.queueNotification("task.updated", map[string]any{
 		"task_id": record.TaskID,
 		"status":  record.Status,
 	})
 
-	return record.clone(), true
+	return record.clone(), nil
 }
 
 // MarkWaitingApproval 处理当前模块的相关逻辑。

--- a/services/local-service/internal/runengine/engine.go
+++ b/services/local-service/internal/runengine/engine.go
@@ -639,6 +639,22 @@ func (e *Engine) SetMemoryPlans(taskID string, readPlans []map[string]any, write
 // SetDeliveryPlans 设置DeliveryPlans。
 
 // SetDeliveryPlans 记录 workspace 写入计划和 artifact 持久化计划。
+// SetMirrorReferences 记录任务挂接后的镜像引用快照。
+// SetMirrorReferences 记录任务挂接后的镜像引用快照。
+func (e *Engine) SetMirrorReferences(taskID string, mirrorReferences []map[string]any) (TaskRecord, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	record, ok := e.tasks[taskID]
+	if !ok {
+		return TaskRecord{}, false
+	}
+
+	record.MirrorReferences = cloneMapSlice(mirrorReferences)
+	return record.clone(), true
+}
+
+// SetDeliveryPlans 记录 workspace 写入计划和 artifact 持久化计划。
 func (e *Engine) SetDeliveryPlans(taskID string, storageWritePlan map[string]any, artifactPlans []map[string]any) (TaskRecord, bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/services/local-service/internal/runengine/engine_test.go
+++ b/services/local-service/internal/runengine/engine_test.go
@@ -77,6 +77,54 @@ func TestEngineTaskLifecycle(t *testing.T) {
 	}
 }
 
+// TestEngineExecutionProgressAndToolCall 验证真实执行阶段的 timeline 和 tool_call 会被记录。
+func TestEngineExecutionProgressAndToolCall(t *testing.T) {
+	engine := NewEngine()
+	engine.now = func() time.Time { return time.Date(2026, 4, 8, 10, 30, 0, 0, time.UTC) }
+
+	task := engine.CreateTask(CreateTaskInput{
+		SessionID:   "sess_exec",
+		Title:       "执行测试任务",
+		SourceType:  "hover_input",
+		Status:      "processing",
+		Intent:      map[string]any{"name": "summarize", "arguments": map[string]any{"style": "key_points"}},
+		CurrentStep: "generate_output",
+		RiskLevel:   "green",
+		Timeline: []TaskStepRecord{{
+			Name:          "generate_output",
+			Status:        "running",
+			OrderIndex:    1,
+			InputSummary:  "task input",
+			OutputSummary: "等待生成",
+		}},
+	})
+
+	started, ok := engine.BeginExecution(task.TaskID, "generate_output", "开始生成正式结果")
+	if !ok {
+		t.Fatal("expected begin execution to succeed")
+	}
+	if started.CurrentStep != "generate_output" {
+		t.Fatalf("expected current step to remain generate_output, got %s", started.CurrentStep)
+	}
+	if started.Timeline[len(started.Timeline)-1].OutputSummary != "开始生成正式结果" {
+		t.Fatalf("expected execution summary to update timeline, got %v", started.Timeline[len(started.Timeline)-1].OutputSummary)
+	}
+
+	recorded, ok := engine.RecordToolCall(task.TaskID, "write_file", map[string]any{"path": "workspace/result.md"}, map[string]any{"bytes": 128}, 32)
+	if !ok {
+		t.Fatal("expected tool call recording to succeed")
+	}
+	if recorded.LatestToolCall["tool_name"] != "write_file" {
+		t.Fatalf("expected latest tool call to be write_file, got %v", recorded.LatestToolCall["tool_name"])
+	}
+	if recorded.LatestToolCall["duration_ms"] != int64(32) {
+		t.Fatalf("expected duration_ms to be preserved, got %v", recorded.LatestToolCall["duration_ms"])
+	}
+	if recorded.LatestEvent["type"] != "tool_call.completed" {
+		t.Fatalf("expected latest event to reflect tool_call.completed, got %v", recorded.LatestEvent["type"])
+	}
+}
+
 // TestEngineAuthorizationAndHandoffState 验证EngineAuthorizationAndHandoffState。
 func TestEngineAuthorizationAndHandoffState(t *testing.T) {
 	engine := NewEngine()

--- a/services/local-service/internal/runengine/engine_test.go
+++ b/services/local-service/internal/runengine/engine_test.go
@@ -2,6 +2,7 @@
 package runengine
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -251,8 +252,8 @@ func TestEngineListTasksSupportsSorting(t *testing.T) {
 	second := createTask("second")
 	third := createTask("third")
 
-	if _, ok := engine.ControlTask(first.TaskID, "pause", map[string]any{"task_id": first.TaskID, "type": "status"}); !ok {
-		t.Fatal("expected first task update to succeed")
+	if _, err := engine.ControlTask(first.TaskID, "pause", map[string]any{"task_id": first.TaskID, "type": "status"}); err != nil {
+		t.Fatalf("expected first task update to succeed: %v", err)
 	}
 	currentTime = currentTime.Add(time.Minute)
 	if _, ok := engine.CompleteTask(second.TaskID, map[string]any{"type": "bubble"}, map[string]any{"task_id": second.TaskID, "type": "result"}, nil); !ok {
@@ -284,5 +285,92 @@ func TestEngineListTasksSupportsSorting(t *testing.T) {
 	defaultSorted, _ := engine.ListTasks("finished", "unknown_field", "unknown_order", 10, 0)
 	if defaultSorted[0].TaskID != third.TaskID || defaultSorted[1].TaskID != second.TaskID {
 		t.Fatalf("expected invalid sort options to fall back to updated_at desc, got %s -> %s", defaultSorted[0].TaskID, defaultSorted[1].TaskID)
+	}
+}
+
+func TestEngineControlTaskRejectsInvalidTransitions(t *testing.T) {
+	engine := NewEngine()
+	task := engine.CreateTask(CreateTaskInput{
+		SessionID:   "sess_control",
+		Title:       "task control transition test",
+		SourceType:  "hover_input",
+		Status:      "confirming_intent",
+		Intent:      map[string]any{"name": "summarize", "arguments": map[string]any{"style": "key_points"}},
+		CurrentStep: "intent_confirmation",
+		RiskLevel:   "green",
+		Timeline: []TaskStepRecord{{
+			Name:          "intent_confirmation",
+			Status:        "pending",
+			OrderIndex:    1,
+			InputSummary:  "task input",
+			OutputSummary: "waiting for confirm",
+		}},
+	})
+
+	if _, err := engine.ControlTask(task.TaskID, "resume", map[string]any{"task_id": task.TaskID, "type": "status"}); !errors.Is(err, ErrTaskStatusInvalid) {
+		t.Fatalf("expected resume from confirming_intent to be invalid, got %v", err)
+	}
+
+	if _, err := engine.ControlTask(task.TaskID, "pause", map[string]any{"task_id": task.TaskID, "type": "status"}); !errors.Is(err, ErrTaskStatusInvalid) {
+		t.Fatalf("expected pause from confirming_intent to be invalid, got %v", err)
+	}
+
+	completed, ok := engine.CompleteTask(task.TaskID, map[string]any{"type": "bubble"}, map[string]any{"task_id": task.TaskID, "type": "result"}, nil)
+	if !ok || completed.Status != "completed" {
+		t.Fatalf("expected task to complete for finished-state checks, got %#v ok=%v", completed, ok)
+	}
+
+	if _, err := engine.ControlTask(task.TaskID, "cancel", map[string]any{"task_id": task.TaskID, "type": "status"}); !errors.Is(err, ErrTaskAlreadyFinished) {
+		t.Fatalf("expected cancel on completed task to return ErrTaskAlreadyFinished, got %v", err)
+	}
+}
+
+func TestEngineControlTaskRestartResetsFinishedOutputs(t *testing.T) {
+	engine := NewEngine()
+	task := engine.CreateTask(CreateTaskInput{
+		SessionID:   "sess_restart",
+		Title:       "restart finished task",
+		SourceType:  "hover_input",
+		Status:      "processing",
+		Intent:      map[string]any{"name": "summarize", "arguments": map[string]any{"style": "key_points"}},
+		CurrentStep: "generate_output",
+		RiskLevel:   "green",
+		Timeline: []TaskStepRecord{{
+			Name:          "generate_output",
+			Status:        "running",
+			OrderIndex:    1,
+			InputSummary:  "task input",
+			OutputSummary: "generating output",
+		}},
+	})
+
+	deliveryResult := map[string]any{"type": "workspace_document", "payload": map[string]any{"path": "workspace/result.md"}}
+	artifacts := []map[string]any{{"artifact_id": "art_test", "task_id": task.TaskID, "path": "workspace/result.md"}}
+	completed, ok := engine.CompleteTask(task.TaskID, deliveryResult, map[string]any{"task_id": task.TaskID, "type": "result"}, artifacts)
+	if !ok || completed.Status != "completed" {
+		t.Fatalf("expected task to complete before restart, got %#v ok=%v", completed, ok)
+	}
+	if _, ok := engine.SetMemoryPlans(task.TaskID, []map[string]any{{"kind": "retrieval"}}, []map[string]any{{"kind": "summary_write"}}); !ok {
+		t.Fatal("expected memory plans to be stored before restart")
+	}
+	if _, ok := engine.SetMirrorReferences(task.TaskID, []map[string]any{{"memory_id": "mem_write_task_001_1"}}); !ok {
+		t.Fatal("expected mirror references to be stored before restart")
+	}
+
+	restarted, err := engine.ControlTask(task.TaskID, "restart", map[string]any{"task_id": task.TaskID, "type": "status"})
+	if err != nil {
+		t.Fatalf("expected restart on completed task to succeed: %v", err)
+	}
+	if restarted.Status != "processing" {
+		t.Fatalf("expected restarted task to return to processing, got %s", restarted.Status)
+	}
+	if restarted.FinishedAt != nil {
+		t.Fatal("expected restart to clear finished_at")
+	}
+	if restarted.DeliveryResult != nil || len(restarted.Artifacts) != 0 {
+		t.Fatal("expected restart to clear finished delivery outputs")
+	}
+	if restarted.MemoryReadPlans != nil || restarted.MemoryWritePlans != nil || restarted.MirrorReferences != nil {
+		t.Fatal("expected restart to clear handoff and mirror snapshots")
 	}
 }


### PR DESCRIPTION
## Summary
- add a real in-process execution service for the harness P0 backend flow
- generate task output through the unified model layer when available, with a safe local fallback path when no configured client is active
- write `workspace_document` deliveries into the workspace instead of completing tasks with synthetic delivery payloads only
- keep `bubble` deliveries backed by generated content instead of fixed placeholder result text
- add explicit workspace target-path support for delivery payloads and generated document artifacts
- record runtime execution progress and completed tool-call snapshots in the runengine
- route `agent.input.submit`, `agent.task.start`, `agent.task.confirm`, and `agent.security.respond` through the same execution pipeline
- wire the execution service in bootstrap using the existing filesystem, model, tool registry, and plugin boundaries

## Unified Item Impact
- affects the P0 harness main flow
- reuses existing protocol fields
- does not add new JSON-RPC methods
- does not add new error codes

## Main Flow Impact
- yes
- replaces synthetic task completion in the main task flow with a real execution path that generates content, writes workspace outputs, and records runtime execution traces

## Platform Abstraction Impact
- yes
- reuses the existing `FileSystemAdapter` for workspace writes instead of introducing platform-specific path handling in business logic

## Memory / Model / Stronghold Impact
- reuses the existing model service as the only model entry point
- keeps memory handoff attachment unchanged and attaches it after real execution finishes
- no Stronghold change

## AI Usage
- generated with AI assistance and manually cleaned up
- manually reviewed execution boundaries, delivery path handling, runtime state transitions, and test coverage

## Testing
- `go test ./services/local-service/internal/orchestrator ./services/local-service/internal/runengine ./services/local-service/internal/delivery ./services/local-service/internal/execution ./services/local-service/internal/bootstrap`
- `go test ./...`
