### PR TITLE
feat(governance): add risk, audit, and checkpoint foundations

### DIFF
--- a/services/local-service/internal/audit/README.md
+++ b/services/local-service/internal/audit/README.md
@@ -1,0 +1,161 @@
+# audit 模块 README
+
+## 1. 模块定位
+
+`/services/local-service/internal/audit` 是 CialloClaw 后端治理与安全层中的**审计记录模块**。
+
+本模块的职责是把已经发生、已经判定完成、已经执行完成的操作，整理成统一、稳定、可追踪的审计记录输入，供上层或存储层落盘。
+
+在 `task-centric` 架构中：
+
+- 对外界面围绕 `task_id` 组织；
+- `audit` 只负责“记录什么”，不负责“何时执行”和“如何推进任务状态”。
+
+---
+
+## 2. 本模块负责什么
+
+本模块当前只负责以下内容：
+
+1. 审计记录输入收口
+   - 对文件、命令、工具执行等已完成动作生成统一审计输入
+
+2. 审计记录最小结构定义
+   - 对齐 `audit_record` 概念，保证后续存储层和 RPC 层可稳定消费
+
+3. 审计摘要标准化
+   - 给上层提供一致的 `type / action / summary / target / result` 语义
+
+---
+
+## 3. 本模块不负责什么
+
+本模块明确不负责：
+
+- 风险判断
+- 审批流转
+- checkpoint 创建
+- artifact 正式生成
+- task / run / step 状态机推进
+- 前端安全页展示
+- 直接持久化数据库写入（当前阶段）
+
+一句话说：
+
+> `audit` 只负责整理“要写什么审计记录”，不负责“何时写”和“写到哪里”。
+
+---
+
+## 4. 当前输入输出
+
+### 4.1 输入
+
+当前建议的最小输入应围绕以下已冻结概念组织：
+
+- `task_id`
+- `type`
+- `action`
+- `summary`
+- `target`
+- `result`
+
+### 4.2 输出
+
+当前建议输出对齐 `AuditRecord`：
+
+- `audit_id`
+- `task_id`
+- `type`
+- `action`
+- `summary`
+- `target`
+- `result`
+- `created_at`
+
+说明：
+
+- 当前模块内可以先保留最小骨架；
+- 不能在这里自行发明协议层不存在的正式字段。
+
+---
+
+## 5. 已冻结规则
+
+### 5.1 协议概念
+
+- `audit_record`
+
+### 5.2 协议返回位置
+
+安全类接口可以返回：
+
+- `approval_request`
+- `authorization_record`
+- `audit_record`
+- `recovery_point`
+- 必要时附带 `impact_scope`
+
+### 5.3 存储职责
+
+根据架构文档，SQLite + WAL 负责：
+
+- 结构化运行态
+- 审计
+- 授权记录
+- checkpoint
+
+---
+
+## 6. 当前未冻结规则
+
+以下规则当前未冻结，不应擅自定死：
+
+1. `audit_id` 的生成方式
+2. 同一 task 下审计记录的粒度（按工具、按动作、按阶段）
+3. 审计写入时机（执行中、执行后、失败后）
+4. 审计记录与 ToolCall / Event 的最终映射关系
+
+---
+
+## 7. 模块内待完成清单
+
+### P0
+
+- 定义 audit 模块最小输入输出结构
+- 定义最小 writer 接口或 service 入口
+- 补 table-driven tests
+
+### P1
+
+- 增加 audit record 构造 helper
+- 对齐与 ToolCall / risk / checkpoint 的关系说明
+
+### P2
+
+- 根据主链路需要扩展更多审计分类
+
+---
+
+## 8. 跨模块待完成清单
+
+### P0
+
+- `tools` / `execution` / `orchestrator` 产出可消费的 audit candidate
+- `storage` 接入 audit 真实持久化
+- `rpc` / dashboard 安全页读取 audit 数据
+
+### P1
+
+- 与 `checkpoint`、`risk` 结果做联动视图
+- 与 `ToolCall`、`Event` 做统一关联
+
+---
+
+## 9. 模块自检清单
+
+- 有没有把风险判断写进 audit？
+- 有没有把 checkpoint 创建写进 audit？
+- 有没有擅自发明协议字段？
+- 有没有越界到 orchestrator / storage 实现细节？
+
+若答案不明确，不要直接开写。

--- a/services/local-service/internal/audit/README.md
+++ b/services/local-service/internal/audit/README.md
@@ -124,6 +124,7 @@
 - 定义 audit 模块最小输入输出结构
 - 定义最小 writer 接口或 service 入口
 - 补 table-driven tests
+- 对齐 tools 输出的 `audit_candidate` 到 `RecordInput`
 
 ### P1
 

--- a/services/local-service/internal/audit/service.go
+++ b/services/local-service/internal/audit/service.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	ErrTaskIDRequired = errors.New("audit: task_id is required")
-	ErrTypeRequired   = errors.New("audit: type is required")
-	ErrActionRequired = errors.New("audit: action is required")
-	ErrResultRequired = errors.New("audit: result is required")
+	ErrTaskIDRequired   = errors.New("audit: task_id is required")
+	ErrTypeRequired     = errors.New("audit: type is required")
+	ErrActionRequired   = errors.New("audit: action is required")
+	ErrResultRequired   = errors.New("audit: result is required")
+	ErrCandidateInvalid = errors.New("audit: candidate is invalid")
 )
 
 type noopWriter struct{}
@@ -57,6 +58,44 @@ func (s *Service) BuildRecord(input RecordInput) (Record, error) {
 		Target:    strings.TrimSpace(input.Target),
 		Result:    strings.TrimSpace(input.Result),
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// BuildRecordInputFromCandidate 将上游 candidate 结构转换为最小 audit 输入。
+//
+// 当前主要用于消费 tools 模块产出的 audit_candidate，
+// 不在此处扩展为通用协议解析器。
+func BuildRecordInputFromCandidate(taskID string, candidate map[string]any) (RecordInput, error) {
+	if strings.TrimSpace(taskID) == "" {
+		return RecordInput{}, ErrTaskIDRequired
+	}
+	if candidate == nil {
+		return RecordInput{}, ErrCandidateInvalid
+	}
+
+	typeValue, ok := candidate["type"].(string)
+	if !ok || strings.TrimSpace(typeValue) == "" {
+		return RecordInput{}, ErrTypeRequired
+	}
+	actionValue, ok := candidate["action"].(string)
+	if !ok || strings.TrimSpace(actionValue) == "" {
+		return RecordInput{}, ErrActionRequired
+	}
+	resultValue, ok := candidate["result"].(string)
+	if !ok || strings.TrimSpace(resultValue) == "" {
+		return RecordInput{}, ErrResultRequired
+	}
+
+	summaryValue, _ := candidate["summary"].(string)
+	targetValue, _ := candidate["target"].(string)
+
+	return RecordInput{
+		TaskID:  strings.TrimSpace(taskID),
+		Type:    strings.TrimSpace(typeValue),
+		Action:  strings.TrimSpace(actionValue),
+		Summary: strings.TrimSpace(summaryValue),
+		Target:  strings.TrimSpace(targetValue),
+		Result:  strings.TrimSpace(resultValue),
 	}, nil
 }
 

--- a/services/local-service/internal/audit/service.go
+++ b/services/local-service/internal/audit/service.go
@@ -1,15 +1,96 @@
 // 该文件负责审计层的最小骨架。
 package audit
 
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	ErrTaskIDRequired = errors.New("audit: task_id is required")
+	ErrTypeRequired   = errors.New("audit: type is required")
+	ErrActionRequired = errors.New("audit: action is required")
+	ErrResultRequired = errors.New("audit: result is required")
+)
+
+type noopWriter struct{}
+
+func (noopWriter) WriteAuditRecord(_ context.Context, _ Record) error {
+	return nil
+}
+
 // Service 提供当前模块的服务能力。
-type Service struct{}
+type Service struct {
+	writer Writer
+}
 
 // NewService 创建并返回Service。
-func NewService() *Service {
-	return &Service{}
+func NewService(writers ...Writer) *Service {
+	writer := Writer(noopWriter{})
+	if len(writers) > 0 && writers[0] != nil {
+		writer = writers[0]
+	}
+	return &Service{writer: writer}
 }
 
 // Status 处理当前模块的相关逻辑。
 func (s *Service) Status() string {
 	return "ready"
+}
+
+// BuildRecord 把 RecordInput 归一化为最小审计记录。
+func (s *Service) BuildRecord(input RecordInput) (Record, error) {
+	if err := validateRecordInput(input); err != nil {
+		return Record{}, err
+	}
+
+	return Record{
+		AuditID:   nextAuditID(),
+		TaskID:    strings.TrimSpace(input.TaskID),
+		Type:      strings.TrimSpace(input.Type),
+		Action:    strings.TrimSpace(input.Action),
+		Summary:   strings.TrimSpace(input.Summary),
+		Target:    strings.TrimSpace(input.Target),
+		Result:    strings.TrimSpace(input.Result),
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// Write 归一化并输出一条审计记录。
+func (s *Service) Write(ctx context.Context, input RecordInput) (Record, error) {
+	record, err := s.BuildRecord(input)
+	if err != nil {
+		return Record{}, err
+	}
+	if err := s.writer.WriteAuditRecord(ctx, record); err != nil {
+		return Record{}, fmt.Errorf("audit: write record: %w", err)
+	}
+	return record, nil
+}
+
+func validateRecordInput(input RecordInput) error {
+	if strings.TrimSpace(input.TaskID) == "" {
+		return ErrTaskIDRequired
+	}
+	if strings.TrimSpace(input.Type) == "" {
+		return ErrTypeRequired
+	}
+	if strings.TrimSpace(input.Action) == "" {
+		return ErrActionRequired
+	}
+	if strings.TrimSpace(input.Result) == "" {
+		return ErrResultRequired
+	}
+	return nil
+}
+
+var auditCounter uint64
+
+func nextAuditID() string {
+	seq := atomic.AddUint64(&auditCounter, 1)
+	return fmt.Sprintf("audit_%d_%d", time.Now().UnixNano(), seq)
 }

--- a/services/local-service/internal/audit/service_test.go
+++ b/services/local-service/internal/audit/service_test.go
@@ -1,0 +1,96 @@
+package audit
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type stubWriter struct {
+	records []Record
+	err     error
+}
+
+func (s *stubWriter) WriteAuditRecord(_ context.Context, record Record) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.records = append(s.records, record)
+	return nil
+}
+
+func TestServiceBuildRecord(t *testing.T) {
+	service := NewService()
+
+	tests := []struct {
+		name    string
+		input   RecordInput
+		wantErr error
+	}{
+		{name: "missing_task_id", input: RecordInput{Type: "file", Action: "write_file", Result: "success"}, wantErr: ErrTaskIDRequired},
+		{name: "missing_type", input: RecordInput{TaskID: "task_001", Action: "write_file", Result: "success"}, wantErr: ErrTypeRequired},
+		{name: "missing_action", input: RecordInput{TaskID: "task_001", Type: "file", Result: "success"}, wantErr: ErrActionRequired},
+		{name: "missing_result", input: RecordInput{TaskID: "task_001", Type: "file", Action: "write_file"}, wantErr: ErrResultRequired},
+		{name: "valid_record", input: RecordInput{TaskID: "task_001", Type: "file", Action: "write_file", Summary: "write result file", Target: "D:/workspace/report.md", Result: "success"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			record, err := service.BuildRecord(tc.input)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("BuildRecord returned error: %v", err)
+			}
+			if record.AuditID == "" || record.CreatedAt == "" {
+				t.Fatalf("expected generated audit id and created_at, got %+v", record)
+			}
+			if _, err := time.Parse(time.RFC3339, record.CreatedAt); err != nil {
+				t.Fatalf("expected RFC3339 created_at, got %q", record.CreatedAt)
+			}
+		})
+	}
+}
+
+func TestServiceWrite(t *testing.T) {
+	writer := &stubWriter{}
+	service := NewService(writer)
+
+	record, err := service.Write(context.Background(), RecordInput{
+		TaskID:  "task_001",
+		Type:    "file",
+		Action:  "write_file",
+		Summary: "write result file",
+		Target:  "D:/workspace/report.md",
+		Result:  "success",
+	})
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if len(writer.records) != 1 {
+		t.Fatalf("expected 1 written record, got %d", len(writer.records))
+	}
+	if writer.records[0].AuditID != record.AuditID {
+		t.Fatalf("expected persisted record to match returned record, got %+v vs %+v", writer.records[0], record)
+	}
+}
+
+func TestServiceWritePropagatesWriterError(t *testing.T) {
+	writer := &stubWriter{err: errors.New("write failed")}
+	service := NewService(writer)
+
+	_, err := service.Write(context.Background(), RecordInput{
+		TaskID: "task_001",
+		Type:   "file",
+		Action: "write_file",
+		Result: "success",
+	})
+	if err == nil {
+		t.Fatal("expected writer error")
+	}
+}

--- a/services/local-service/internal/audit/service_test.go
+++ b/services/local-service/internal/audit/service_test.go
@@ -94,3 +94,37 @@ func TestServiceWritePropagatesWriterError(t *testing.T) {
 		t.Fatal("expected writer error")
 	}
 }
+
+func TestBuildRecordInputFromCandidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		taskID    string
+		candidate map[string]any
+		wantErr   error
+	}{
+		{name: "missing_task_id", taskID: "", candidate: map[string]any{"type": "file", "action": "write_file", "result": "success"}, wantErr: ErrTaskIDRequired},
+		{name: "nil_candidate", taskID: "task_001", candidate: nil, wantErr: ErrCandidateInvalid},
+		{name: "missing_type", taskID: "task_001", candidate: map[string]any{"action": "write_file", "result": "success"}, wantErr: ErrTypeRequired},
+		{name: "missing_action", taskID: "task_001", candidate: map[string]any{"type": "file", "result": "success"}, wantErr: ErrActionRequired},
+		{name: "missing_result", taskID: "task_001", candidate: map[string]any{"type": "file", "action": "write_file"}, wantErr: ErrResultRequired},
+		{name: "valid_candidate", taskID: "task_001", candidate: map[string]any{"type": "file", "action": "write_file", "summary": "write file", "target": "D:/workspace/report.md", "result": "success"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input, err := BuildRecordInputFromCandidate(tc.taskID, tc.candidate)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("BuildRecordInputFromCandidate returned error: %v", err)
+			}
+			if input.TaskID != "task_001" || input.Action != "write_file" {
+				t.Fatalf("unexpected converted input: %+v", input)
+			}
+		})
+	}
+}

--- a/services/local-service/internal/audit/types.go
+++ b/services/local-service/internal/audit/types.go
@@ -1,0 +1,37 @@
+package audit
+
+import "context"
+
+// RecordInput 是 audit 模块当前最小输入结构。
+//
+// 字段语义对齐协议中的 AuditRecord，
+// 但本类型仅用于后端模块内部，不替代协议真源。
+type RecordInput struct {
+	TaskID  string
+	Type    string
+	Action  string
+	Summary string
+	Target  string
+	Result  string
+}
+
+// Record 是 audit 模块当前最小输出结构。
+//
+// created_at 使用 RFC3339 时间字符串，便于后续持久化与协议映射。
+type Record struct {
+	AuditID   string
+	TaskID    string
+	Type      string
+	Action    string
+	Summary   string
+	Target    string
+	Result    string
+	CreatedAt string
+}
+
+// Writer 是审计记录输出边界。
+//
+// 当前不直接绑定数据库实现，后续由 storage 或其他持久化层注入。
+type Writer interface {
+	WriteAuditRecord(ctx context.Context, record Record) error
+}

--- a/services/local-service/internal/checkpoint/README.md
+++ b/services/local-service/internal/checkpoint/README.md
@@ -108,6 +108,7 @@
 - 定义 checkpoint 模块最小输入输出结构
 - 定义最小 service 入口
 - 补 table-driven tests
+- 对齐 tools 输出的 `checkpoint_candidate` 到 `CreateInput`
 
 ### P1
 

--- a/services/local-service/internal/checkpoint/README.md
+++ b/services/local-service/internal/checkpoint/README.md
@@ -1,0 +1,145 @@
+# checkpoint 模块 README
+
+## 1. 模块定位
+
+`/services/local-service/internal/checkpoint` 是 CialloClaw 后端治理与安全层中的**恢复点模块**。
+
+本模块负责在高风险动作执行前，为上层提供“是否需要创建恢复点、恢复点描述如何组织、恢复点对象如何表达”的统一能力入口。
+
+本模块当前不是回滚编排器，也不是文件恢复执行器，而是恢复点能力的最小收口层。
+
+---
+
+## 2. 本模块负责什么
+
+本模块当前只负责以下内容：
+
+1. 恢复点最小结构定义
+2. 恢复点输入整理
+3. 恢复点候选生成
+4. 为上层提供统一 checkpoint service 入口
+
+---
+
+## 3. 本模块不负责什么
+
+本模块明确不负责：
+
+- 风险判断
+- 审批流程
+- 正式文件回滚执行（当前阶段）
+- task / run 状态流转
+- artifact 正式交付
+- 前端恢复点页面展示
+
+一句话说：
+
+> `checkpoint` 只负责“恢复点是什么、什么时候应该准备”，不负责“完整回滚流程如何推进”。
+
+---
+
+## 4. 当前输入输出
+
+### 4.1 输入
+
+当前最小输入建议包含：
+
+- `task_id`
+- `summary`
+- `objects`
+
+### 4.2 输出
+
+当前输出建议对齐 `RecoveryPoint`：
+
+- `recovery_point_id`
+- `task_id`
+- `summary`
+- `created_at`
+- `objects`
+
+说明：
+
+- 本模块内部可以先保留最小骨架；
+- 不要在这里自行发明协议真源之外的正式字段。
+
+---
+
+## 5. 已冻结规则
+
+### 5.1 协议概念
+
+- `recovery_point`
+
+### 5.2 主链路约束
+
+主链路要求 dashboard 最终可看到：
+
+- `task`
+- `artifact`
+- `audit`
+- `recovery_point`
+
+### 5.3 存储职责
+
+根据架构文档，SQLite + WAL 负责：
+
+- checkpoint
+- 审计
+- 授权记录
+
+---
+
+## 6. 当前未冻结规则
+
+以下规则当前未冻结，不应擅自定死：
+
+1. 恢复点对象的最小粒度（文件级、目录级、任务级）
+2. 恢复点创建时机（执行前统一创建，还是按风险等级条件创建）
+3. 恢复点是否支持真正的一键恢复，以及恢复动作归属哪个模块
+4. 恢复点与 artifact / audit 的关系是否需要强绑定
+
+---
+
+## 7. 模块内待完成清单
+
+### P0
+
+- 定义 checkpoint 模块最小输入输出结构
+- 定义最小 service 入口
+- 补 table-driven tests
+
+### P1
+
+- 增加 checkpoint candidate 构造 helper
+- 补更明确的对象分类策略
+
+### P2
+
+- 为真正回滚流程做扩展准备
+
+---
+
+## 8. 跨模块待完成清单
+
+### P0
+
+- `tools` / `orchestrator` / `risk` 产出 checkpoint candidate
+- `storage` 接入 recovery point 的真实持久化
+- dashboard / security 页读取 recovery point 列表
+
+### P1
+
+- 与 `audit` 记录联动
+- 与授权流和恢复流联动
+
+---
+
+## 9. 模块自检清单
+
+- 有没有把风险判断写进 checkpoint？
+- 有没有把真正回滚执行逻辑写进 checkpoint？
+- 有没有发明协议真源外字段？
+- 有没有越界到 storage / orchestrator 实现细节？
+
+若答案不明确，不要直接开写。

--- a/services/local-service/internal/checkpoint/service.go
+++ b/services/local-service/internal/checkpoint/service.go
@@ -1,15 +1,93 @@
 // 该文件负责恢复点层的最小骨架。
 package checkpoint
 
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	ErrTaskIDRequired  = errors.New("checkpoint: task_id is required")
+	ErrSummaryRequired = errors.New("checkpoint: summary is required")
+)
+
+type noopWriter struct{}
+
+func (noopWriter) WriteRecoveryPoint(_ context.Context, _ RecoveryPoint) error {
+	return nil
+}
+
 // Service 提供当前模块的服务能力。
-type Service struct{}
+type Service struct {
+	writer Writer
+}
 
 // NewService 创建并返回Service。
-func NewService() *Service {
-	return &Service{}
+func NewService(writers ...Writer) *Service {
+	writer := Writer(noopWriter{})
+	if len(writers) > 0 && writers[0] != nil {
+		writer = writers[0]
+	}
+	return &Service{writer: writer}
 }
 
 // Status 处理当前模块的相关逻辑。
 func (s *Service) Status() string {
 	return "ready"
+}
+
+// BuildRecoveryPoint 把 CreateInput 归一化为最小恢复点结构。
+func (s *Service) BuildRecoveryPoint(input CreateInput) (RecoveryPoint, error) {
+	if err := validateCreateInput(input); err != nil {
+		return RecoveryPoint{}, err
+	}
+
+	objects := make([]string, 0, len(input.Objects))
+	for _, object := range input.Objects {
+		trimmed := strings.TrimSpace(object)
+		if trimmed != "" {
+			objects = append(objects, trimmed)
+		}
+	}
+
+	return RecoveryPoint{
+		RecoveryPointID: nextRecoveryPointID(),
+		TaskID:          strings.TrimSpace(input.TaskID),
+		Summary:         strings.TrimSpace(input.Summary),
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+		Objects:         objects,
+	}, nil
+}
+
+// Create 归一化并输出一条恢复点记录。
+func (s *Service) Create(ctx context.Context, input CreateInput) (RecoveryPoint, error) {
+	point, err := s.BuildRecoveryPoint(input)
+	if err != nil {
+		return RecoveryPoint{}, err
+	}
+	if err := s.writer.WriteRecoveryPoint(ctx, point); err != nil {
+		return RecoveryPoint{}, fmt.Errorf("checkpoint: write recovery point: %w", err)
+	}
+	return point, nil
+}
+
+func validateCreateInput(input CreateInput) error {
+	if strings.TrimSpace(input.TaskID) == "" {
+		return ErrTaskIDRequired
+	}
+	if strings.TrimSpace(input.Summary) == "" {
+		return ErrSummaryRequired
+	}
+	return nil
+}
+
+var recoveryPointCounter uint64
+
+func nextRecoveryPointID() string {
+	seq := atomic.AddUint64(&recoveryPointCounter, 1)
+	return fmt.Sprintf("recovery_point_%d_%d", time.Now().UnixNano(), seq)
 }

--- a/services/local-service/internal/checkpoint/service.go
+++ b/services/local-service/internal/checkpoint/service.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	ErrTaskIDRequired  = errors.New("checkpoint: task_id is required")
-	ErrSummaryRequired = errors.New("checkpoint: summary is required")
+	ErrTaskIDRequired   = errors.New("checkpoint: task_id is required")
+	ErrSummaryRequired  = errors.New("checkpoint: summary is required")
+	ErrCandidateInvalid = errors.New("checkpoint: candidate is invalid")
 )
 
 type noopWriter struct{}
@@ -61,6 +62,45 @@ func (s *Service) BuildRecoveryPoint(input CreateInput) (RecoveryPoint, error) {
 		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
 		Objects:         objects,
 	}, nil
+}
+
+// BuildCreateInputFromCandidate 将上游 checkpoint candidate 转换为最小 checkpoint 输入。
+//
+// shouldCreate 表示当前 candidate 是否要求真正创建恢复点；
+// 当前主要用于消费 tools 模块中的 checkpoint_candidate。
+func BuildCreateInputFromCandidate(taskID string, candidate map[string]any) (input CreateInput, shouldCreate bool, err error) {
+	if strings.TrimSpace(taskID) == "" {
+		return CreateInput{}, false, ErrTaskIDRequired
+	}
+	if candidate == nil {
+		return CreateInput{}, false, ErrCandidateInvalid
+	}
+
+	if required, ok := candidate["required"].(bool); ok {
+		shouldCreate = required
+	}
+	if !shouldCreate {
+		return CreateInput{}, false, nil
+	}
+
+	targetPath, _ := candidate["target_path"].(string)
+	reason, _ := candidate["reason"].(string)
+	trimmedTarget := strings.TrimSpace(targetPath)
+	trimmedReason := strings.TrimSpace(reason)
+	if trimmedTarget == "" {
+		return CreateInput{}, false, ErrCandidateInvalid
+	}
+
+	summary := trimmedReason
+	if summary == "" {
+		summary = "checkpoint_requested"
+	}
+
+	return CreateInput{
+		TaskID:  strings.TrimSpace(taskID),
+		Summary: summary,
+		Objects: []string{trimmedTarget},
+	}, true, nil
 }
 
 // Create 归一化并输出一条恢复点记录。

--- a/services/local-service/internal/checkpoint/service_test.go
+++ b/services/local-service/internal/checkpoint/service_test.go
@@ -90,3 +90,40 @@ func TestServiceCreatePropagatesWriterError(t *testing.T) {
 		t.Fatal("expected writer error")
 	}
 }
+
+func TestBuildCreateInputFromCandidate(t *testing.T) {
+	tests := []struct {
+		name       string
+		taskID     string
+		candidate  map[string]any
+		wantCreate bool
+		wantErr    error
+	}{
+		{name: "missing_task_id", taskID: "", candidate: map[string]any{"required": true, "target_path": "D:/workspace/report.md"}, wantErr: ErrTaskIDRequired},
+		{name: "nil_candidate", taskID: "task_001", candidate: nil, wantErr: ErrCandidateInvalid},
+		{name: "not_required", taskID: "task_001", candidate: map[string]any{"required": false, "target_path": "D:/workspace/report.md"}, wantCreate: false},
+		{name: "required_missing_target", taskID: "task_001", candidate: map[string]any{"required": true}, wantErr: ErrCandidateInvalid},
+		{name: "required_with_reason", taskID: "task_001", candidate: map[string]any{"required": true, "target_path": "D:/workspace/report.md", "reason": "write_file_before_change"}, wantCreate: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input, shouldCreate, err := BuildCreateInputFromCandidate(tc.taskID, tc.candidate)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("BuildCreateInputFromCandidate returned error: %v", err)
+			}
+			if shouldCreate != tc.wantCreate {
+				t.Fatalf("expected shouldCreate=%v, got %v", tc.wantCreate, shouldCreate)
+			}
+			if shouldCreate && (input.TaskID != "task_001" || len(input.Objects) != 1) {
+				t.Fatalf("unexpected converted input: %+v", input)
+			}
+		})
+	}
+}

--- a/services/local-service/internal/checkpoint/service_test.go
+++ b/services/local-service/internal/checkpoint/service_test.go
@@ -1,0 +1,92 @@
+package checkpoint
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type stubWriter struct {
+	points []RecoveryPoint
+	err    error
+}
+
+func (s *stubWriter) WriteRecoveryPoint(_ context.Context, point RecoveryPoint) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.points = append(s.points, point)
+	return nil
+}
+
+func TestServiceBuildRecoveryPoint(t *testing.T) {
+	service := NewService()
+
+	tests := []struct {
+		name    string
+		input   CreateInput
+		wantErr error
+	}{
+		{name: "missing_task_id", input: CreateInput{Summary: "before overwrite"}, wantErr: ErrTaskIDRequired},
+		{name: "missing_summary", input: CreateInput{TaskID: "task_001"}, wantErr: ErrSummaryRequired},
+		{name: "valid_point", input: CreateInput{TaskID: "task_001", Summary: "before overwrite", Objects: []string{"D:/workspace/report.md", ""}}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			point, err := service.BuildRecoveryPoint(tc.input)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("BuildRecoveryPoint returned error: %v", err)
+			}
+			if point.RecoveryPointID == "" || point.CreatedAt == "" {
+				t.Fatalf("expected generated recovery point id and created_at, got %+v", point)
+			}
+			if _, err := time.Parse(time.RFC3339, point.CreatedAt); err != nil {
+				t.Fatalf("expected RFC3339 created_at, got %q", point.CreatedAt)
+			}
+			if len(point.Objects) != 1 {
+				t.Fatalf("expected trimmed objects, got %+v", point.Objects)
+			}
+		})
+	}
+}
+
+func TestServiceCreate(t *testing.T) {
+	writer := &stubWriter{}
+	service := NewService(writer)
+
+	point, err := service.Create(context.Background(), CreateInput{
+		TaskID:  "task_001",
+		Summary: "before overwrite",
+		Objects: []string{"D:/workspace/report.md"},
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if len(writer.points) != 1 {
+		t.Fatalf("expected 1 recovery point, got %d", len(writer.points))
+	}
+	if writer.points[0].RecoveryPointID != point.RecoveryPointID {
+		t.Fatalf("expected persisted point to match returned point, got %+v vs %+v", writer.points[0], point)
+	}
+}
+
+func TestServiceCreatePropagatesWriterError(t *testing.T) {
+	writer := &stubWriter{err: errors.New("write failed")}
+	service := NewService(writer)
+
+	_, err := service.Create(context.Background(), CreateInput{
+		TaskID:  "task_001",
+		Summary: "before overwrite",
+	})
+	if err == nil {
+		t.Fatal("expected writer error")
+	}
+}

--- a/services/local-service/internal/checkpoint/types.go
+++ b/services/local-service/internal/checkpoint/types.go
@@ -1,0 +1,31 @@
+package checkpoint
+
+import "context"
+
+// CreateInput 是 checkpoint 模块当前最小输入结构。
+//
+// 字段语义对齐协议中的 RecoveryPoint，
+// 但本类型仅用于后端模块内部，不替代协议真源。
+type CreateInput struct {
+	TaskID  string
+	Summary string
+	Objects []string
+}
+
+// RecoveryPoint 是 checkpoint 模块当前最小输出结构。
+//
+// created_at 使用 RFC3339 字符串，便于后续持久化与协议映射。
+type RecoveryPoint struct {
+	RecoveryPointID string
+	TaskID          string
+	Summary         string
+	CreatedAt       string
+	Objects         []string
+}
+
+// Writer 是恢复点输出边界。
+//
+// 当前不绑定数据库实现，后续由 storage 或其他持久化层注入。
+type Writer interface {
+	WriteRecoveryPoint(ctx context.Context, point RecoveryPoint) error
+}

--- a/services/local-service/internal/risk/README.md
+++ b/services/local-service/internal/risk/README.md
@@ -1,0 +1,261 @@
+# risk 模块 README
+
+## 1. 模块定位
+
+`/services/local-service/internal/risk` 是 CialloClaw 后端治理与安全层中的**风险判断模块**。
+
+本模块的职责不是执行工具，也不是推进主链路状态，而是对“某个操作是否安全、是否需要人工确认、是否应直接拦截”给出统一判断结果，供上层编排层消费。
+
+在 `task-centric` 架构中：
+
+- 对外主对象是 `task`；
+- 后端保留 `run / step / event / tool_call` 兼容执行层；
+- `risk` 模块只负责**风险评估**，不直接接管状态机。
+
+---
+
+## 2. 本模块负责什么
+
+本模块当前只负责以下内容：
+
+1. 风险等级判断
+   - 按统一风险等级输出：`green` / `yellow` / `red`
+
+2. 风险原因归一化
+   - 对 workspace 越界、覆盖/删除风险、危险命令、能力缺失等场景给出统一 reason
+
+3. 最小影响面收口
+   - 用 `ImpactScope` 表示本次操作的文件、网页、应用及是否越界、是否存在覆盖/删除风险
+
+4. 审批建议输出
+   - 给出 `approval_required` / `deny` 这样的判断结果
+   - 由上层决定是否真正进入审批流
+
+---
+
+## 3. 本模块不负责什么
+
+本模块明确不负责：
+
+- `intent` 识别
+- `orchestrator / runengine` 状态机流转
+- `delivery_result` 编排
+- `ApprovalRequest` / `AuthorizationRecord` 的真实持久化写入
+- audit / checkpoint / artifact 的写入与消费
+- 前端协议消费与 UI 提示
+- 直接阻断或执行工具调用本身
+
+一句话说：
+
+> `risk` 只负责“判断风险”，不负责“推进流程”。
+
+---
+
+## 4. 依赖关系与边界
+
+### 4.1 允许依赖
+
+本模块可以依赖：
+
+- `/packages/protocol`（概念对齐，不复制协议真源）
+- `/packages/config`
+- 必要的标准库
+
+### 4.2 被谁依赖
+
+本模块通常会被以下模块依赖：
+
+- `orchestrator`
+- `tools`（如工具执行前预判断）
+- 后续可能的 `security` / `audit` 聚合层
+
+### 4.3 禁止依赖
+
+本模块不得依赖：
+
+- `apps/desktop/*`
+- 前端页面、store、RPC client
+- `delivery` 的正式交付逻辑
+- `runengine` 的内部持久化实现细节
+
+---
+
+## 5. 当前输入输出
+
+## 5.1 输入
+
+当前主输入是 `AssessmentInput`：
+
+- `operation_name`
+- `target_object`
+- `capability_available`
+- `command_preview`
+- `impact_scope`
+
+其中 `impact_scope` 当前包含：
+
+- `files`
+- `webpages`
+- `apps`
+- `out_of_workspace`
+- `overwrite_or_delete_risk`
+
+说明：
+
+- 当前输入只保留风险判断真正需要的信息；
+- 不直接传整套 task/run 状态，避免把业务状态机侵入 risk 模块。
+
+## 5.2 输出
+
+当前主输出是 `AssessmentResult`：
+
+- `risk_level`
+- `approval_required`
+- `deny`
+- `reason`
+- `impact_scope`
+
+说明：
+
+- 这是 risk 模块内部的最小判断结果；
+- 不直接替代正式协议对象；
+- 上层可基于它构造统一错误、审批请求或安全摘要。
+
+---
+
+## 6. 当前已实现规则
+
+当前 `Service.Assess(...)` 的最小规则如下：
+
+1. `capability_available = false`
+   - 输出：`red + deny`
+   - `reason = capability_denied`
+
+2. `command_preview` 命中危险命令模式
+   - 输出：`red + deny`
+   - `reason = command_not_allowed`
+
+3. `impact_scope.out_of_workspace = true`
+   - 输出：`red + approval_required`
+   - `reason = out_of_workspace`
+
+4. `impact_scope.overwrite_or_delete_risk = true`
+   - 输出：`yellow + approval_required`
+   - `reason = overwrite_or_delete_risk`
+
+5. 其他情况
+   - 输出：`green`
+   - `reason = normal`
+
+---
+
+## 7. 已冻结规则
+
+以下内容当前已冻结，应严格遵守：
+
+### 7.1 风险等级
+
+- `green`
+- `yellow`
+- `red`
+
+### 7.2 相关错误码
+
+- `1004001` `APPROVAL_REQUIRED`
+- `1004002` `APPROVAL_REJECTED`
+- `1004003` `WORKSPACE_BOUNDARY_DENIED`
+- `1004004` `COMMAND_NOT_ALLOWED`
+- `1004005` `CAPABILITY_DENIED`
+
+### 7.3 相关协议概念
+
+- `ApprovalRequest`
+- `AuthorizationRecord`
+- `ImpactScope`
+
+注意：
+
+- 本模块内部类型可以对齐这些概念；
+- 但不能在本模块里重新发明一套协议真源。
+
+---
+
+## 8. 当前未冻结规则
+
+以下规则目前**未冻结**，后续实现不得擅自编造为最终产品逻辑：
+
+1. workspace 外操作最终是：
+   - 一律直接拒绝；
+   - 还是 `red` 后允许人工审批；
+   - 还是按工具类别区分；
+
+2. 覆盖/删除风险最终统一是 `yellow` 还是在某些场景升为 `red`
+
+3. 危险命令黑名单的最终范围
+
+4. `risk` 是否最终直接产出 `ApprovalRequest`，还是只输出 assessment 结果供上层转换
+
+5. `ImpactScope` 是否还要扩展网页、应用、覆盖对象更多细节
+
+---
+
+## 9. 模块内待完成清单
+
+### P0
+
+- 增加 `README` 对应的示例输入输出样例，便于后续 AI 与人工统一理解
+- 为危险命令判断补更完整的 table-driven tests
+- 增加对 `ImpactScope.Files` / `TargetObject` 的一致性校验
+
+### P1
+
+- 抽离更明确的规则函数，如：
+  - `assessCapabilityRisk(...)`
+  - `assessCommandRisk(...)`
+  - `assessWorkspaceRisk(...)`
+- 增加更清晰的 reason 常量与注释文档
+- 为后续 `ApprovalRequest` 映射准备更明确的内部转换辅助函数
+
+### P2
+
+- 如果规则继续增长，再考虑拆成 `rules/` 子目录
+- 增加更多命令模式与能力不可用场景覆盖
+
+---
+
+## 10. 跨模块待完成清单
+
+### P0
+
+- `orchestrator` 真实接入 `risk.Service.Assess(...)`，不再只依赖临时或分散判断
+- `tools` 与 `risk` 的规则收口，避免各自维护一套命令风险与 workspace 风险逻辑
+- 上层将 `AssessmentResult` 正式映射到：
+  - `APPROVAL_REQUIRED`
+  - `WORKSPACE_BOUNDARY_DENIED`
+  - `COMMAND_NOT_ALLOWED`
+  - `CAPABILITY_DENIED`
+
+### P1
+
+- `audit` / `checkpoint` / `security` 聚合层消费 risk 输出
+- `storage` 或协议层决定是否记录风险评估快照
+- `rpc` 层按统一协议返回 `approval_request` / `impact_scope`
+
+### P2
+
+- 与更完整的审批流、恢复流、安全摘要页做联动
+- 评估是否把风险评估规则配置化
+
+---
+
+## 11. 模块自检清单
+
+开始修改 `risk` 模块前，先检查：
+
+- 这是风险判断逻辑，还是状态机逻辑？
+- 有没有擅自生成协议真源中未登记的字段？
+- 有没有把审批流或持久化逻辑写进 risk 模块？
+- 有没有写死平台路径或命令平台差异？
+- 有没有越界到 `orchestrator` / `audit` / `checkpoint`？
+
+只要其中任一项答案不明确，就不要直接开写。

--- a/services/local-service/internal/risk/service.go
+++ b/services/local-service/internal/risk/service.go
@@ -1,6 +1,8 @@
 // 该文件负责风险评估层的最小骨架。
 package risk
 
+import "strings"
+
 // Service 提供当前模块的服务能力。
 type Service struct{}
 
@@ -11,5 +13,79 @@ func NewService() *Service {
 
 // DefaultLevel 处理当前模块的相关逻辑。
 func (s *Service) DefaultLevel() string {
-	return "green"
+	return string(RiskLevelGreen)
+}
+
+// Assess 对一次工具或操作请求进行最小风险评估。
+//
+// 当前规则保持保守：
+// 1. 能力不可用 => red + deny
+// 2. 命中危险命令 => red + deny
+// 3. 超出工作区 => red + approval_required
+// 4. 存在覆盖/删除风险 => yellow + approval_required
+// 5. 其他 => green
+//
+// 注意：
+// - 这里不直接生成 ApprovalRequest；
+// - 这里不推进状态机；
+// - 这里只给上层一个稳定、可测试的风险判断结果。
+func (s *Service) Assess(input AssessmentInput) AssessmentResult {
+	result := AssessmentResult{
+		RiskLevel:   RiskLevelGreen,
+		Reason:      ReasonNormal,
+		ImpactScope: input.ImpactScope,
+	}
+
+	if !input.CapabilityAvailable {
+		result.RiskLevel = RiskLevelRed
+		result.Deny = true
+		result.Reason = ReasonCapabilityDenied
+		return result
+	}
+
+	if isDeniedCommand(input.CommandPreview) {
+		result.RiskLevel = RiskLevelRed
+		result.Deny = true
+		result.Reason = ReasonCommandNotAllowed
+		return result
+	}
+
+	if input.ImpactScope.OutOfWorkspace {
+		result.RiskLevel = RiskLevelRed
+		result.ApprovalRequired = true
+		result.Reason = ReasonOutOfWorkspace
+		return result
+	}
+
+	if input.ImpactScope.OverwriteOrDeleteRisk {
+		result.RiskLevel = RiskLevelYellow
+		result.ApprovalRequired = true
+		result.Reason = ReasonOverwriteOrDelete
+		return result
+	}
+
+	return result
+}
+
+func isDeniedCommand(commandPreview string) bool {
+	preview := strings.ToLower(strings.TrimSpace(commandPreview))
+	if preview == "" {
+		return false
+	}
+
+	deniedPatterns := []string{
+		"rm -rf",
+		"del /f",
+		"format ",
+		"shutdown ",
+		"powershell remove-item",
+	}
+
+	for _, pattern := range deniedPatterns {
+		if strings.Contains(preview, pattern) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/services/local-service/internal/risk/service.go
+++ b/services/local-service/internal/risk/service.go
@@ -21,9 +21,11 @@ func (s *Service) DefaultLevel() string {
 // 当前规则保持保守：
 // 1. 能力不可用 => red + deny
 // 2. 命中危险命令 => red + deny
-// 3. 超出工作区 => red + approval_required
-// 4. 存在覆盖/删除风险 => yellow + approval_required
-// 5. 其他 => green
+// 3. 命中需审批命令 => red + approval_required
+// 4. 超出工作区 => red + deny
+// 5. write_file 且工作区信息未知 => yellow + approval_required
+// 6. 存在覆盖/删除风险 => yellow + checkpoint_required
+// 7. 其他 => green
 //
 // 注意：
 // - 这里不直接生成 ApprovalRequest；
@@ -50,16 +52,30 @@ func (s *Service) Assess(input AssessmentInput) AssessmentResult {
 		return result
 	}
 
-	if input.ImpactScope.OutOfWorkspace {
+	if isApprovalCommand(input.CommandPreview) {
 		result.RiskLevel = RiskLevelRed
 		result.ApprovalRequired = true
+		result.Reason = ReasonCommandApproval
+		return result
+	}
+
+	if input.ImpactScope.OutOfWorkspace {
+		result.RiskLevel = RiskLevelRed
+		result.Deny = true
 		result.Reason = ReasonOutOfWorkspace
+		return result
+	}
+
+	if input.OperationName == "write_file" && (!input.WorkspaceKnown || strings.TrimSpace(input.TargetObject) == "") {
+		result.RiskLevel = RiskLevelYellow
+		result.ApprovalRequired = true
+		result.Reason = ReasonWorkspaceUnknown
 		return result
 	}
 
 	if input.ImpactScope.OverwriteOrDeleteRisk {
 		result.RiskLevel = RiskLevelYellow
-		result.ApprovalRequired = true
+		result.CheckpointRequired = true
 		result.Reason = ReasonOverwriteOrDelete
 		return result
 	}
@@ -82,6 +98,30 @@ func isDeniedCommand(commandPreview string) bool {
 	}
 
 	for _, pattern := range deniedPatterns {
+		if strings.Contains(preview, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isApprovalCommand(commandPreview string) bool {
+	preview := strings.ToLower(strings.TrimSpace(commandPreview))
+	if preview == "" {
+		return false
+	}
+
+	approvalPatterns := []string{
+		"curl ",
+		"wget ",
+		"powershell",
+		"chmod ",
+		"chown ",
+		"git clean",
+	}
+
+	for _, pattern := range approvalPatterns {
 		if strings.Contains(preview, pattern) {
 			return true
 		}

--- a/services/local-service/internal/risk/service_test.go
+++ b/services/local-service/internal/risk/service_test.go
@@ -61,20 +61,34 @@ func TestServiceAssess(t *testing.T) {
 			},
 		},
 		{
-			name: "out_of_workspace_requires_approval",
+			name: "command_requires_approval_red",
+			input: AssessmentInput{
+				OperationName:       "exec_command",
+				CapabilityAvailable: true,
+				CommandPreview:      "powershell Get-Process",
+			},
+			want: AssessmentResult{
+				RiskLevel:        RiskLevelRed,
+				ApprovalRequired: true,
+				Reason:           ReasonCommandApproval,
+			},
+		},
+		{
+			name: "out_of_workspace_denied",
 			input: AssessmentInput{
 				OperationName:       "write_file",
 				TargetObject:        "D:/outside/report.md",
 				CapabilityAvailable: true,
+				WorkspaceKnown:      true,
 				ImpactScope: ImpactScope{
 					Files:          []string{"D:/outside/report.md"},
 					OutOfWorkspace: true,
 				},
 			},
 			want: AssessmentResult{
-				RiskLevel:        RiskLevelRed,
-				ApprovalRequired: true,
-				Reason:           ReasonOutOfWorkspace,
+				RiskLevel: RiskLevelRed,
+				Deny:      true,
+				Reason:    ReasonOutOfWorkspace,
 				ImpactScope: ImpactScope{
 					Files:          []string{"D:/outside/report.md"},
 					OutOfWorkspace: true,
@@ -82,20 +96,35 @@ func TestServiceAssess(t *testing.T) {
 			},
 		},
 		{
-			name: "overwrite_requires_yellow_approval",
+			name: "write_file_unknown_workspace_requires_approval",
+			input: AssessmentInput{
+				OperationName:       "write_file",
+				TargetObject:        "",
+				CapabilityAvailable: true,
+				WorkspaceKnown:      false,
+			},
+			want: AssessmentResult{
+				RiskLevel:        RiskLevelYellow,
+				ApprovalRequired: true,
+				Reason:           ReasonWorkspaceUnknown,
+			},
+		},
+		{
+			name: "overwrite_requires_checkpoint",
 			input: AssessmentInput{
 				OperationName:       "write_file",
 				TargetObject:        "D:/workspace/report.md",
 				CapabilityAvailable: true,
+				WorkspaceKnown:      true,
 				ImpactScope: ImpactScope{
 					Files:                 []string{"D:/workspace/report.md"},
 					OverwriteOrDeleteRisk: true,
 				},
 			},
 			want: AssessmentResult{
-				RiskLevel:        RiskLevelYellow,
-				ApprovalRequired: true,
-				Reason:           ReasonOverwriteOrDelete,
+				RiskLevel:          RiskLevelYellow,
+				CheckpointRequired: true,
+				Reason:             ReasonOverwriteOrDelete,
 				ImpactScope: ImpactScope{
 					Files:                 []string{"D:/workspace/report.md"},
 					OverwriteOrDeleteRisk: true,
@@ -113,6 +142,9 @@ func TestServiceAssess(t *testing.T) {
 			}
 			if got.ApprovalRequired != tc.want.ApprovalRequired {
 				t.Fatalf("expected approval_required %v, got %v", tc.want.ApprovalRequired, got.ApprovalRequired)
+			}
+			if got.CheckpointRequired != tc.want.CheckpointRequired {
+				t.Fatalf("expected checkpoint_required %v, got %v", tc.want.CheckpointRequired, got.CheckpointRequired)
 			}
 			if got.Deny != tc.want.Deny {
 				t.Fatalf("expected deny %v, got %v", tc.want.Deny, got.Deny)

--- a/services/local-service/internal/risk/service_test.go
+++ b/services/local-service/internal/risk/service_test.go
@@ -1,0 +1,131 @@
+package risk
+
+import "testing"
+
+func TestServiceDefaultLevel(t *testing.T) {
+	service := NewService()
+
+	if service.DefaultLevel() != "green" {
+		t.Fatalf("expected green default level, got %q", service.DefaultLevel())
+	}
+}
+
+func TestServiceAssess(t *testing.T) {
+	service := NewService()
+
+	tests := []struct {
+		name  string
+		input AssessmentInput
+		want  AssessmentResult
+	}{
+		{
+			name: "normal_operation_green",
+			input: AssessmentInput{
+				OperationName:       "read_file",
+				TargetObject:        "D:/workspace/notes/demo.txt",
+				CapabilityAvailable: true,
+				ImpactScope: ImpactScope{
+					Files: []string{"D:/workspace/notes/demo.txt"},
+				},
+			},
+			want: AssessmentResult{
+				RiskLevel:   RiskLevelGreen,
+				Reason:      ReasonNormal,
+				ImpactScope: ImpactScope{Files: []string{"D:/workspace/notes/demo.txt"}},
+			},
+		},
+		{
+			name: "capability_denied_red",
+			input: AssessmentInput{
+				OperationName:       "write_file",
+				TargetObject:        "D:/workspace/report.md",
+				CapabilityAvailable: false,
+			},
+			want: AssessmentResult{
+				RiskLevel: RiskLevelRed,
+				Deny:      true,
+				Reason:    ReasonCapabilityDenied,
+			},
+		},
+		{
+			name: "command_not_allowed_red",
+			input: AssessmentInput{
+				OperationName:       "exec_command",
+				CapabilityAvailable: true,
+				CommandPreview:      "rm -rf /tmp/demo",
+			},
+			want: AssessmentResult{
+				RiskLevel: RiskLevelRed,
+				Deny:      true,
+				Reason:    ReasonCommandNotAllowed,
+			},
+		},
+		{
+			name: "out_of_workspace_requires_approval",
+			input: AssessmentInput{
+				OperationName:       "write_file",
+				TargetObject:        "D:/outside/report.md",
+				CapabilityAvailable: true,
+				ImpactScope: ImpactScope{
+					Files:          []string{"D:/outside/report.md"},
+					OutOfWorkspace: true,
+				},
+			},
+			want: AssessmentResult{
+				RiskLevel:        RiskLevelRed,
+				ApprovalRequired: true,
+				Reason:           ReasonOutOfWorkspace,
+				ImpactScope: ImpactScope{
+					Files:          []string{"D:/outside/report.md"},
+					OutOfWorkspace: true,
+				},
+			},
+		},
+		{
+			name: "overwrite_requires_yellow_approval",
+			input: AssessmentInput{
+				OperationName:       "write_file",
+				TargetObject:        "D:/workspace/report.md",
+				CapabilityAvailable: true,
+				ImpactScope: ImpactScope{
+					Files:                 []string{"D:/workspace/report.md"},
+					OverwriteOrDeleteRisk: true,
+				},
+			},
+			want: AssessmentResult{
+				RiskLevel:        RiskLevelYellow,
+				ApprovalRequired: true,
+				Reason:           ReasonOverwriteOrDelete,
+				ImpactScope: ImpactScope{
+					Files:                 []string{"D:/workspace/report.md"},
+					OverwriteOrDeleteRisk: true,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := service.Assess(tc.input)
+
+			if got.RiskLevel != tc.want.RiskLevel {
+				t.Fatalf("expected risk level %q, got %q", tc.want.RiskLevel, got.RiskLevel)
+			}
+			if got.ApprovalRequired != tc.want.ApprovalRequired {
+				t.Fatalf("expected approval_required %v, got %v", tc.want.ApprovalRequired, got.ApprovalRequired)
+			}
+			if got.Deny != tc.want.Deny {
+				t.Fatalf("expected deny %v, got %v", tc.want.Deny, got.Deny)
+			}
+			if got.Reason != tc.want.Reason {
+				t.Fatalf("expected reason %q, got %q", tc.want.Reason, got.Reason)
+			}
+			if got.ImpactScope.OutOfWorkspace != tc.want.ImpactScope.OutOfWorkspace {
+				t.Fatalf("expected out_of_workspace %v, got %v", tc.want.ImpactScope.OutOfWorkspace, got.ImpactScope.OutOfWorkspace)
+			}
+			if got.ImpactScope.OverwriteOrDeleteRisk != tc.want.ImpactScope.OverwriteOrDeleteRisk {
+				t.Fatalf("expected overwrite_or_delete_risk %v, got %v", tc.want.ImpactScope.OverwriteOrDeleteRisk, got.ImpactScope.OverwriteOrDeleteRisk)
+			}
+		})
+	}
+}

--- a/services/local-service/internal/risk/types.go
+++ b/services/local-service/internal/risk/types.go
@@ -15,7 +15,9 @@ const (
 	ReasonOutOfWorkspace    = "out_of_workspace"
 	ReasonOverwriteOrDelete = "overwrite_or_delete_risk"
 	ReasonCommandNotAllowed = "command_not_allowed"
+	ReasonCommandApproval   = "command_requires_approval"
 	ReasonCapabilityDenied  = "capability_denied"
+	ReasonWorkspaceUnknown  = "workspace_unknown"
 	ReasonNormal            = "normal"
 )
 
@@ -38,6 +40,7 @@ type AssessmentInput struct {
 	OperationName       string
 	TargetObject        string
 	CapabilityAvailable bool
+	WorkspaceKnown      bool
 	CommandPreview      string
 	ImpactScope         ImpactScope
 }
@@ -48,9 +51,10 @@ type AssessmentInput struct {
 // deny 表示当前模块建议直接拦截，不进入执行；
 // reason 用于上层构造统一错误或审批原因，但不直接等同完整协议对象。
 type AssessmentResult struct {
-	RiskLevel        RiskLevel
-	ApprovalRequired bool
-	Deny             bool
-	Reason           string
-	ImpactScope      ImpactScope
+	RiskLevel          RiskLevel
+	ApprovalRequired   bool
+	CheckpointRequired bool
+	Deny               bool
+	Reason             string
+	ImpactScope        ImpactScope
 }

--- a/services/local-service/internal/risk/types.go
+++ b/services/local-service/internal/risk/types.go
@@ -1,0 +1,56 @@
+package risk
+
+// RiskLevel 定义风险等级。
+//
+// 取值严格对齐已冻结枚举：green / yellow / red。
+type RiskLevel string
+
+const (
+	RiskLevelGreen  RiskLevel = "green"
+	RiskLevelYellow RiskLevel = "yellow"
+	RiskLevelRed    RiskLevel = "red"
+)
+
+const (
+	ReasonOutOfWorkspace    = "out_of_workspace"
+	ReasonOverwriteOrDelete = "overwrite_or_delete_risk"
+	ReasonCommandNotAllowed = "command_not_allowed"
+	ReasonCapabilityDenied  = "capability_denied"
+	ReasonNormal            = "normal"
+)
+
+// ImpactScope 是 risk 模块内部使用的最小影响面结构。
+//
+// 字段语义对齐 protocol 中已定义的 ImpactScope，
+// 但本类型只在后端 risk 模块内部使用，不直接替代协议真源。
+type ImpactScope struct {
+	Files                 []string
+	Webpages              []string
+	Apps                  []string
+	OutOfWorkspace        bool
+	OverwriteOrDeleteRisk bool
+}
+
+// AssessmentInput 描述一次风险评估的最小输入。
+//
+// 本阶段只保留 risk 模块真正需要的判断信息，避免侵入主链路状态机。
+type AssessmentInput struct {
+	OperationName       string
+	TargetObject        string
+	CapabilityAvailable bool
+	CommandPreview      string
+	ImpactScope         ImpactScope
+}
+
+// AssessmentResult 描述一次风险评估的最小结果。
+//
+// approval_required 表示应交由上层进入人工确认流；
+// deny 表示当前模块建议直接拦截，不进入执行；
+// reason 用于上层构造统一错误或审批原因，但不直接等同完整协议对象。
+type AssessmentResult struct {
+	RiskLevel        RiskLevel
+	ApprovalRequired bool
+	Deny             bool
+	Reason           string
+	ImpactScope      ImpactScope
+}

--- a/services/local-service/internal/tools/risk_precheck.go
+++ b/services/local-service/internal/tools/risk_precheck.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"path/filepath"
 	"strings"
+
+	risksvc "github.com/cialloclaw/cialloclaw/services/local-service/internal/risk"
 )
 
 const (
-	RiskLevelGreen  = "green"
-	RiskLevelYellow = "yellow"
-	RiskLevelRed    = "red"
+	RiskLevelGreen  = string(risksvc.RiskLevelGreen)
+	RiskLevelYellow = string(risksvc.RiskLevelYellow)
+	RiskLevelRed    = string(risksvc.RiskLevelRed)
 )
 
 // WorkspaceBoundaryInfo 描述当前工具调用涉及的工作区边界信息。
@@ -49,26 +51,31 @@ type RiskPrechecker interface {
 }
 
 // DefaultRiskPrechecker 提供最小可用的默认策略。
-type DefaultRiskPrechecker struct{}
+type DefaultRiskPrechecker struct {
+	service *risksvc.Service
+}
+
+func NewDefaultRiskPrechecker(service *risksvc.Service) DefaultRiskPrechecker {
+	return DefaultRiskPrechecker{service: service}
+}
+
+func (p DefaultRiskPrechecker) riskService() *risksvc.Service {
+	if p.service != nil {
+		return p.service
+	}
+	return risksvc.NewService()
+}
 
 // Precheck implements RiskPrechecker.
-func (DefaultRiskPrechecker) Precheck(_ context.Context, input RiskPrecheckInput) (RiskPrecheckResult, error) {
-	result := RiskPrecheckResult{RiskLevel: RiskLevelGreen}
-
-	switch input.ToolName {
-	case "read_file":
-		return result, nil
-	case "write_file":
-		return evaluateWriteFileRisk(input), nil
-	case "exec_command":
-		return evaluateExecCommandRisk(input), nil
-	default:
-		if input.Metadata.RiskHint == RiskLevelRed {
-			result.RiskLevel = RiskLevelRed
-			result.ApprovalRequired = true
-		}
-		return result, nil
-	}
+func (p DefaultRiskPrechecker) Precheck(_ context.Context, input RiskPrecheckInput) (RiskPrecheckResult, error) {
+	assessment := p.riskService().Assess(buildAssessmentInput(input))
+	return RiskPrecheckResult{
+		RiskLevel:          string(assessment.RiskLevel),
+		ApprovalRequired:   assessment.ApprovalRequired,
+		CheckpointRequired: assessment.CheckpointRequired,
+		Deny:               assessment.Deny,
+		DenyReason:         assessment.Reason,
+	}, nil
 }
 
 // BuildRiskPrecheckInput 从执行上下文中提取风险判定所需的最小信息。
@@ -112,60 +119,31 @@ func BuildRiskPrecheckInput(metadata ToolMetadata, toolName string, execCtx *Too
 	return precheckInput
 }
 
-func evaluateWriteFileRisk(input RiskPrecheckInput) RiskPrecheckResult {
-	result := RiskPrecheckResult{
-		RiskLevel:          RiskLevelYellow,
-		CheckpointRequired: true,
+func buildAssessmentInput(input RiskPrecheckInput) risksvc.AssessmentInput {
+	outOfWorkspace := false
+	workspaceKnown := false
+	if input.Workspace.Within != nil {
+		workspaceKnown = true
+		outOfWorkspace = !*input.Workspace.Within
 	}
 
-	if input.Workspace.TargetPath == "" {
-		result.ApprovalRequired = true
-		result.DenyReason = "write target path is missing"
-		return result
+	assessment := risksvc.AssessmentInput{
+		OperationName:       input.ToolName,
+		TargetObject:        input.Workspace.TargetPath,
+		CapabilityAvailable: true,
+		WorkspaceKnown:      workspaceKnown,
+		CommandPreview:      normalizeCommandString(input.Input),
+		ImpactScope: risksvc.ImpactScope{
+			Files:          filesFromTarget(input.Workspace.TargetPath),
+			OutOfWorkspace: outOfWorkspace,
+		},
 	}
 
-	if input.Workspace.Within == nil {
-		result.ApprovalRequired = true
-		result.DenyReason = "workspace boundary is unknown"
-		return result
+	if input.ToolName == "write_file" {
+		assessment.ImpactScope.OverwriteOrDeleteRisk = workspaceKnown && !outOfWorkspace
 	}
 
-	if !*input.Workspace.Within {
-		result.RiskLevel = RiskLevelRed
-		result.Deny = true
-		result.DenyReason = "write target is outside workspace boundary"
-	}
-
-	return result
-}
-
-func evaluateExecCommandRisk(input RiskPrecheckInput) RiskPrecheckResult {
-	command := normalizeCommandString(input.Input)
-	if command == "" {
-		return RiskPrecheckResult{
-			RiskLevel:        RiskLevelYellow,
-			ApprovalRequired: true,
-			DenyReason:       "command content is missing",
-		}
-	}
-
-	if matchesDangerousCommand(command) {
-		return RiskPrecheckResult{
-			RiskLevel:  RiskLevelRed,
-			Deny:       true,
-			DenyReason: "command is blocked by local risk policy",
-		}
-	}
-
-	if matchesApprovalCommand(command) {
-		return RiskPrecheckResult{
-			RiskLevel:        RiskLevelRed,
-			ApprovalRequired: true,
-			DenyReason:       "command requires approval before execution",
-		}
-	}
-
-	return RiskPrecheckResult{RiskLevel: RiskLevelYellow}
+	return assessment
 }
 
 func extractTargetPath(input map[string]any) (string, bool) {
@@ -191,43 +169,16 @@ func normalizeCommandString(input map[string]any) string {
 	return ""
 }
 
-func matchesDangerousCommand(command string) bool {
-	patterns := []string{
-		"rm -rf",
-		"del /f",
-		"rd /s /q",
-		"format ",
-		"mkfs",
-		"shutdown",
-		"reboot",
-		"diskpart",
-	}
-	return matchesAnyPattern(command, patterns)
-}
-
-func matchesApprovalCommand(command string) bool {
-	patterns := []string{
-		"curl ",
-		"wget ",
-		"powershell",
-		"chmod ",
-		"chown ",
-		"git clean",
-	}
-	return matchesAnyPattern(command, patterns)
-}
-
-func matchesAnyPattern(command string, patterns []string) bool {
-	for _, pattern := range patterns {
-		if strings.Contains(command, pattern) {
-			return true
-		}
-	}
-	return false
-}
-
 func boolPtr(v bool) *bool {
 	return &v
+}
+
+func filesFromTarget(target string) []string {
+	trimmed := strings.TrimSpace(target)
+	if trimmed == "" {
+		return nil
+	}
+	return []string{trimmed}
 }
 
 func withinWorkspacePath(workspacePath, targetPath string) *bool {


### PR DESCRIPTION
## 背景

当前后端治理与安全层在 `risk`、`audit`、`checkpoint` 这三个模块上仍然是最小骨架，缺少稳定的模块边界、最小输入输出结构以及与 tools 层对齐的规则基础。为了避免后续继续在 `tools`、`orchestrator`、`storage` 中散落安全与治理逻辑，本分支先补齐治理层基础能力，并把 tools 中的风险规则收口到 `risk` 模块。

## 本次变更

- 为 `risk` 模块补齐最小 assessment service、类型定义与测试
- 为 `risk` 模块补 README，明确职责、边界、输入输出、已冻结/未冻结规则与待办清单
- 为 `audit` 模块补齐最小输入输出、writer 边界、service 与测试
- 为 `checkpoint` 模块补齐最小输入输出、writer 边界、service 与测试
- 为 `audit` / `checkpoint` 补 README，明确模块职责、边界和后续待办
- 合入 `feat/tools-foundation-p0` 作为当前分支基线，保证后续 risk-tools 收口不重复造轮子
- 将 `tools/risk_precheck` 的规则收口到 `risk.Service.Assess(...)`，避免 `risk` 与 `tools` 各维护一套命令风险、workspace 风险和 overwrite 风险逻辑
- 为 `audit` / `checkpoint` 增加与 `tools` candidate 的最小结构对齐 helper，先完成结构对齐，不直接改 tool 输出字段

## 结果

当前分支已经提供：

- `risk` 的统一风险判断入口：`AssessmentInput -> AssessmentResult`
- `audit` 的最小 record service：`RecordInput -> Record`
- `checkpoint` 的最小 recovery point service：`CreateInput -> RecoveryPoint`
- `tools` 与 `risk` 的规则收口基础
- `tools` 输出 candidate 到 `audit` / `checkpoint` 输入的最小适配能力

## 影响范围

### governance 模块

- `services/local-service/internal/risk/service.go`
- `services/local-service/internal/risk/types.go`
- `services/local-service/internal/risk/service_test.go`
- `services/local-service/internal/risk/README.md`
- `services/local-service/internal/audit/service.go`
- `services/local-service/internal/audit/types.go`
- `services/local-service/internal/audit/service_test.go`
- `services/local-service/internal/audit/README.md`
- `services/local-service/internal/checkpoint/service.go`
- `services/local-service/internal/checkpoint/types.go`
- `services/local-service/internal/checkpoint/service_test.go`
- `services/local-service/internal/checkpoint/README.md`

### 为完成规则收口而引入/对齐的 tools 基线

- `services/local-service/internal/tools/risk_precheck.go`
- `services/local-service/internal/tools/*`（来自已完成的 tools foundation 基线合入）

## 验证方式

```bash
go test ./services/local-service/internal/risk
go test ./services/local-service/internal/audit
go test ./services/local-service/internal/checkpoint
go test ./services/local-service/internal/risk ./services/local-service/internal/tools/...
```

## 设计说明

- `risk` 只负责“判”，不负责推进审批流和状态机
- `audit` 只负责“记什么”，不直接绑定持久化实现
- `checkpoint` 只负责“恢复点是什么”，不直接执行回滚
- `tools` 继续负责 candidate 产出和 precheck 桥接，但规则真源转到 `risk`

## 当前未完成项

- `orchestrator` 还未真实消费 `risk` / `audit` / `checkpoint`
- `storage` 还未接入 `audit.Writer` / `checkpoint.Writer`
- `risk` 的最终产品规则仍有未冻结部分，例如：
  - workspace 外操作最终是审批还是一律拒绝
  - overwrite/delete 风险最终等级
  - 危险命令黑名单范围