### PR TITLE
Persist P0 task and run state through SQLite storage

### DIFF
--- a/services/local-service/internal/bootstrap/bootstrap.go
+++ b/services/local-service/internal/bootstrap/bootstrap.go
@@ -59,11 +59,16 @@ func New(cfg config.Config) (*App, error) {
 	toolRegistry := tools.NewRegistry()
 	pluginService := plugin.NewService()
 	executionService := execution.NewService(fileSystem, modelService, deliveryService, toolRegistry, pluginService)
+	runEngine, err := runengine.NewEngineWithStore(storageService.TaskRunStore())
+	if err != nil {
+		_ = storageService.Close()
+		return nil, err
+	}
 
 	orchestratorService := orchestrator.NewService(
 		contextsvc.NewService(),
 		intent.NewService(),
-		runengine.NewEngine(),
+		runEngine,
 		deliveryService,
 		memory.NewServiceFromStorage(storageService.MemoryStore(), storageService.Capabilities().MemoryRetrievalBackend),
 		risk.NewService(),

--- a/services/local-service/internal/bootstrap/bootstrap_test.go
+++ b/services/local-service/internal/bootstrap/bootstrap_test.go
@@ -35,6 +35,9 @@ func TestNewWiresStorageBackedMemoryService(t *testing.T) {
 	if app.storage.MemoryStore() == nil {
 		t.Fatal("expected storage memory store to be available")
 	}
+	if app.storage.TaskRunStore() == nil {
+		t.Fatal("expected storage task/run store to be available")
+	}
 	capabilities := app.storage.Capabilities()
 	if !capabilities.SupportsMemoryStore {
 		t.Fatalf("expected storage capabilities to expose memory store: %+v", app.storage.Capabilities())

--- a/services/local-service/internal/runengine/engine.go
+++ b/services/local-service/internal/runengine/engine.go
@@ -2,11 +2,14 @@
 package runengine
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/storage"
 )
 
 const (
@@ -125,6 +128,7 @@ type Engine struct {
 	mu           sync.RWMutex
 	nextID       uint64
 	now          func() time.Time
+	taskStore    storage.TaskRunStore
 	tasks        map[string]*TaskRecord
 	taskOrder    []string
 	sessionOrder []string
@@ -137,8 +141,19 @@ type Engine struct {
 
 // NewEngine 创建一套新的内存态引擎，并填充主链路需要的默认设置和巡检配置。
 func NewEngine() *Engine {
+	engine, _ := newEngine(nil)
+	return engine
+}
+
+// NewEngineWithStore 创建带有 task/run 持久化存储的引擎实例。
+func NewEngineWithStore(taskStore storage.TaskRunStore) (*Engine, error) {
+	return newEngine(taskStore)
+}
+
+func newEngine(taskStore storage.TaskRunStore) (*Engine, error) {
 	engine := &Engine{
 		now:          time.Now,
+		taskStore:    taskStore,
 		tasks:        map[string]*TaskRecord{},
 		taskOrder:    []string{},
 		sessionOrder: []string{},
@@ -164,7 +179,11 @@ func NewEngine() *Engine {
 		},
 	}
 
-	return engine
+	if err := engine.loadPersistedTaskRuns(context.Background()); err != nil {
+		return nil, err
+	}
+
+	return engine, nil
 }
 
 // CurrentState 处理当前模块的相关逻辑。
@@ -245,6 +264,7 @@ func (e *Engine) CreateTask(input CreateTaskInput) TaskRecord {
 
 	e.tasks[taskID] = record
 	e.taskOrder = append([]string{taskID}, e.taskOrder...)
+	e.persistTaskLocked(record)
 
 	return record.clone()
 }
@@ -323,6 +343,7 @@ func (e *Engine) ConfirmTask(taskID string, intent map[string]any, bubbleMessage
 		"task_id": record.TaskID,
 		"status":  record.Status,
 	})
+	e.persistTaskLocked(record)
 
 	return record.clone(), true
 }
@@ -347,6 +368,7 @@ func (e *Engine) BeginExecution(taskID, stepName, outputSummary string) (TaskRec
 		"task_id": record.TaskID,
 		"status":  record.Status,
 	})
+	e.persistTaskLocked(record)
 
 	return record.clone(), true
 }
@@ -370,6 +392,7 @@ func (e *Engine) UpdateIntent(taskID string, intent map[string]any) (TaskRecord,
 		"task_id": record.TaskID,
 		"status":  record.Status,
 	})
+	e.persistTaskLocked(record)
 
 	return record.clone(), true
 }
@@ -408,6 +431,7 @@ func (e *Engine) SetPresentation(taskID string, bubbleMessage map[string]any, de
 			"delivery_result": cloneMap(record.DeliveryResult),
 		})
 	}
+	e.persistTaskLocked(record)
 
 	return record.clone(), true
 }
@@ -432,6 +456,7 @@ func (e *Engine) RecordToolCall(taskID, toolName string, input, output map[strin
 		"task_id": record.TaskID,
 		"status":  record.Status,
 	})
+	e.persistTaskLocked(record)
 
 	return record.clone(), true
 }
@@ -468,6 +493,7 @@ func (e *Engine) CompleteTask(taskID string, deliveryResult map[string]any, bubb
 		"task_id":         record.TaskID,
 		"delivery_result": cloneMap(record.DeliveryResult),
 	})
+	e.persistTaskLocked(record)
 
 	return record.clone(), true
 }
@@ -546,6 +572,7 @@ func (e *Engine) ControlTask(taskID, action string, bubbleMessage map[string]any
 		"task_id": record.TaskID,
 		"status":  record.Status,
 	})
+	e.persistTaskLocked(record)
 
 	return record.clone(), nil
 }
@@ -596,6 +623,7 @@ func (e *Engine) MarkWaitingApprovalWithPlan(taskID string, approvalRequest map[
 		"task_id":          record.TaskID,
 		"approval_request": cloneMap(record.ApprovalRequest),
 	})
+	e.persistTaskLocked(record)
 
 	return record.clone(), true
 }
@@ -621,6 +649,7 @@ func (e *Engine) ResolveAuthorization(taskID string, authorization map[string]an
 		latestRestorePoint = cloneMap(existingRestorePoint)
 	}
 	record.SecuritySummary = buildSecuritySummary(record.RiskLevel, latestRestorePoint)
+	e.persistTaskLocked(record)
 	return record.clone(), true
 }
 
@@ -652,6 +681,7 @@ func (e *Engine) ResumeAfterApproval(taskID string, authorization map[string]any
 		"task_id": record.TaskID,
 		"status":  record.Status,
 	})
+	e.persistTaskLocked(record)
 
 	return record.clone(), true
 }
@@ -691,6 +721,7 @@ func (e *Engine) DenyAfterApproval(taskID string, authorization map[string]any, 
 		"task_id": record.TaskID,
 		"status":  record.Status,
 	})
+	e.persistTaskLocked(record)
 
 	return record.clone(), true
 }
@@ -728,6 +759,7 @@ func (e *Engine) SetMemoryPlans(taskID string, readPlans []map[string]any, write
 	if writePlans != nil {
 		record.MemoryWritePlans = cloneMapSlice(writePlans)
 	}
+	e.persistTaskLocked(record)
 	return record.clone(), true
 }
 
@@ -746,6 +778,7 @@ func (e *Engine) SetMirrorReferences(taskID string, mirrorReferences []map[strin
 	}
 
 	record.MirrorReferences = cloneMapSlice(mirrorReferences)
+	e.persistTaskLocked(record)
 	return record.clone(), true
 }
 
@@ -761,6 +794,7 @@ func (e *Engine) SetDeliveryPlans(taskID string, storageWritePlan map[string]any
 
 	record.StorageWritePlan = cloneMap(storageWritePlan)
 	record.ArtifactPlans = cloneMapSlice(artifactPlans)
+	e.persistTaskLocked(record)
 	return record.clone(), true
 }
 
@@ -793,6 +827,7 @@ func (e *Engine) DrainNotifications(taskID string) ([]NotificationRecord, bool) 
 
 	notifications := cloneNotifications(record.Notifications)
 	record.Notifications = nil
+	e.persistTaskLocked(record)
 	return notifications, true
 }
 
@@ -1012,8 +1047,51 @@ func (e *Engine) buildToolCallRecord(record *TaskRecord, toolName string, input,
 
 // nextIdentifier 处理当前模块的相关逻辑。
 func (e *Engine) nextIdentifier(prefix string) string {
+	if e.taskStore != nil {
+		identifier, err := e.taskStore.AllocateIdentifier(context.Background(), prefix)
+		if err == nil {
+			return identifier
+		}
+	}
+
 	e.nextID++
 	return fmt.Sprintf("%s_%03d", prefix, e.nextID)
+}
+
+func (e *Engine) loadPersistedTaskRuns(ctx context.Context) error {
+	if e.taskStore == nil {
+		return nil
+	}
+
+	records, err := e.taskStore.LoadTaskRuns(ctx)
+	if err != nil {
+		return fmt.Errorf("load persisted task runs: %w", err)
+	}
+
+	if len(records) == 0 {
+		return nil
+	}
+
+	seenSessions := make(map[string]struct{}, len(records))
+	for _, persisted := range records {
+		record := taskRecordFromStorage(persisted)
+		e.tasks[record.TaskID] = &record
+		e.taskOrder = append(e.taskOrder, record.TaskID)
+		if _, seen := seenSessions[record.SessionID]; !seen {
+			e.sessionOrder = append(e.sessionOrder, record.SessionID)
+			seenSessions[record.SessionID] = struct{}{}
+		}
+	}
+
+	return nil
+}
+
+func (e *Engine) persistTaskLocked(record *TaskRecord) {
+	if e.taskStore == nil || record == nil {
+		return
+	}
+
+	_ = e.taskStore.SaveTaskRun(context.Background(), taskRecordToStorage(record.clone()))
 }
 
 // clone 处理当前模块的相关逻辑。
@@ -1372,4 +1450,163 @@ func buildDefaultSettings() map[string]any {
 			"budget_auto_downgrade": true,
 		},
 	}
+}
+
+func taskRecordToStorage(record TaskRecord) storage.TaskRunRecord {
+	return storage.TaskRunRecord{
+		TaskID:            record.TaskID,
+		SessionID:         record.SessionID,
+		RunID:             record.RunID,
+		Title:             record.Title,
+		SourceType:        record.SourceType,
+		Status:            record.Status,
+		Intent:            cloneMap(record.Intent),
+		PreferredDelivery: record.PreferredDelivery,
+		FallbackDelivery:  record.FallbackDelivery,
+		CurrentStep:       record.CurrentStep,
+		RiskLevel:         record.RiskLevel,
+		StartedAt:         record.StartedAt,
+		UpdatedAt:         record.UpdatedAt,
+		FinishedAt:        cloneTimePointer(record.FinishedAt),
+		Timeline:          timelineToStorage(record.Timeline),
+		BubbleMessage:     cloneMap(record.BubbleMessage),
+		DeliveryResult:    cloneMap(record.DeliveryResult),
+		Artifacts:         cloneMapSlice(record.Artifacts),
+		MirrorReferences:  cloneMapSlice(record.MirrorReferences),
+		SecuritySummary:   cloneMap(record.SecuritySummary),
+		ApprovalRequest:   cloneMap(record.ApprovalRequest),
+		PendingExecution:  cloneMap(record.PendingExecution),
+		Authorization:     cloneMap(record.Authorization),
+		ImpactScope:       cloneMap(record.ImpactScope),
+		MemoryReadPlans:   cloneMapSlice(record.MemoryReadPlans),
+		MemoryWritePlans:  cloneMapSlice(record.MemoryWritePlans),
+		StorageWritePlan:  cloneMap(record.StorageWritePlan),
+		ArtifactPlans:     cloneMapSlice(record.ArtifactPlans),
+		Notifications:     notificationsToStorage(record.Notifications),
+		LatestEvent:       cloneMap(record.LatestEvent),
+		LatestToolCall:    cloneMap(record.LatestToolCall),
+		CurrentStepStatus: record.CurrentStepStatus,
+	}
+}
+
+func taskRecordFromStorage(record storage.TaskRunRecord) TaskRecord {
+	return TaskRecord{
+		TaskID:            record.TaskID,
+		SessionID:         record.SessionID,
+		RunID:             record.RunID,
+		Title:             record.Title,
+		SourceType:        record.SourceType,
+		Status:            record.Status,
+		Intent:            cloneMap(record.Intent),
+		PreferredDelivery: record.PreferredDelivery,
+		FallbackDelivery:  record.FallbackDelivery,
+		CurrentStep:       record.CurrentStep,
+		RiskLevel:         record.RiskLevel,
+		StartedAt:         record.StartedAt,
+		UpdatedAt:         record.UpdatedAt,
+		FinishedAt:        cloneTimePointer(record.FinishedAt),
+		Timeline:          timelineFromStorage(record.Timeline),
+		BubbleMessage:     cloneMap(record.BubbleMessage),
+		DeliveryResult:    cloneMap(record.DeliveryResult),
+		Artifacts:         cloneMapSlice(record.Artifacts),
+		MirrorReferences:  cloneMapSlice(record.MirrorReferences),
+		SecuritySummary:   cloneMap(record.SecuritySummary),
+		ApprovalRequest:   cloneMap(record.ApprovalRequest),
+		PendingExecution:  cloneMap(record.PendingExecution),
+		Authorization:     cloneMap(record.Authorization),
+		ImpactScope:       cloneMap(record.ImpactScope),
+		MemoryReadPlans:   cloneMapSlice(record.MemoryReadPlans),
+		MemoryWritePlans:  cloneMapSlice(record.MemoryWritePlans),
+		StorageWritePlan:  cloneMap(record.StorageWritePlan),
+		ArtifactPlans:     cloneMapSlice(record.ArtifactPlans),
+		Notifications:     notificationsFromStorage(record.Notifications),
+		LatestEvent:       cloneMap(record.LatestEvent),
+		LatestToolCall:    cloneMap(record.LatestToolCall),
+		CurrentStepStatus: record.CurrentStepStatus,
+	}
+}
+
+func timelineToStorage(timeline []TaskStepRecord) []storage.TaskStepSnapshot {
+	if len(timeline) == 0 {
+		return nil
+	}
+
+	result := make([]storage.TaskStepSnapshot, len(timeline))
+	for index, step := range timeline {
+		result[index] = storage.TaskStepSnapshot{
+			StepID:        step.StepID,
+			TaskID:        step.TaskID,
+			Name:          step.Name,
+			Status:        step.Status,
+			OrderIndex:    step.OrderIndex,
+			InputSummary:  step.InputSummary,
+			OutputSummary: step.OutputSummary,
+		}
+	}
+
+	return result
+}
+
+func timelineFromStorage(timeline []storage.TaskStepSnapshot) []TaskStepRecord {
+	if len(timeline) == 0 {
+		return nil
+	}
+
+	result := make([]TaskStepRecord, len(timeline))
+	for index, step := range timeline {
+		result[index] = TaskStepRecord{
+			StepID:        step.StepID,
+			TaskID:        step.TaskID,
+			Name:          step.Name,
+			Status:        step.Status,
+			OrderIndex:    step.OrderIndex,
+			InputSummary:  step.InputSummary,
+			OutputSummary: step.OutputSummary,
+		}
+	}
+
+	return result
+}
+
+func notificationsToStorage(values []NotificationRecord) []storage.NotificationSnapshot {
+	if len(values) == 0 {
+		return nil
+	}
+
+	result := make([]storage.NotificationSnapshot, len(values))
+	for index, value := range values {
+		result[index] = storage.NotificationSnapshot{
+			Method:    value.Method,
+			Params:    cloneMap(value.Params),
+			CreatedAt: value.CreatedAt,
+		}
+	}
+
+	return result
+}
+
+func notificationsFromStorage(values []storage.NotificationSnapshot) []NotificationRecord {
+	if len(values) == 0 {
+		return nil
+	}
+
+	result := make([]NotificationRecord, len(values))
+	for index, value := range values {
+		result[index] = NotificationRecord{
+			Method:    value.Method,
+			Params:    cloneMap(value.Params),
+			CreatedAt: value.CreatedAt,
+		}
+	}
+
+	return result
+}
+
+func cloneTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+
+	cloned := *value
+	return &cloned
 }

--- a/services/local-service/internal/runengine/engine_test.go
+++ b/services/local-service/internal/runengine/engine_test.go
@@ -3,8 +3,11 @@ package runengine
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/storage"
 )
 
 // TestEngineTaskLifecycle 验证EngineTaskLifecycle。
@@ -420,5 +423,98 @@ func TestEngineControlTaskRestartResetsFinishedOutputs(t *testing.T) {
 	}
 	if restarted.MemoryReadPlans != nil || restarted.MemoryWritePlans != nil || restarted.MirrorReferences != nil {
 		t.Fatal("expected restart to clear handoff and mirror snapshots")
+	}
+}
+
+func TestEngineWithStorePersistsTaskLifecycleAcrossReload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "task-run-engine.db")
+	store, err := storage.NewSQLiteTaskRunStore(path)
+	if err != nil {
+		t.Fatalf("NewSQLiteTaskRunStore returned error: %v", err)
+	}
+
+	engine, err := NewEngineWithStore(store)
+	if err != nil {
+		t.Fatalf("NewEngineWithStore returned error: %v", err)
+	}
+	engine.now = func() time.Time { return time.Date(2026, 4, 10, 8, 0, 0, 0, time.UTC) }
+
+	task := engine.CreateTask(CreateTaskInput{
+		SessionID:   "sess_persist",
+		Title:       "persist me",
+		SourceType:  "hover_input",
+		Status:      "processing",
+		Intent:      map[string]any{"name": "summarize"},
+		CurrentStep: "generate_output",
+		RiskLevel:   "yellow",
+		Timeline: []TaskStepRecord{{
+			Name:          "generate_output",
+			Status:        "running",
+			OrderIndex:    1,
+			InputSummary:  "input",
+			OutputSummary: "working",
+		}},
+	})
+
+	if _, ok := engine.MarkWaitingApprovalWithPlan(
+		task.TaskID,
+		map[string]any{
+			"approval_id": "appr_001",
+			"task_id":     task.TaskID,
+			"risk_level":  "yellow",
+			"status":      "pending",
+		},
+		map[string]any{
+			"task_id":       task.TaskID,
+			"delivery_type": "workspace_document",
+		},
+		map[string]any{"task_id": task.TaskID, "type": "status", "text": "waiting auth"},
+	); !ok {
+		t.Fatal("expected task to enter waiting_auth")
+	}
+	if _, ok := engine.SetMemoryPlans(task.TaskID, []map[string]any{{"kind": "retrieval"}}, []map[string]any{{"kind": "summary_write"}}); !ok {
+		t.Fatal("expected memory plans to persist")
+	}
+	if _, ok := engine.SetDeliveryPlans(task.TaskID, map[string]any{"target_path": "workspace/result.md"}, []map[string]any{{"artifact_id": "art_001"}}); !ok {
+		t.Fatal("expected delivery plans to persist")
+	}
+
+	reloaded, err := NewEngineWithStore(store)
+	if err != nil {
+		t.Fatalf("NewEngineWithStore reload returned error: %v", err)
+	}
+
+	persisted, ok := reloaded.GetTask(task.TaskID)
+	if !ok {
+		t.Fatal("expected persisted task to reload from sqlite")
+	}
+	if persisted.RunID != task.RunID {
+		t.Fatalf("expected run_id to round-trip, got %s want %s", persisted.RunID, task.RunID)
+	}
+	if persisted.Status != "waiting_auth" {
+		t.Fatalf("expected waiting_auth to round-trip, got %s", persisted.Status)
+	}
+	if persisted.PendingExecution["delivery_type"] != "workspace_document" {
+		t.Fatalf("expected pending execution to round-trip, got %+v", persisted.PendingExecution)
+	}
+	if len(persisted.MemoryReadPlans) != 1 || len(persisted.ArtifactPlans) != 1 {
+		t.Fatalf("expected persisted plans to reload, got %+v", persisted)
+	}
+
+	nextTask := reloaded.CreateTask(CreateTaskInput{
+		SessionID:   "sess_persist_2",
+		Title:       "new task after reload",
+		SourceType:  "hover_input",
+		Status:      "processing",
+		Intent:      map[string]any{"name": "rewrite"},
+		CurrentStep: "generate_output",
+		RiskLevel:   "green",
+	})
+	if nextTask.TaskID == task.TaskID {
+		t.Fatalf("expected identifier allocation to continue after reload, got duplicate %s", nextTask.TaskID)
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
 	}
 }

--- a/services/local-service/internal/storage/README.md
+++ b/services/local-service/internal/storage/README.md
@@ -9,7 +9,9 @@ This module owns the backend-local storage boundary inside `services/local-servi
 - Report whether the storage service is configured
 - Provide a typed descriptor snapshot for upper layers
 - Expose a storage-local memory persistence contract with an in-memory implementation
+- Expose a storage-local task/run persistence contract with both SQLite-backed and in-memory implementations
 - Prefer a SQLite-backed memory store with WAL when a database path is configured
+- Prefer a SQLite-backed task/run store with WAL when a database path is configured
 - Report a typed capability snapshot for future module integration
 - Expose whether SQLite initialization fell back to in-memory behavior
 - Expose retrieval-hit persistence and FTS5/sqlite-vec skeleton capabilities for later memory integration
@@ -20,13 +22,15 @@ This module owns the backend-local storage boundary inside `services/local-servi
 - Adapter contract: `platform.StorageAdapter`
 - Required configuration: non-empty `DatabasePath()`
 - Memory persistence contract prefers SQLite + WAL and falls back to in-memory storage if SQLite initialization is unavailable
+- Task/run persistence contract prefers SQLite + WAL and falls back to in-memory storage if SQLite initialization is unavailable
 - SQLite-backed memory writes require non-empty `memory_summary_id`, `task_id`, `run_id`, `summary`, and RFC3339 `created_at`
+- SQLite-backed task/run writes require non-empty `task_id`, `session_id`, `run_id`, `status`, and non-zero `started_at` / `updated_at`
 - SQLite-backed retrieval-hit writes require non-empty hit identifiers and RFC3339 `created_at`
 - FTS5 is initialized as the current local full-text skeleton, while sqlite-vec remains a storage-level skeleton placeholder only
 
 ## Boundary Rules
 
-- `task` / `run` orchestration does not belong here
+- `task` / `run` orchestration does not belong here; only persistence-facing contracts and repository implementations live here
 - RPC response assembly does not belong here
 - Memory retrieval business logic does not belong here; only storage-facing contracts and temporary local implementations live here
 - Artifact and Stronghold implementations do not belong here yet

--- a/services/local-service/internal/storage/service.go
+++ b/services/local-service/internal/storage/service.go
@@ -42,7 +42,9 @@ type Descriptor struct {
 type Service struct {
 	adapter          platform.StorageAdapter
 	memoryStore      MemoryStore
+	taskRunStore     TaskRunStore
 	memoryStoreName  string
+	taskRunStoreName string
 	retrievalBackend string
 	storeInitErr     error
 	fallbackActive   bool
@@ -51,9 +53,11 @@ type Service struct {
 // NewService 创建并返回Service。
 func NewService(adapter platform.StorageAdapter) *Service {
 	memoryStore := MemoryStore(NewInMemoryMemoryStore())
+	taskRunStore := TaskRunStore(NewInMemoryTaskRunStore())
 	memoryStoreName := memoryStoreBackendInMemory
+	taskRunStoreName := memoryStoreBackendInMemory
 	retrievalBackend := memoryRetrievalBackendInMemory
-	var storeInitErr error
+	storeInitErrors := make([]error, 0, 2)
 	fallbackActive := false
 
 	if adapter != nil {
@@ -65,16 +69,30 @@ func NewService(adapter platform.StorageAdapter) *Service {
 				retrievalBackend = memoryRetrievalBackendSQLite
 			}
 			if err != nil {
-				storeInitErr = fmt.Errorf("initialize sqlite memory store: %w", err)
+				storeInitErrors = append(storeInitErrors, fmt.Errorf("initialize sqlite memory store: %w", err))
+				fallbackActive = true
+			}
+
+			sqliteTaskRunStore, err := NewSQLiteTaskRunStore(databasePath)
+			if err == nil {
+				taskRunStore = sqliteTaskRunStore
+				taskRunStoreName = memoryStoreBackendSQLite
+			}
+			if err != nil {
+				storeInitErrors = append(storeInitErrors, fmt.Errorf("initialize sqlite task_run store: %w", err))
 				fallbackActive = true
 			}
 		}
 	}
 
+	storeInitErr := errors.Join(storeInitErrors...)
+
 	return &Service{
 		adapter:          adapter,
 		memoryStore:      memoryStore,
+		taskRunStore:     taskRunStore,
 		memoryStoreName:  memoryStoreName,
+		taskRunStoreName: taskRunStoreName,
 		retrievalBackend: retrievalBackend,
 		storeInitErr:     storeInitErr,
 		fallbackActive:   fallbackActive,
@@ -130,7 +148,7 @@ func (s *Service) Descriptor() Descriptor {
 // Capabilities 处理当前模块的相关逻辑。
 func (s *Service) Capabilities() CapabilitySnapshot {
 	configured := s.Configured()
-	structuredReady := configured && s.storeInitErr == nil && s.memoryStoreName == memoryStoreBackendSQLite
+	structuredReady := configured && s.storeInitErr == nil && s.memoryStoreName == memoryStoreBackendSQLite && s.taskRunStoreName == memoryStoreBackendSQLite
 
 	return CapabilitySnapshot{
 		Backend:                s.Backend(),
@@ -153,11 +171,19 @@ func (s *Service) MemoryStore() MemoryStore {
 	return s.memoryStore
 }
 
+func (s *Service) TaskRunStore() TaskRunStore {
+	return s.taskRunStore
+}
+
 // Close 处理当前模块的相关逻辑。
 func (s *Service) Close() error {
+	errs := make([]error, 0, 2)
 	if closer, ok := s.memoryStore.(interface{ Close() error }); ok {
-		return closer.Close()
+		errs = append(errs, closer.Close())
+	}
+	if closer, ok := s.taskRunStore.(interface{ Close() error }); ok {
+		errs = append(errs, closer.Close())
 	}
 
-	return nil
+	return errors.Join(errs...)
 }

--- a/services/local-service/internal/storage/service_test.go
+++ b/services/local-service/internal/storage/service_test.go
@@ -65,7 +65,9 @@ func TestConfiguredReturnsFalseWhenPathEmpty(t *testing.T) {
 
 // TestConfiguredReturnsTrueWhenAdapterAndPathPresent 验证ConfiguredReturnsTrueWhenAdapterAndPathPresent。
 func TestConfiguredReturnsTrueWhenAdapterAndPathPresent(t *testing.T) {
-	service := NewService(stubAdapter{databasePath: "D:/CialloClaw/data.db"})
+	path := filepath.Join(t.TempDir(), "configured.db")
+	service := NewService(stubAdapter{databasePath: path})
+	defer func() { _ = service.Close() }()
 
 	if !service.Configured() {
 		t.Fatal("expected service to be configured")
@@ -94,7 +96,9 @@ func TestValidateReturnsErrorWhenPathMissing(t *testing.T) {
 
 // TestValidatePassesWhenAdapterConfigured 验证ValidatePassesWhenAdapterConfigured。
 func TestValidatePassesWhenAdapterConfigured(t *testing.T) {
-	service := NewService(stubAdapter{databasePath: "D:/CialloClaw/data.db"})
+	path := filepath.Join(t.TempDir(), "validate.db")
+	service := NewService(stubAdapter{databasePath: path})
+	defer func() { _ = service.Close() }()
 
 	if err := service.Validate(); err != nil {
 		t.Fatalf("expected valid storage service, got %v", err)
@@ -207,5 +211,34 @@ func TestCloseIsSafeWithoutConfiguredStore(t *testing.T) {
 	service := NewService(nil)
 	if err := service.Close(); err != nil {
 		t.Fatalf("Close returned error: %v", err)
+	}
+}
+
+func TestTaskRunStoreReturnsWorkingImplementation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "task-runs.db")
+	service := NewService(stubAdapter{databasePath: path})
+	defer func() { _ = service.Close() }()
+
+	store := service.TaskRunStore()
+	taskID, err := store.AllocateIdentifier(context.Background(), "task")
+	if err != nil {
+		t.Fatalf("AllocateIdentifier returned error: %v", err)
+	}
+	if taskID != "task_001" {
+		t.Fatalf("expected sqlite-backed task identifier, got %q", taskID)
+	}
+
+	record := sampleTaskRunRecord()
+	record.TaskID = taskID
+	if err := store.SaveTaskRun(context.Background(), record); err != nil {
+		t.Fatalf("SaveTaskRun returned error: %v", err)
+	}
+
+	records, err := store.LoadTaskRuns(context.Background())
+	if err != nil {
+		t.Fatalf("LoadTaskRuns returned error: %v", err)
+	}
+	if len(records) != 1 || records[0].TaskID != taskID {
+		t.Fatalf("unexpected persisted task runs: %+v", records)
 	}
 }

--- a/services/local-service/internal/storage/sqlite_memory_store_test.go
+++ b/services/local-service/internal/storage/sqlite_memory_store_test.go
@@ -96,12 +96,12 @@ func TestSQLiteMemoryStoreSaveSearchAndListRecent(t *testing.T) {
 func TestNewServicePrefersSQLiteMemoryStoreWhenConfigured(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "service.db")
 	service := NewService(stubAdapter{databasePath: path})
+	defer func() { _ = service.Close() }()
 
 	store, ok := service.MemoryStore().(*SQLiteMemoryStore)
 	if !ok {
 		t.Fatalf("expected SQLiteMemoryStore, got %T", service.MemoryStore())
 	}
-	defer func() { _ = store.Close() }()
 
 	mode, err := store.journalMode(context.Background())
 	if err != nil {

--- a/services/local-service/internal/storage/sqlite_task_run_store.go
+++ b/services/local-service/internal/storage/sqlite_task_run_store.go
@@ -1,0 +1,381 @@
+// 该文件负责 task/run 主状态在 SQLite 中的持久化实现。
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+const sqliteTaskRunTableName = "task_runs"
+const sqliteEngineSequenceTableName = "engine_sequences"
+
+var (
+	// ErrTaskRunTaskIDRequired 表示缺少 task_id。
+	ErrTaskRunTaskIDRequired = errors.New("storage task_run task_id is required")
+	// ErrTaskRunSessionIDRequired 表示缺少 session_id。
+	ErrTaskRunSessionIDRequired = errors.New("storage task_run session_id is required")
+	// ErrTaskRunRunIDRequired 表示缺少 run_id。
+	ErrTaskRunRunIDRequired = errors.New("storage task_run run_id is required")
+	// ErrTaskRunStatusRequired 表示缺少 status。
+	ErrTaskRunStatusRequired = errors.New("storage task_run status is required")
+	// ErrTaskRunStartedAtRequired 表示缺少 started_at。
+	ErrTaskRunStartedAtRequired = errors.New("storage task_run started_at is required")
+	// ErrTaskRunUpdatedAtRequired 表示缺少 updated_at。
+	ErrTaskRunUpdatedAtRequired = errors.New("storage task_run updated_at is required")
+	// ErrTaskRunIdentifierPrefixRequired 表示缺少分配标识符所需的 prefix。
+	ErrTaskRunIdentifierPrefixRequired = errors.New("storage task_run identifier prefix is required")
+)
+
+// SQLiteTaskRunStore 提供 task/run 主状态的 SQLite 持久化能力。
+type SQLiteTaskRunStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteTaskRunStore 创建并返回 SQLiteTaskRunStore。
+func NewSQLiteTaskRunStore(databasePath string) (*SQLiteTaskRunStore, error) {
+	databasePath = strings.TrimSpace(databasePath)
+	if databasePath == "" {
+		return nil, ErrDatabasePathRequired
+	}
+
+	if err := os.MkdirAll(filepath.Dir(databasePath), 0o755); err != nil {
+		return nil, fmt.Errorf("prepare sqlite directory: %w", err)
+	}
+
+	db, err := sql.Open(sqliteDriverName, databasePath)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite database: %w", err)
+	}
+	if err := db.PingContext(context.Background()); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ping sqlite database: %w", err)
+	}
+
+	store := &SQLiteTaskRunStore{db: db}
+	if err := store.initialize(context.Background()); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	return store, nil
+}
+
+// AllocateIdentifier 为给定前缀分配一个稳定递增的标识符。
+func (s *SQLiteTaskRunStore) AllocateIdentifier(ctx context.Context, prefix string) (string, error) {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		return "", ErrTaskRunIdentifierPrefixRequired
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("begin identifier allocation transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT OR IGNORE INTO engine_sequences (prefix, current_value) VALUES (?, 0)`,
+		prefix,
+	); err != nil {
+		return "", fmt.Errorf("insert engine sequence seed: %w", err)
+	}
+	if _, err := tx.ExecContext(
+		ctx,
+		`UPDATE engine_sequences SET current_value = current_value + 1 WHERE prefix = ?`,
+		prefix,
+	); err != nil {
+		return "", fmt.Errorf("update engine sequence: %w", err)
+	}
+
+	var currentValue uint64
+	if err := tx.QueryRowContext(
+		ctx,
+		`SELECT current_value FROM engine_sequences WHERE prefix = ?`,
+		prefix,
+	).Scan(&currentValue); err != nil {
+		return "", fmt.Errorf("query engine sequence: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", fmt.Errorf("commit identifier allocation transaction: %w", err)
+	}
+
+	return fmt.Sprintf("%s_%03d", prefix, currentValue), nil
+}
+
+// SaveTaskRun 保存或覆盖一条 task/run 主状态快照。
+func (s *SQLiteTaskRunStore) SaveTaskRun(ctx context.Context, record TaskRunRecord) error {
+	if err := validateTaskRunRecord(record); err != nil {
+		return err
+	}
+
+	recordJSON, err := marshalTaskRunRecord(record)
+	if err != nil {
+		return err
+	}
+
+	var finishedAt any
+	if record.FinishedAt != nil {
+		finishedAt = record.FinishedAt.Format(time.RFC3339Nano)
+	}
+
+	if _, err := s.db.ExecContext(
+		ctx,
+		`INSERT OR REPLACE INTO task_runs (
+			task_id,
+			run_id,
+			session_id,
+			status,
+			started_at,
+			updated_at,
+			finished_at,
+			record_json
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		record.TaskID,
+		record.RunID,
+		record.SessionID,
+		record.Status,
+		record.StartedAt.Format(time.RFC3339Nano),
+		record.UpdatedAt.Format(time.RFC3339Nano),
+		finishedAt,
+		recordJSON,
+	); err != nil {
+		return fmt.Errorf("save task run %s: %w", record.TaskID, err)
+	}
+
+	return nil
+}
+
+// LoadTaskRuns 加载所有 task/run 主状态快照。
+func (s *SQLiteTaskRunStore) LoadTaskRuns(ctx context.Context) ([]TaskRunRecord, error) {
+	rows, err := s.db.QueryContext(
+		ctx,
+		`SELECT record_json
+		 FROM task_runs
+		 ORDER BY started_at DESC, task_id DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load task runs: %w", err)
+	}
+	defer rows.Close()
+
+	records := make([]TaskRunRecord, 0)
+	for rows.Next() {
+		var recordJSON string
+		if err := rows.Scan(&recordJSON); err != nil {
+			return nil, fmt.Errorf("scan task run row: %w", err)
+		}
+
+		record, err := unmarshalTaskRunRecord(recordJSON)
+		if err != nil {
+			return nil, err
+		}
+
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate task run rows: %w", err)
+	}
+
+	return records, nil
+}
+
+// Close 关闭底层 SQLite 连接。
+func (s *SQLiteTaskRunStore) Close() error {
+	if s.db == nil {
+		return nil
+	}
+
+	return s.db.Close()
+}
+
+func (s *SQLiteTaskRunStore) journalMode(ctx context.Context) (string, error) {
+	var mode string
+	if err := s.db.QueryRowContext(ctx, `PRAGMA journal_mode;`).Scan(&mode); err != nil {
+		return "", fmt.Errorf("query sqlite journal mode: %w", err)
+	}
+
+	return strings.ToLower(strings.TrimSpace(mode)), nil
+}
+
+func (s *SQLiteTaskRunStore) initialize(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, `PRAGMA journal_mode=WAL;`); err != nil {
+		return fmt.Errorf("enable sqlite wal mode: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `PRAGMA busy_timeout=5000;`); err != nil {
+		return fmt.Errorf("set sqlite busy timeout: %w", err)
+	}
+
+	if _, err := s.db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS task_runs (
+			task_id TEXT PRIMARY KEY,
+			run_id TEXT NOT NULL UNIQUE,
+			session_id TEXT NOT NULL,
+			status TEXT NOT NULL,
+			started_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			finished_at TEXT,
+			record_json TEXT NOT NULL
+		);
+	`); err != nil {
+		return fmt.Errorf("create task_runs table: %w", err)
+	}
+
+	if _, err := s.db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS engine_sequences (
+			prefix TEXT PRIMARY KEY,
+			current_value INTEGER NOT NULL
+		);
+	`); err != nil {
+		return fmt.Errorf("create engine_sequences table: %w", err)
+	}
+
+	if _, err := s.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_task_runs_started_at ON task_runs(started_at DESC, task_id DESC);`); err != nil {
+		return fmt.Errorf("create task_runs started_at index: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_task_runs_updated_at ON task_runs(updated_at DESC, task_id DESC);`); err != nil {
+		return fmt.Errorf("create task_runs updated_at index: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_task_runs_session_id ON task_runs(session_id);`); err != nil {
+		return fmt.Errorf("create task_runs session_id index: %w", err)
+	}
+
+	return nil
+}
+
+func marshalTaskRunRecord(record TaskRunRecord) (string, error) {
+	payload, err := json.Marshal(cloneTaskRunRecord(record))
+	if err != nil {
+		return "", fmt.Errorf("marshal task run record %s: %w", record.TaskID, err)
+	}
+
+	return string(payload), nil
+}
+
+func unmarshalTaskRunRecord(payload string) (TaskRunRecord, error) {
+	var record TaskRunRecord
+	if err := json.Unmarshal([]byte(payload), &record); err != nil {
+		return TaskRunRecord{}, fmt.Errorf("unmarshal task run record: %w", err)
+	}
+	if err := validateTaskRunRecord(record); err != nil {
+		return TaskRunRecord{}, err
+	}
+
+	return record, nil
+}
+
+func validateTaskRunRecord(record TaskRunRecord) error {
+	switch {
+	case strings.TrimSpace(record.TaskID) == "":
+		return ErrTaskRunTaskIDRequired
+	case strings.TrimSpace(record.SessionID) == "":
+		return ErrTaskRunSessionIDRequired
+	case strings.TrimSpace(record.RunID) == "":
+		return ErrTaskRunRunIDRequired
+	case strings.TrimSpace(record.Status) == "":
+		return ErrTaskRunStatusRequired
+	case record.StartedAt.IsZero():
+		return ErrTaskRunStartedAtRequired
+	case record.UpdatedAt.IsZero():
+		return ErrTaskRunUpdatedAtRequired
+	default:
+		return nil
+	}
+}
+
+func cloneTaskRunRecord(record TaskRunRecord) TaskRunRecord {
+	clone := record
+	clone.Intent = cloneMap(record.Intent)
+	clone.Timeline = cloneTaskStepSnapshots(record.Timeline)
+	clone.BubbleMessage = cloneMap(record.BubbleMessage)
+	clone.DeliveryResult = cloneMap(record.DeliveryResult)
+	clone.Artifacts = cloneMapSlice(record.Artifacts)
+	clone.MirrorReferences = cloneMapSlice(record.MirrorReferences)
+	clone.SecuritySummary = cloneMap(record.SecuritySummary)
+	clone.ApprovalRequest = cloneMap(record.ApprovalRequest)
+	clone.PendingExecution = cloneMap(record.PendingExecution)
+	clone.Authorization = cloneMap(record.Authorization)
+	clone.ImpactScope = cloneMap(record.ImpactScope)
+	clone.MemoryReadPlans = cloneMapSlice(record.MemoryReadPlans)
+	clone.MemoryWritePlans = cloneMapSlice(record.MemoryWritePlans)
+	clone.StorageWritePlan = cloneMap(record.StorageWritePlan)
+	clone.ArtifactPlans = cloneMapSlice(record.ArtifactPlans)
+	clone.Notifications = cloneNotificationSnapshots(record.Notifications)
+	clone.LatestEvent = cloneMap(record.LatestEvent)
+	clone.LatestToolCall = cloneMap(record.LatestToolCall)
+	if record.FinishedAt != nil {
+		finishedAt := *record.FinishedAt
+		clone.FinishedAt = &finishedAt
+	}
+	return clone
+}
+
+func cloneTaskStepSnapshots(values []TaskStepSnapshot) []TaskStepSnapshot {
+	if len(values) == 0 {
+		return nil
+	}
+
+	result := make([]TaskStepSnapshot, len(values))
+	copy(result, values)
+	return result
+}
+
+func cloneNotificationSnapshots(values []NotificationSnapshot) []NotificationSnapshot {
+	if len(values) == 0 {
+		return nil
+	}
+
+	result := make([]NotificationSnapshot, len(values))
+	for index, value := range values {
+		result[index] = NotificationSnapshot{
+			Method:    value.Method,
+			Params:    cloneMap(value.Params),
+			CreatedAt: value.CreatedAt,
+		}
+	}
+
+	return result
+}
+
+func cloneMap(values map[string]any) map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+
+	result := make(map[string]any, len(values))
+	for key, value := range values {
+		switch typed := value.(type) {
+		case map[string]any:
+			result[key] = cloneMap(typed)
+		case []map[string]any:
+			result[key] = cloneMapSlice(typed)
+		case []string:
+			result[key] = append([]string(nil), typed...)
+		default:
+			result[key] = value
+		}
+	}
+	return result
+}
+
+func cloneMapSlice(values []map[string]any) []map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]any, 0, len(values))
+	for _, value := range values {
+		result = append(result, cloneMap(value))
+	}
+	return result
+}

--- a/services/local-service/internal/storage/sqlite_task_run_store_test.go
+++ b/services/local-service/internal/storage/sqlite_task_run_store_test.go
@@ -1,0 +1,173 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestInMemoryTaskRunStoreSaveLoadAndAllocate(t *testing.T) {
+	store := NewInMemoryTaskRunStore()
+
+	firstID, err := store.AllocateIdentifier(context.Background(), "task")
+	if err != nil {
+		t.Fatalf("AllocateIdentifier returned error: %v", err)
+	}
+	secondID, err := store.AllocateIdentifier(context.Background(), "task")
+	if err != nil {
+		t.Fatalf("AllocateIdentifier returned error: %v", err)
+	}
+	if firstID != "task_001" || secondID != "task_002" {
+		t.Fatalf("expected sequential in-memory identifiers, got %q and %q", firstID, secondID)
+	}
+
+	record := sampleTaskRunRecord()
+	if err := store.SaveTaskRun(context.Background(), record); err != nil {
+		t.Fatalf("SaveTaskRun returned error: %v", err)
+	}
+
+	records, err := store.LoadTaskRuns(context.Background())
+	if err != nil {
+		t.Fatalf("LoadTaskRuns returned error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected one task run record, got %d", len(records))
+	}
+	if records[0].TaskID != record.TaskID || records[0].RunID != record.RunID {
+		t.Fatalf("unexpected task run record: %+v", records[0])
+	}
+}
+
+func TestNewSQLiteTaskRunStoreInitializesWALMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "task-runs.db")
+	store, err := NewSQLiteTaskRunStore(path)
+	if err != nil {
+		t.Fatalf("NewSQLiteTaskRunStore returned error: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	mode, err := store.journalMode(context.Background())
+	if err != nil {
+		t.Fatalf("journalMode returned error: %v", err)
+	}
+	if mode != "wal" {
+		t.Fatalf("expected wal journal mode, got %q", mode)
+	}
+
+	assertTableExists(t, store.db, sqliteTaskRunTableName)
+	assertTableExists(t, store.db, sqliteEngineSequenceTableName)
+}
+
+func TestSQLiteTaskRunStoreSaveLoadAndAllocate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "task-runs.db")
+	store, err := NewSQLiteTaskRunStore(path)
+	if err != nil {
+		t.Fatalf("NewSQLiteTaskRunStore returned error: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	taskID, err := store.AllocateIdentifier(context.Background(), "task")
+	if err != nil {
+		t.Fatalf("AllocateIdentifier returned error: %v", err)
+	}
+	runID, err := store.AllocateIdentifier(context.Background(), "run")
+	if err != nil {
+		t.Fatalf("AllocateIdentifier returned error: %v", err)
+	}
+	if taskID != "task_001" || runID != "run_001" {
+		t.Fatalf("expected sequential sqlite identifiers, got %q and %q", taskID, runID)
+	}
+
+	record := sampleTaskRunRecord()
+	record.TaskID = taskID
+	record.RunID = runID
+	if err := store.SaveTaskRun(context.Background(), record); err != nil {
+		t.Fatalf("SaveTaskRun returned error: %v", err)
+	}
+
+	records, err := store.LoadTaskRuns(context.Background())
+	if err != nil {
+		t.Fatalf("LoadTaskRuns returned error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected one task run record, got %d", len(records))
+	}
+	if records[0].TaskID != taskID || records[0].RunID != runID {
+		t.Fatalf("unexpected loaded record: %+v", records[0])
+	}
+	if records[0].DeliveryResult["type"] != "workspace_document" {
+		t.Fatalf("expected delivery result to round-trip, got %+v", records[0].DeliveryResult)
+	}
+	if len(records[0].Notifications) != 1 || records[0].Notifications[0].Method != "task.updated" {
+		t.Fatalf("expected notifications to round-trip, got %+v", records[0].Notifications)
+	}
+}
+
+func TestSQLiteTaskRunStoreRejectsInvalidRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "task-runs-invalid.db")
+	store, err := NewSQLiteTaskRunStore(path)
+	if err != nil {
+		t.Fatalf("NewSQLiteTaskRunStore returned error: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	record := sampleTaskRunRecord()
+	record.RunID = ""
+	if err := store.SaveTaskRun(context.Background(), record); err != ErrTaskRunRunIDRequired {
+		t.Fatalf("expected ErrTaskRunRunIDRequired, got %v", err)
+	}
+}
+
+func sampleTaskRunRecord() TaskRunRecord {
+	startedAt := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+	updatedAt := startedAt.Add(2 * time.Minute)
+	finishedAt := updatedAt.Add(3 * time.Minute)
+
+	return TaskRunRecord{
+		TaskID:            "task_001",
+		SessionID:         "sess_001",
+		RunID:             "run_001",
+		Title:             "sqlite task record",
+		SourceType:        "hover_input",
+		Status:            "completed",
+		Intent:            map[string]any{"name": "summarize", "arguments": map[string]any{"style": "key_points"}},
+		PreferredDelivery: "workspace_document",
+		FallbackDelivery:  "bubble",
+		CurrentStep:       "return_result",
+		RiskLevel:         "yellow",
+		StartedAt:         startedAt,
+		UpdatedAt:         updatedAt,
+		FinishedAt:        &finishedAt,
+		Timeline: []TaskStepSnapshot{{
+			StepID:        "step_001",
+			TaskID:        "task_001",
+			Name:          "return_result",
+			Status:        "completed",
+			OrderIndex:    1,
+			InputSummary:  "task input",
+			OutputSummary: "task output",
+		}},
+		BubbleMessage:  map[string]any{"task_id": "task_001", "type": "result", "text": "completed"},
+		DeliveryResult: map[string]any{"type": "workspace_document", "payload": map[string]any{"path": "workspace/result.md"}},
+		Artifacts:      []map[string]any{{"artifact_id": "art_001", "task_id": "task_001"}},
+		MirrorReferences: []map[string]any{{
+			"memory_id": "mem_001",
+		}},
+		SecuritySummary:  map[string]any{"security_status": "recoverable", "risk_level": "yellow"},
+		Authorization:    map[string]any{"decision": "allow_once"},
+		ImpactScope:      map[string]any{"files": []string{"workspace/result.md"}},
+		MemoryReadPlans:  []map[string]any{{"kind": "retrieval"}},
+		MemoryWritePlans: []map[string]any{{"kind": "summary_write"}},
+		StorageWritePlan: map[string]any{"target_path": "workspace/result.md"},
+		ArtifactPlans:    []map[string]any{{"artifact_id": "art_001"}},
+		Notifications: []NotificationSnapshot{{
+			Method:    "task.updated",
+			Params:    map[string]any{"task_id": "task_001", "status": "completed"},
+			CreatedAt: updatedAt,
+		}},
+		LatestEvent:       map[string]any{"type": "delivery.ready"},
+		LatestToolCall:    map[string]any{"tool_name": "write_file"},
+		CurrentStepStatus: "completed",
+	}
+}

--- a/services/local-service/internal/storage/task_run_store.go
+++ b/services/local-service/internal/storage/task_run_store.go
@@ -1,0 +1,72 @@
+// 该文件负责 task/run 主状态在存储层的本地回退实现。
+package storage
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// InMemoryTaskRunStore 提供 task/run 主状态的内存回退存储。
+type InMemoryTaskRunStore struct {
+	mu        sync.RWMutex
+	records   map[string]TaskRunRecord
+	sequences map[string]uint64
+}
+
+// NewInMemoryTaskRunStore 创建并返回 InMemoryTaskRunStore。
+func NewInMemoryTaskRunStore() *InMemoryTaskRunStore {
+	return &InMemoryTaskRunStore{
+		records:   make(map[string]TaskRunRecord),
+		sequences: make(map[string]uint64),
+	}
+}
+
+// AllocateIdentifier 为给定前缀分配一个稳定递增的标识符。
+func (s *InMemoryTaskRunStore) AllocateIdentifier(_ context.Context, prefix string) (string, error) {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		return "", ErrTaskRunIdentifierPrefixRequired
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.sequences[prefix]++
+	return fmt.Sprintf("%s_%03d", prefix, s.sequences[prefix]), nil
+}
+
+// SaveTaskRun 保存或覆盖一条 task/run 主状态快照。
+func (s *InMemoryTaskRunStore) SaveTaskRun(_ context.Context, record TaskRunRecord) error {
+	if err := validateTaskRunRecord(record); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.records[record.TaskID] = cloneTaskRunRecord(record)
+	return nil
+}
+
+// LoadTaskRuns 返回当前所有 task/run 主状态快照。
+func (s *InMemoryTaskRunStore) LoadTaskRuns(_ context.Context) ([]TaskRunRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	records := make([]TaskRunRecord, 0, len(s.records))
+	for _, record := range s.records {
+		records = append(records, cloneTaskRunRecord(record))
+	}
+
+	sort.SliceStable(records, func(i, j int) bool {
+		if records[i].StartedAt.Equal(records[j].StartedAt) {
+			return records[i].TaskID > records[j].TaskID
+		}
+		return records[i].StartedAt.After(records[j].StartedAt)
+	})
+
+	return records, nil
+}

--- a/services/local-service/internal/storage/types.go
+++ b/services/local-service/internal/storage/types.go
@@ -1,7 +1,10 @@
 // 该文件负责存储层的数据接口或落盘实现。
 package storage
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // CapabilitySnapshot 定义当前模块的数据结构。
 type CapabilitySnapshot struct {
@@ -46,4 +49,65 @@ type MemoryStore interface {
 	SaveRetrievalHits(ctx context.Context, hits []MemoryRetrievalRecord) error
 	SearchSummaries(ctx context.Context, taskID, runID, query string, limit int) ([]MemoryRetrievalRecord, error)
 	ListRecentSummaries(ctx context.Context, limit int) ([]MemorySummaryRecord, error)
+}
+
+// TaskStepSnapshot 描述 task timeline 在存储层的快照格式。
+type TaskStepSnapshot struct {
+	StepID        string
+	TaskID        string
+	Name          string
+	Status        string
+	OrderIndex    int
+	InputSummary  string
+	OutputSummary string
+}
+
+// NotificationSnapshot 描述待发送通知在存储层的快照格式。
+type NotificationSnapshot struct {
+	Method    string
+	Params    map[string]any
+	CreatedAt time.Time
+}
+
+// TaskRunRecord 描述 task/run 主状态在存储层的完整快照。
+type TaskRunRecord struct {
+	TaskID            string
+	SessionID         string
+	RunID             string
+	Title             string
+	SourceType        string
+	Status            string
+	Intent            map[string]any
+	PreferredDelivery string
+	FallbackDelivery  string
+	CurrentStep       string
+	RiskLevel         string
+	StartedAt         time.Time
+	UpdatedAt         time.Time
+	FinishedAt        *time.Time
+	Timeline          []TaskStepSnapshot
+	BubbleMessage     map[string]any
+	DeliveryResult    map[string]any
+	Artifacts         []map[string]any
+	MirrorReferences  []map[string]any
+	SecuritySummary   map[string]any
+	ApprovalRequest   map[string]any
+	PendingExecution  map[string]any
+	Authorization     map[string]any
+	ImpactScope       map[string]any
+	MemoryReadPlans   []map[string]any
+	MemoryWritePlans  []map[string]any
+	StorageWritePlan  map[string]any
+	ArtifactPlans     []map[string]any
+	Notifications     []NotificationSnapshot
+	LatestEvent       map[string]any
+	LatestToolCall    map[string]any
+	CurrentStepStatus string
+}
+
+// TaskRunStore 定义 task/run 主状态的持久化契约。
+type TaskRunStore interface {
+	AllocateIdentifier(ctx context.Context, prefix string) (string, error)
+	SaveTaskRun(ctx context.Context, record TaskRunRecord) error
+	LoadTaskRuns(ctx context.Context) ([]TaskRunRecord, error)
 }


### PR DESCRIPTION
## Summary
- add a storage-local `TaskRunStore` contract for the harness backend main flow
- add SQLite-backed and in-memory task/run persistence implementations inside the storage module
- persist `task_id`, `run_id`, `session_id`, task status, timestamps, timeline snapshots, delivery state, authorization state, and handoff plans in SQLite
- add stable engine-side identifier allocation through persisted SQLite sequences so task/run ids continue across reloads
- make `runengine` load persisted task/run snapshots on startup instead of starting from a pure in-memory state
- make `runengine` write task lifecycle updates back to storage after task creation, execution progress, approval suspension, approval resume, completion, control actions, and handoff updates
- wire bootstrap to construct the main-flow engine with the storage-backed task/run store
- add regression coverage for SQLite store initialization, task/run persistence, engine reload behavior, and bootstrap wiring

## Unified Item Impact
- affects the P0 harness main flow
- reuses existing protocol fields
- does not add new JSON-RPC methods
- does not add new error codes

## Main Flow Impact
- yes
- closes the P0 task-centric persistence gap by making the harness main pipeline keep task/run mapping and lifecycle state in SQLite instead of memory only

## Platform Abstraction Impact
- yes
- keeps persistence behind the existing storage boundary instead of leaking SQLite details into orchestrator or RPC logic

## Memory / Model / Stronghold Impact
- reuses the existing storage service to host both memory persistence and task/run persistence
- no model SDK change
- no Stronghold change

## AI Usage
- generated with AI assistance and manually cleaned up
- manually reviewed storage boundaries, lifecycle persistence points, bootstrap wiring, and regression coverage

## Testing
- `go test ./services/local-service/internal/storage ./services/local-service/internal/runengine ./services/local-service/internal/bootstrap`
- `go test ./...`
