### PR TITLE
Derive task inspector results from runtime state

### DIFF
--- a/services/local-service/internal/bootstrap/bootstrap.go
+++ b/services/local-service/internal/bootstrap/bootstrap.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/rpc"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/runengine"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/storage"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/taskinspector"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/tools"
 )
 
@@ -59,6 +60,7 @@ func New(cfg config.Config) (*App, error) {
 	toolRegistry := tools.NewRegistry()
 	pluginService := plugin.NewService()
 	executionService := execution.NewService(fileSystem, modelService, deliveryService, toolRegistry, pluginService)
+	inspectorService := taskinspector.NewService(fileSystem)
 	runEngine, err := runengine.NewEngineWithStore(storageService.TaskRunStore())
 	if err != nil {
 		_ = storageService.Close()
@@ -75,7 +77,7 @@ func New(cfg config.Config) (*App, error) {
 		modelService,
 		toolRegistry,
 		pluginService,
-	).WithExecutor(executionService)
+	).WithExecutor(executionService).WithTaskInspector(inspectorService)
 
 	return &App{server: rpc.NewServer(cfg.RPC, orchestratorService), storage: storageService}, nil
 }

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -460,17 +460,6 @@ func (s *Service) TaskInspectorRun(params map[string]any) (map[string]any, error
 		"summary":       result.Summary,
 		"suggestions":   append([]string(nil), result.Suggestions...),
 	}, nil
-	return map[string]any{
-		"inspection_id": "insp_001",
-		"summary": map[string]any{
-			"parsed_files":     3,
-			"identified_items": 12,
-			"due_today":        2,
-			"overdue":          1,
-			"stale":            3,
-		},
-		"suggestions": []string{"优先处理今天到期的复盘邮件", "下周评审材料建议先生成草稿"},
-	}, nil
 }
 
 // NotepadList 处理当前模块的相关逻辑。

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/plugin"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/risk"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/runengine"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/taskinspector"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/tools"
 )
 
@@ -45,6 +46,7 @@ type Service struct {
 	tools     *tools.Registry
 	plugin    *plugin.Service
 	executor  *execution.Service
+	inspector *taskinspector.Service
 }
 
 // NewService 创建并返回Service。
@@ -71,12 +73,21 @@ func NewService(
 		model:     model,
 		tools:     tools,
 		plugin:    plugin,
+		inspector: taskinspector.NewService(nil),
 	}
 }
 
 // WithExecutor 把真实执行服务挂入 orchestrator。
 func (s *Service) WithExecutor(executorService *execution.Service) *Service {
 	s.executor = executorService
+	return s
+}
+
+// WithTaskInspector 挂接任务巡检运行态服务。
+func (s *Service) WithTaskInspector(inspectorService *taskinspector.Service) *Service {
+	if inspectorService != nil {
+		s.inspector = inspectorService
+	}
 	return s
 }
 
@@ -429,7 +440,26 @@ func (s *Service) TaskInspectorConfigUpdate(params map[string]any) (map[string]a
 
 // TaskInspectorRun 处理 agent.task_inspector.run，返回巡检摘要和建议。
 func (s *Service) TaskInspectorRun(params map[string]any) (map[string]any, error) {
-	_ = params
+	config := s.runEngine.InspectorConfig()
+	targetSources := stringSliceValue(params["target_sources"])
+	notepadItems, _ := s.runEngine.NotepadItems("", 0, 0)
+	unfinishedTasks, _ := s.runEngine.ListTasks("unfinished", "updated_at", "desc", 0, 0)
+	finishedTasks, _ := s.runEngine.ListTasks("finished", "finished_at", "desc", 0, 0)
+
+	result := s.inspector.Run(taskinspector.RunInput{
+		Reason:          stringValue(params, "reason", ""),
+		TargetSources:   targetSources,
+		Config:          config,
+		UnfinishedTasks: unfinishedTasks,
+		FinishedTasks:   finishedTasks,
+		NotepadItems:    notepadItems,
+	})
+
+	return map[string]any{
+		"inspection_id": result.InspectionID,
+		"summary":       result.Summary,
+		"suggestions":   append([]string(nil), result.Suggestions...),
+	}, nil
 	return map[string]any{
 		"inspection_id": "insp_001",
 		"summary": map[string]any{
@@ -1750,3 +1780,29 @@ func (s *Service) executeTask(task runengine.TaskRecord, snapshot contextsvc.Tas
 }
 
 const dateTimeLayout = time.RFC3339
+
+func stringSliceValue(rawValue any) []string {
+	values, ok := rawValue.([]string)
+	if ok {
+		return append([]string(nil), values...)
+	}
+
+	anyValues, ok := rawValue.([]any)
+	if !ok {
+		return nil
+	}
+
+	result := make([]string, 0, len(anyValues))
+	for _, rawItem := range anyValues {
+		item, ok := rawItem.(string)
+		if ok && strings.TrimSpace(item) != "" {
+			result = append(result, item)
+		}
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+
+	return result
+}

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/plugin"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/risk"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/runengine"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/taskinspector"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/tools"
 )
 
@@ -53,7 +54,8 @@ func newTestServiceWithExecution(t *testing.T, modelOutput string) (*Service, st
 	deliveryService := delivery.NewService()
 	toolRegistry := tools.NewRegistry()
 	pluginService := plugin.NewService()
-	executor := execution.NewService(platform.NewLocalFileSystemAdapter(pathPolicy), modelService, deliveryService, toolRegistry, pluginService)
+	fileSystem := platform.NewLocalFileSystemAdapter(pathPolicy)
+	executor := execution.NewService(fileSystem, modelService, deliveryService, toolRegistry, pluginService)
 
 	service := NewService(
 		contextsvc.NewService(),
@@ -65,7 +67,7 @@ func newTestServiceWithExecution(t *testing.T, modelOutput string) (*Service, st
 		modelService,
 		toolRegistry,
 		pluginService,
-	).WithExecutor(executor)
+	).WithExecutor(executor).WithTaskInspector(taskinspector.NewService(fileSystem))
 
 	return service, workspaceRoot
 }
@@ -149,6 +151,50 @@ func TestServiceStartTaskAndConfirmFlow(t *testing.T) {
 	}
 	if record.DeliveryResult == nil {
 		t.Fatal("expected confirmation flow to persist delivery result")
+	}
+}
+
+func TestTaskInspectorRunAggregatesRuntimeState(t *testing.T) {
+	service, workspaceRoot := newTestServiceWithExecution(t, "inspector output")
+
+	todosDir := filepath.Join(workspaceRoot, "todos")
+	if err := os.MkdirAll(todosDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(todosDir, "inbox.md"), []byte("- [ ] review task\n- [x] archive task\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	result, err := service.TaskInspectorRun(map[string]any{
+		"reason":         "startup_scan",
+		"target_sources": []any{"workspace/todos"},
+	})
+	if err != nil {
+		t.Fatalf("TaskInspectorRun returned error: %v", err)
+	}
+
+	inspectionID, ok := result["inspection_id"].(string)
+	if !ok || !strings.HasPrefix(inspectionID, "insp_") {
+		t.Fatalf("expected runtime inspection_id, got %+v", result["inspection_id"])
+	}
+
+	summary, ok := result["summary"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected summary payload, got %+v", result["summary"])
+	}
+	if summary["parsed_files"] != 1 {
+		t.Fatalf("expected parsed_files to reflect workspace scan, got %+v", summary)
+	}
+	if summary["identified_items"] == nil || summary["identified_items"].(int) < 3 {
+		t.Fatalf("expected identified_items to include file and notepad items, got %+v", summary)
+	}
+	if summary["due_today"] != 1 {
+		t.Fatalf("expected due_today to reflect runtime notepad state, got %+v", summary)
+	}
+
+	suggestions, ok := result["suggestions"].([]string)
+	if !ok || len(suggestions) == 0 {
+		t.Fatalf("expected runtime suggestions, got %+v", result["suggestions"])
 	}
 }
 

--- a/services/local-service/internal/taskinspector/service.go
+++ b/services/local-service/internal/taskinspector/service.go
@@ -1,0 +1,329 @@
+// 该文件负责任务巡检模块的最小运行态聚合逻辑。
+package taskinspector
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/platform"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/runengine"
+)
+
+const defaultStaleInterval = 15 * time.Minute
+
+// Service 负责根据 workspace、notepad 和 runtime task 状态生成巡检结果。
+type Service struct {
+	fileSystem platform.FileSystemAdapter
+	now        func() time.Time
+}
+
+// RunInput 描述一次巡检执行所需的运行态输入。
+type RunInput struct {
+	Reason          string
+	TargetSources   []string
+	Config          map[string]any
+	UnfinishedTasks []runengine.TaskRecord
+	FinishedTasks   []runengine.TaskRecord
+	NotepadItems    []map[string]any
+}
+
+// RunResult 描述一次巡检执行输出的协议兼容结果。
+type RunResult struct {
+	InspectionID string
+	Summary      map[string]any
+	Suggestions  []string
+}
+
+// NewService 创建并返回 task inspector 服务。
+func NewService(fileSystem platform.FileSystemAdapter) *Service {
+	return &Service{
+		fileSystem: fileSystem,
+		now:        time.Now,
+	}
+}
+
+// Run 执行一次最小真实巡检。
+func (s *Service) Run(input RunInput) RunResult {
+	sources := resolveSources(input.TargetSources, input.Config)
+	parsedFiles, fileItems := s.inspectSources(sources)
+	dueToday, overdue := countDueBuckets(input.NotepadItems)
+	staleCount := countStaleTasks(input.UnfinishedTasks, inspectionDuration(input.Config), s.now())
+	identifiedItems := fileItems + countOpenNotepadItems(input.NotepadItems)
+
+	return RunResult{
+		InspectionID: fmt.Sprintf("insp_%d", s.now().UnixNano()),
+		Summary: map[string]any{
+			"parsed_files":     parsedFiles,
+			"identified_items": identifiedItems,
+			"due_today":        dueToday,
+			"overdue":          overdue,
+			"stale":            staleCount,
+		},
+		Suggestions: buildSuggestions(input.NotepadItems, input.UnfinishedTasks, sources, parsedFiles, dueToday, overdue, staleCount, fileItems),
+	}
+}
+
+func (s *Service) inspectSources(sources []string) (int, int) {
+	if s.fileSystem == nil || len(sources) == 0 {
+		return 0, 0
+	}
+
+	parsedFiles := 0
+	identifiedItems := 0
+	seenFiles := map[string]struct{}{}
+
+	for _, source := range sources {
+		root := sourceToFSPath(source)
+		if root == "" {
+			continue
+		}
+
+		_ = fs.WalkDir(s.fileSystem, root, func(currentPath string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil || entry == nil || entry.IsDir() {
+				return nil
+			}
+			if _, seen := seenFiles[currentPath]; seen {
+				return nil
+			}
+			seenFiles[currentPath] = struct{}{}
+			parsedFiles++
+
+			content, err := fs.ReadFile(s.fileSystem, currentPath)
+			if err != nil {
+				return nil
+			}
+			identifiedItems += countChecklistItems(string(content))
+			return nil
+		})
+	}
+
+	return parsedFiles, identifiedItems
+}
+
+func resolveSources(targetSources []string, config map[string]any) []string {
+	if len(targetSources) > 0 {
+		return dedupeNonEmptyStrings(targetSources)
+	}
+
+	rawSources, ok := config["task_sources"].([]string)
+	if ok {
+		return dedupeNonEmptyStrings(rawSources)
+	}
+
+	anySources, ok := config["task_sources"].([]any)
+	if !ok {
+		return nil
+	}
+
+	sources := make([]string, 0, len(anySources))
+	for _, rawSource := range anySources {
+		source, ok := rawSource.(string)
+		if ok && strings.TrimSpace(source) != "" {
+			sources = append(sources, source)
+		}
+	}
+
+	return dedupeNonEmptyStrings(sources)
+}
+
+func dedupeNonEmptyStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func sourceToFSPath(source string) string {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return ""
+	}
+
+	source = strings.TrimPrefix(source, "workspace/")
+	if source == "workspace" || source == "." || source == "/" {
+		return "."
+	}
+
+	normalized := path.Clean(strings.TrimPrefix(source, "/"))
+	if normalized == "." {
+		return "."
+	}
+	if strings.HasPrefix(normalized, "../") || normalized == ".." {
+		return ""
+	}
+	return normalized
+}
+
+func countChecklistItems(content string) int {
+	lines := strings.Split(content, "\n")
+	count := 0
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "- [ ]"),
+			strings.HasPrefix(trimmed, "* [ ]"),
+			strings.HasPrefix(trimmed, "- [x]"),
+			strings.HasPrefix(trimmed, "* [x]"),
+			strings.HasPrefix(trimmed, "- [X]"),
+			strings.HasPrefix(trimmed, "* [X]"):
+			count++
+		}
+	}
+	return count
+}
+
+func countOpenNotepadItems(items []map[string]any) int {
+	count := 0
+	for _, item := range items {
+		status := stringValue(item, "status")
+		if status == "completed" || status == "cancelled" {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func countDueBuckets(items []map[string]any) (int, int) {
+	dueToday := 0
+	overdue := 0
+	for _, item := range items {
+		switch stringValue(item, "status") {
+		case "due_today":
+			dueToday++
+		case "overdue":
+			overdue++
+		}
+	}
+	return dueToday, overdue
+}
+
+func countStaleTasks(tasks []runengine.TaskRecord, interval time.Duration, now time.Time) int {
+	count := 0
+	for _, task := range tasks {
+		if task.Status == "waiting_auth" || task.Status == "paused" || task.Status == "processing" || task.Status == "waiting_input" || task.Status == "blocked" || task.Status == "confirming_intent" {
+			if now.Sub(task.UpdatedAt) >= interval {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func inspectionDuration(config map[string]any) time.Duration {
+	interval, ok := config["inspection_interval"].(map[string]any)
+	if !ok {
+		return defaultStaleInterval
+	}
+
+	value, ok := interval["value"].(int)
+	if !ok {
+		floatValue, ok := interval["value"].(float64)
+		if !ok || floatValue <= 0 {
+			return defaultStaleInterval
+		}
+		value = int(floatValue)
+	}
+	if value <= 0 {
+		return defaultStaleInterval
+	}
+
+	switch unit := stringValue(interval, "unit"); unit {
+	case "minute":
+		return time.Duration(value) * time.Minute
+	case "hour":
+		return time.Duration(value) * time.Hour
+	case "day":
+		return time.Duration(value) * 24 * time.Hour
+	case "week":
+		return time.Duration(value) * 7 * 24 * time.Hour
+	default:
+		return defaultStaleInterval
+	}
+}
+
+func buildSuggestions(notepadItems []map[string]any, unfinishedTasks []runengine.TaskRecord, sources []string, parsedFiles, dueToday, overdue, staleCount, fileItems int) []string {
+	suggestions := make([]string, 0, 4)
+
+	if overdueTitle := firstNotepadTitleByStatus(notepadItems, "overdue"); overdueTitle != "" {
+		suggestions = append(suggestions, fmt.Sprintf("优先处理逾期待办：%s", overdueTitle))
+	}
+	if dueToday > 0 {
+		title := firstNotepadTitleByStatus(notepadItems, "due_today")
+		if title != "" {
+			suggestions = append(suggestions, fmt.Sprintf("今天到期的待办建议先推进：%s", title))
+		}
+	}
+	if staleCount > 0 {
+		title := firstStaleTaskTitle(unfinishedTasks)
+		if title != "" {
+			suggestions = append(suggestions, fmt.Sprintf("有任务超过巡检窗口未更新，建议先复查：%s", title))
+		} else {
+			suggestions = append(suggestions, fmt.Sprintf("有 %d 个任务超过巡检窗口未更新，建议优先复查。", staleCount))
+		}
+	}
+	if parsedFiles == 0 && len(sources) > 0 {
+		suggestions = append(suggestions, fmt.Sprintf("当前巡检源未发现可解析文件，建议检查 %s。", sources[0]))
+	}
+	if fileItems > 0 {
+		suggestions = append(suggestions, fmt.Sprintf("已从巡检源识别 %d 条候选事项，可继续转为任务。", fileItems))
+	}
+	if len(suggestions) == 0 {
+		suggestions = append(suggestions, "当前未发现高优先级异常，建议继续保持定期巡检。")
+	}
+
+	return suggestions
+}
+
+func firstNotepadTitleByStatus(items []map[string]any, status string) string {
+	for _, item := range items {
+		if stringValue(item, "status") == status {
+			return stringValue(item, "title")
+		}
+	}
+	return ""
+}
+
+func firstStaleTaskTitle(tasks []runengine.TaskRecord) string {
+	if len(tasks) == 0 {
+		return ""
+	}
+
+	staleTitle := ""
+	staleUpdatedAt := time.Time{}
+	for _, task := range tasks {
+		if task.UpdatedAt.IsZero() {
+			continue
+		}
+		if staleTitle == "" || task.UpdatedAt.Before(staleUpdatedAt) {
+			staleTitle = task.Title
+			staleUpdatedAt = task.UpdatedAt
+		}
+	}
+	return staleTitle
+}
+
+func stringValue(values map[string]any, key string) string {
+	rawValue, ok := values[key]
+	if !ok {
+		return ""
+	}
+	value, ok := rawValue.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}

--- a/services/local-service/internal/taskinspector/service_test.go
+++ b/services/local-service/internal/taskinspector/service_test.go
@@ -1,0 +1,95 @@
+package taskinspector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/platform"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/runengine"
+)
+
+func TestServiceRunAggregatesWorkspaceNotepadAndRuntimeState(t *testing.T) {
+	workspaceRoot := filepath.Join(t.TempDir(), "workspace")
+	pathPolicy, err := platform.NewLocalPathPolicy(workspaceRoot)
+	if err != nil {
+		t.Fatalf("NewLocalPathPolicy returned error: %v", err)
+	}
+	fileSystem := platform.NewLocalFileSystemAdapter(pathPolicy)
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, "todos"), 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "todos", "inbox.md"), []byte("- [ ] review report\n- [x] archive note\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "todos", "later.md"), []byte("- [ ] follow up\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	service := NewService(fileSystem)
+	service.now = func() time.Time { return time.Date(2026, 4, 10, 9, 30, 0, 0, time.UTC) }
+
+	result := service.Run(RunInput{
+		Config: map[string]any{
+			"task_sources":           []string{"workspace/todos"},
+			"inspection_interval":    map[string]any{"unit": "minute", "value": 15},
+			"inspect_on_startup":     true,
+			"inspect_on_file_change": true,
+		},
+		UnfinishedTasks: []runengine.TaskRecord{
+			{
+				TaskID:    "task_001",
+				Title:     "stale task",
+				Status:    "processing",
+				UpdatedAt: time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC),
+			},
+		},
+		NotepadItems: []map[string]any{
+			{"item_id": "todo_001", "title": "today item", "status": "due_today"},
+			{"item_id": "todo_002", "title": "overdue item", "status": "overdue"},
+			{"item_id": "todo_003", "title": "later item", "status": "normal"},
+			{"item_id": "todo_004", "title": "done item", "status": "completed"},
+		},
+	})
+
+	summary := result.Summary
+	if summary["parsed_files"] != 2 {
+		t.Fatalf("expected parsed_files 2, got %+v", summary)
+	}
+	if summary["identified_items"] != 6 {
+		t.Fatalf("expected identified_items 6, got %+v", summary)
+	}
+	if summary["due_today"] != 1 || summary["overdue"] != 1 {
+		t.Fatalf("expected due bucket counts to be aggregated, got %+v", summary)
+	}
+	if summary["stale"] != 1 {
+		t.Fatalf("expected stale count 1, got %+v", summary)
+	}
+	if len(result.Suggestions) < 3 {
+		t.Fatalf("expected runtime suggestions, got %+v", result.Suggestions)
+	}
+}
+
+func TestServiceRunHonorsTargetSourcesAndHandlesMissingFiles(t *testing.T) {
+	service := NewService(nil)
+	service.now = func() time.Time { return time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC) }
+
+	result := service.Run(RunInput{
+		TargetSources: []string{"workspace/missing"},
+		Config: map[string]any{
+			"task_sources":        []string{"workspace/todos"},
+			"inspection_interval": map[string]any{"unit": "hour", "value": 1},
+		},
+	})
+
+	if result.Summary["parsed_files"] != 0 {
+		t.Fatalf("expected no parsed files without file system, got %+v", result.Summary)
+	}
+	if len(result.Suggestions) == 0 || result.Suggestions[0] == "" {
+		t.Fatalf("expected fallback suggestion, got %+v", result.Suggestions)
+	}
+	if sourceToFSPath("workspace/missing") != "missing" {
+		t.Fatalf("expected target source to use workspace-relative fs path")
+	}
+}


### PR DESCRIPTION
## Summary
- add a dedicated runtime task inspector service for the harness backend
- derive inspection results from real workspace task sources, notepad items, and persisted task state
- count parsed files and checklist candidates from workspace markdown sources through the filesystem abstraction
- derive due-today, overdue, and stale signals from runtime notepad and unfinished task data
- generate dynamic inspection ids, summaries, and suggestions instead of returning fixed demo payloads
- wire the runtime task inspector through orchestrator and bootstrap
- remove the stale unreachable stub response left behind in `agent.task_inspector.run`
- add regression coverage for runtime inspector aggregation and orchestrator wiring

## Unified Item Impact
- affects the P0 harness main flow
- reuses existing protocol fields
- does not add new JSON-RPC methods
- does not add new error codes

## Main Flow Impact
- yes
- replaces the demo-style `agent.task_inspector.run` response with a runtime-backed inspection path tied to real workspace and task state

## Platform Abstraction Impact
- yes
- keeps workspace scanning behind the existing `FileSystemAdapter` instead of introducing platform-specific file handling in orchestrator logic

## Memory / Model / Stronghold Impact
- no memory backend change
- no model SDK change
- no Stronghold change

## AI Usage
- generated with AI assistance and manually cleaned up
- manually reviewed runtime aggregation logic, orchestrator integration, and the final dead-code cleanup

## Testing
- `go test ./services/local-service/internal/taskinspector ./services/local-service/internal/orchestrator ./services/local-service/internal/bootstrap`
- `go test ./...`
