### PR TITLE
feat(dashboard): add dashboard page - notes

### DIFF
--- a/apps/desktop/src/features/dashboard/home/components/DashboardCenterOrb.tsx
+++ b/apps/desktop/src/features/dashboard/home/components/DashboardCenterOrb.tsx
@@ -210,7 +210,15 @@ export function DashboardCenterOrb({ activeColor, onDragOffset, onLongPress, vis
         type="button"
       >
         <div className="dashboard-orbit-center__shell">
-          <ShellBallMascot motionConfig={motionConfig} visualState={visualState} />
+          <ShellBallMascot
+            motionConfig={motionConfig}
+            onPressEnd={() => false}
+            onPressMove={() => {}}
+            onPressStart={() => {}}
+            onPrimaryClick={() => {}}
+            visualState={visualState}
+            voicePreview={null}
+          />
         </div>
       </button>
 

--- a/apps/desktop/src/features/dashboard/home/components/DashboardVoiceField.tsx
+++ b/apps/desktop/src/features/dashboard/home/components/DashboardVoiceField.tsx
@@ -238,7 +238,15 @@ export function DashboardVoiceField({ isOpen, onClose, onCommand, sequences }: D
             <div className="dashboard-voice-field__wave dashboard-voice-field__wave--middle" data-stage={stage} />
             <div className="dashboard-voice-field__wave dashboard-voice-field__wave--inner" data-stage={stage} />
             <div className="dashboard-voice-field__mascot-shell">
-              <ShellBallMascot motionConfig={motionConfig} visualState={mascotState} />
+              <ShellBallMascot
+                motionConfig={motionConfig}
+                onPressEnd={() => false}
+                onPressMove={() => {}}
+                onPressStart={() => {}}
+                onPrimaryClick={() => {}}
+                visualState={mascotState}
+                voicePreview={null}
+              />
             </div>
           </div>
 

--- a/apps/desktop/src/features/dashboard/notes/NotePage.tsx
+++ b/apps/desktop/src/features/dashboard/notes/NotePage.tsx
@@ -1,0 +1,302 @@
+import { useMemo, useRef, useState } from "react";
+import { useEffect } from "react";
+import type { CSSProperties } from "react";
+import { Link, NavLink, useNavigate } from "react-router-dom";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { ArrowLeft, CircleDashed, NotebookPen } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import { dashboardModules } from "@/features/dashboard/shared/dashboardRoutes";
+import { cn } from "@/utils/cn";
+import { buildNoteSummary, describeNotePreview, getNoteBucketLabel, groupClosedNotes, sortClosedNotes, sortNotesByUrgency } from "./notePage.mapper";
+import { convertNoteToTask, loadNoteBuckets } from "./notePage.service";
+import type { NoteDetailAction, NoteListItem } from "./notePage.types";
+import { NoteDetailPanel } from "./components/NoteDetailPanel";
+import { NoteEmptyState } from "./components/NoteEmptyState";
+import { NotePreviewCard } from "./components/NotePreviewCard";
+import { NotePreviewSection } from "./components/NotePreviewSection";
+import "./notePage.css";
+
+export function NotePage() {
+  const navigate = useNavigate();
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [showMoreClosed, setShowMoreClosed] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const feedbackTimeoutRef = useRef<number | null>(null);
+
+  const notesQuery = useQuery({
+    queryKey: ["dashboard", "notes", "buckets"],
+    queryFn: loadNoteBuckets,
+  });
+
+  const upcomingItems = sortNotesByUrgency(notesQuery.data?.upcoming ?? []);
+  const laterItems = sortNotesByUrgency(notesQuery.data?.later ?? []);
+  const recurringItems = sortNotesByUrgency(notesQuery.data?.recurring_rule ?? []);
+  const closedItems = sortClosedNotes(notesQuery.data?.closed ?? []);
+  const closedGroups = useMemo(() => groupClosedNotes(closedItems, showMoreClosed), [closedItems, showMoreClosed]);
+  const summary = useMemo(() => buildNoteSummary({ recurring_rule: recurringItems, upcoming: upcomingItems }), [recurringItems, upcomingItems]);
+  const selectedItem = useMemo(() => {
+    const allItems = [...upcomingItems, ...laterItems, ...recurringItems, ...closedItems];
+    return allItems.find((entry) => entry.item.item_id === selectedItemId) ?? upcomingItems[0] ?? laterItems[0] ?? recurringItems[0] ?? closedItems[0] ?? null;
+  }, [closedItems, laterItems, recurringItems, selectedItemId, upcomingItems]);
+
+  const pageStyle = {
+    "--note-accent": "#F4B183",
+    "--note-accent-glow": "rgba(244, 177, 131, 0.2)",
+    "--note-accent-soft": "rgba(247, 225, 203, 0.68)",
+    "--note-accent-surface": "rgba(250, 236, 220, 0.62)",
+    "--note-accent-border": "rgba(244, 177, 131, 0.24)",
+    "--note-accent-shadow": "rgba(166, 120, 86, 0.12)",
+    "--note-paper": "rgba(255, 250, 244, 0.8)",
+    "--note-paper-strong": "rgba(255, 247, 238, 0.9)",
+    "--note-line": "rgba(156, 133, 113, 0.16)",
+    "--note-ink": "#5f544b",
+    "--note-copy": "rgba(95, 84, 75, 0.68)",
+  } as CSSProperties;
+
+  function showFeedback(message: string) {
+    setFeedback(message);
+    if (feedbackTimeoutRef.current) {
+      window.clearTimeout(feedbackTimeoutRef.current);
+    }
+    feedbackTimeoutRef.current = window.setTimeout(() => setFeedback(null), 2400);
+  }
+
+  const convertMutation = useMutation({
+    mutationFn: (itemId: string) => convertNoteToTask(itemId),
+    onSuccess: (outcome) => {
+      showFeedback("已为这条事项生成任务，正在跳转到任务页。");
+      navigate("/tasks", { state: { focusTaskId: outcome.result.task.task_id, openDetail: true } });
+    },
+    onError: () => {
+      showFeedback("转交给 Agent 失败，请稍后再试。");
+    },
+  });
+
+  function handleDetailAction(action: NoteDetailAction) {
+    if (!selectedItem) {
+      return;
+    }
+
+    if (action === "convert-to-task") {
+      convertMutation.mutate(selectedItem.item.item_id);
+      return;
+    }
+
+    const placeholders: Record<Exclude<NoteDetailAction, "convert-to-task">, string> = {
+      cancel: "取消本次事项的真实动作稍后接入。",
+      "cancel-recurring": "取消整个重复事项的真实动作稍后接入。",
+      complete: "标记完成的真实动作稍后接入。",
+      delete: "删除记录的真实动作稍后接入。",
+      edit: "编辑能力稍后接入。",
+      "move-upcoming": "提前到近期要做的真实动作稍后接入。",
+      "open-resource": "当前先展示相关资料入口，后续再接稳定的打开能力。",
+      restore: "恢复为未完成的真实动作稍后接入。",
+      "skip-once": "跳过本次的真实动作稍后接入。",
+      "toggle-recurring": "重复规则开关的真实动作稍后接入。",
+    };
+
+    showFeedback(placeholders[action]);
+  }
+
+  useEffect(() => {
+    const allItems = [...upcomingItems, ...laterItems, ...recurringItems, ...closedItems];
+    if (allItems.length === 0) {
+      return;
+    }
+
+    const selectedExists = selectedItemId ? allItems.some((entry) => entry.item.item_id === selectedItemId) : false;
+    if (selectedExists) {
+      return;
+    }
+
+    const nextItem = upcomingItems[0] ?? laterItems[0] ?? recurringItems[0] ?? closedItems[0];
+    if (nextItem) {
+      setSelectedItemId(nextItem.item.item_id);
+    }
+  }, [closedItems, laterItems, recurringItems, selectedItemId, upcomingItems]);
+
+  useEffect(() => {
+    return () => {
+      if (feedbackTimeoutRef.current) {
+        window.clearTimeout(feedbackTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  if (notesQuery.isLoading && !notesQuery.data) {
+    return (
+      <main className="dashboard-page note-preview-page">
+        <div className="note-preview-page__frame">
+          <div className="note-preview-page__header note-preview-page__header--loading" />
+          <div className="note-preview-page__grid note-preview-page__grid--loading" />
+        </div>
+      </main>
+    );
+  }
+
+  if (!notesQuery.data || [upcomingItems, laterItems, recurringItems, closedItems].every((items) => items.length === 0)) {
+    return (
+      <main className="dashboard-page note-preview-page" style={pageStyle}>
+        <div className="note-preview-page__frame">
+          <NoteEmptyState />
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="dashboard-page note-preview-page" style={pageStyle}>
+      <header className="dashboard-page__topbar">
+        <Link className="dashboard-page__home-link" to="/">
+          <ArrowLeft className="h-4 w-4" />
+          返回首页
+        </Link>
+
+        <nav aria-label="Dashboard modules" className="dashboard-page__module-nav">
+          {dashboardModules.map((item) => (
+            <NavLink key={item.route} className={({ isActive }) => cn("dashboard-page__module-link", isActive && "is-active")} to={item.path}>
+              {item.title}
+            </NavLink>
+          ))}
+        </nav>
+      </header>
+
+      <section className="dashboard-page__hero">
+        <div className="dashboard-page__hero-copy">
+          <p className="dashboard-page__eyebrow">Notepad Collaboration</p>
+          <div className="dashboard-page__title-row">
+            <NotebookPen className="dashboard-page__title-icon" />
+            <h1>便签</h1>
+          </div>
+          <p className="dashboard-page__description">便签协作负责整理未来安排、重复规则与尚未开始但需要记住的事情。正式进入执行后，再转交给 Agent 生成任务。</p>
+        </div>
+
+        <div className="dashboard-card dashboard-card--status note-preview-page__hero-status">
+          <p className="dashboard-card__kicker">今日摘要</p>
+          <div className="note-preview-page__summary-grid">
+            <div className="note-preview-page__summary-item">
+              <span>今天待处理</span>
+              <strong>{summary.dueToday}</strong>
+            </div>
+            <div className="note-preview-page__summary-item">
+              <span>已逾期</span>
+              <strong>{summary.overdue}</strong>
+            </div>
+            <div className="note-preview-page__summary-item">
+              <span>重复事项今日落地</span>
+              <strong>{summary.recurringToday}</strong>
+            </div>
+            <div className="note-preview-page__summary-item">
+              <span>适合交给 Agent</span>
+              <strong>{summary.readyForAgent}</strong>
+            </div>
+          </div>
+          {selectedItem ? (
+            <div className="dashboard-card__status-row">
+              <CircleDashed className="h-4 w-4" />
+              <span>{selectedItem.item.title} · {describeNotePreview(selectedItem.item, selectedItem.experience)}</span>
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="dashboard-page__grid note-preview-page__grid">
+        <NotePreviewSection
+          activeItemId={selectedItem?.item.item_id ?? null}
+          description="快到时间、今天要做、最近几天需要处理的事项。"
+          items={upcomingItems}
+          onSelect={(itemId) => {
+            setSelectedItemId(itemId);
+            setDetailOpen(true);
+          }}
+          title="近期要做"
+          trailing={<span className="note-preview-shell__count">{upcomingItems.length}</span>}
+        />
+
+        <NotePreviewSection
+          activeItemId={selectedItem?.item.item_id ?? null}
+          description="已经记下，但还没到处理窗口的事项。"
+          items={laterItems}
+          onSelect={(itemId) => {
+            setSelectedItemId(itemId);
+            setDetailOpen(true);
+          }}
+          title="后续安排"
+          trailing={<span className="note-preview-shell__count">{laterItems.length}</span>}
+        />
+
+        <NotePreviewSection
+          activeItemId={selectedItem?.item.item_id ?? null}
+          description="展示规则本身，而不是某一次实例。"
+          items={recurringItems}
+          onSelect={(itemId) => {
+            setSelectedItemId(itemId);
+            setDetailOpen(true);
+          }}
+          title="重复事项"
+          trailing={<span className="note-preview-shell__count">{recurringItems.length}</span>}
+        />
+
+        <article className="dashboard-card note-preview-shell">
+          <div className="note-preview-shell__header">
+            <div>
+              <p className="dashboard-card__kicker">已结束</p>
+              <p className="note-preview-shell__description">默认展示近 3 天，可展开到近 7 天与更多。</p>
+            </div>
+            <button className="note-preview-shell__toggle" onClick={() => setShowMoreClosed((current) => !current)} type="button">
+              {showMoreClosed ? "收起" : "更多"}
+            </button>
+          </div>
+          <div className="note-preview-finished-groups">
+            {closedGroups.map((group) => (
+              <section key={group.key} className="note-preview-finished-group">
+                <div>
+                  <p className="note-preview-finished-group__title">{group.title}</p>
+                  <p className="note-preview-finished-group__description">{group.description}</p>
+                </div>
+                <div className="note-preview-shell__list">
+                  {group.items.map((entry) => (
+                    <NotePreviewCard
+                      key={entry.item.item_id}
+                      isActive={entry.item.item_id === selectedItem?.item.item_id}
+                      item={entry}
+                      onSelect={(itemId: string) => {
+                        setSelectedItemId(itemId);
+                        setDetailOpen(true);
+                      }}
+                    />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </article>
+      </section>
+
+      <AnimatePresence>
+        {detailOpen && selectedItem ? (
+          <>
+            <motion.button
+              animate={{ opacity: 1 }}
+              className="note-detail-modal__backdrop"
+              exit={{ opacity: 0 }}
+              initial={{ opacity: 0 }}
+              onClick={() => setDetailOpen(false)}
+              type="button"
+            />
+            <motion.div
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              className="note-detail-modal"
+              exit={{ opacity: 0, scale: 0.98, y: 20 }}
+              initial={{ opacity: 0, scale: 0.98, y: 16 }}
+              transition={{ duration: 0.28, ease: [0.22, 1, 0.36, 1] }}
+            >
+              <NoteDetailPanel feedback={feedback} item={selectedItem} onAction={handleDetailAction} onClose={() => setDetailOpen(false)} />
+            </motion.div>
+          </>
+        ) : null}
+      </AnimatePresence>
+    </main>
+  );
+}

--- a/apps/desktop/src/features/dashboard/notes/NotesPage.tsx
+++ b/apps/desktop/src/features/dashboard/notes/NotesPage.tsx
@@ -1,5 +1,5 @@
-import { DashboardPlaceholderPage } from "@/features/dashboard/shared/DashboardPlaceholderPage";
+import { NotePage } from "./NotePage";
 
 export function NotesPage() {
-  return <DashboardPlaceholderPage route="notes" />;
+  return <NotePage />;
 }

--- a/apps/desktop/src/features/dashboard/notes/components/NoteActionBar.tsx
+++ b/apps/desktop/src/features/dashboard/notes/components/NoteActionBar.tsx
@@ -1,0 +1,86 @@
+import type { ComponentType } from "react";
+import { ArrowUpRight, CalendarClock, CheckCircle2, Clock3, Pencil, Repeat, RotateCcw, Trash2, WandSparkles, XCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { NoteDetailAction, NoteListItem } from "../notePage.types";
+
+type NoteActionBarProps = {
+  item: NoteListItem;
+  onAction: (action: NoteDetailAction) => void;
+};
+
+const actionIcons: Record<NoteDetailAction, ComponentType<{ className?: string }>> = {
+  cancel: XCircle,
+  "cancel-recurring": XCircle,
+  complete: CheckCircle2,
+  "convert-to-task": WandSparkles,
+  delete: Trash2,
+  edit: Pencil,
+  "move-upcoming": CalendarClock,
+  "open-resource": ArrowUpRight,
+  restore: RotateCcw,
+  "skip-once": Clock3,
+  "toggle-recurring": Repeat,
+};
+
+function getActions(item: NoteListItem) {
+  if (item.item.bucket === "upcoming") {
+    return [
+      { action: "complete" as const, label: "标记完成", tooltip: "把这条事项标记为已完成。" },
+      { action: "cancel" as const, label: "取消/跳过", tooltip: "取消或跳过本次事项。" },
+      { action: "edit" as const, label: "编辑", tooltip: "编辑能力稍后接入。" },
+      { action: "open-resource" as const, label: "相关资料", tooltip: "先展示资料入口，暂不直接打开。" },
+      ...(item.experience.canConvertToTask ? [{ action: "convert-to-task" as const, label: "转交给 Agent", tooltip: "确认后会直接生成任务并跳转到任务页。" }] : []),
+    ];
+  }
+
+  if (item.item.bucket === "later") {
+    return [
+      { action: "move-upcoming" as const, label: "提前到近期", tooltip: "将这条事项提前到近期要做。" },
+      { action: "edit" as const, label: "编辑", tooltip: "编辑能力稍后接入。" },
+      { action: "cancel" as const, label: "取消", tooltip: "取消这条后续安排。" },
+      { action: "open-resource" as const, label: "相关资料", tooltip: "先展示资料入口，暂不直接打开。" },
+      ...(item.experience.canConvertToTask ? [{ action: "convert-to-task" as const, label: "转交给 Agent", tooltip: "确认后会直接生成任务并跳转到任务页。" }] : []),
+    ];
+  }
+
+  if (item.item.bucket === "recurring_rule") {
+    return [
+      { action: "toggle-recurring" as const, label: item.experience.isRecurringEnabled ? "暂停重复" : "开启重复", tooltip: "开关重复规则的真实动作稍后接入。" },
+      { action: "edit" as const, label: "修改规则", tooltip: "规则编辑能力稍后接入。" },
+      { action: "cancel-recurring" as const, label: "取消规则", tooltip: "取消整个重复事项。" },
+      { action: "open-resource" as const, label: "相关资料", tooltip: "先展示资料入口，暂不直接打开。" },
+    ];
+  }
+
+  return [
+    { action: "restore" as const, label: "恢复未完成", tooltip: "把这条事项恢复到未完成列表。" },
+    { action: "delete" as const, label: "删除记录", tooltip: "删除记录能力稍后接入。" },
+    { action: "open-resource" as const, label: "相关资料", tooltip: "先展示资料入口，暂不直接打开。" },
+    ...(item.experience.canConvertToTask ? [{ action: "convert-to-task" as const, label: "转交给 Agent", tooltip: "确认后会直接生成任务并跳转到任务页。" }] : []),
+  ];
+}
+
+export function NoteActionBar({ item, onAction }: NoteActionBarProps) {
+  const actions = getActions(item);
+
+  return (
+    <div className="note-detail-actions">
+      {actions.map((action) => {
+        const Icon = actionIcons[action.action];
+
+        return (
+          <Tooltip key={action.label}>
+            <TooltipTrigger>
+              <Button className="note-detail-actions__button" onClick={() => onAction(action.action)} variant="ghost">
+                <Icon className="h-4 w-4" />
+                {action.label}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent className="rounded-full bg-slate-900/90 px-3 py-1.5 text-[0.72rem] text-white">{action.tooltip}</TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/dashboard/notes/components/NoteDetailPanel.tsx
+++ b/apps/desktop/src/features/dashboard/notes/components/NoteDetailPanel.tsx
@@ -1,0 +1,199 @@
+import { AnimatePresence, motion } from "motion/react";
+import { CalendarClock, FolderOpen, Repeat, Sparkles, X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/utils/cn";
+import { formatTimestamp } from "@/utils/formatters";
+import { getNoteBucketLabel, getNoteStatusBadgeClass } from "../notePage.mapper";
+import type { NoteDetailAction, NoteListItem } from "../notePage.types";
+import { NoteActionBar } from "./NoteActionBar";
+
+type NoteDetailPanelProps = {
+  feedback: string | null;
+  item: NoteListItem;
+  onAction: (action: NoteDetailAction) => void;
+  onClose: () => void;
+};
+
+export function NoteDetailPanel({ feedback, item, onAction, onClose }: NoteDetailPanelProps) {
+  const { experience } = item;
+
+  return (
+    <motion.section animate={{ opacity: 1, x: 0 }} className="note-detail-shell" initial={{ opacity: 0, x: 18 }} transition={{ duration: 0.26, ease: [0.22, 1, 0.36, 1] }}>
+      <div className="note-detail-shell__header">
+        <div>
+          <p className="note-detail-shell__eyebrow">便签详情</p>
+          <h2 className="note-detail-shell__title">{item.item.title}</h2>
+          <p className="note-detail-shell__subtitle">{experience.agentSuggestion.detail}</p>
+        </div>
+
+        <div className="note-detail-shell__status-wrap">
+          <Button className="note-detail-shell__close" onClick={onClose} size="icon-sm" variant="ghost">
+            <X className="h-4 w-4" />
+            <span className="sr-only">关闭便签详情</span>
+          </Button>
+          <Badge className={cn("border-0 px-3 py-1 text-[0.74rem] ring-1", getNoteStatusBadgeClass(item.item.status))}>{experience.detailStatus}</Badge>
+          {feedback ? <span className="note-detail-shell__feedback">{feedback}</span> : null}
+        </div>
+      </div>
+
+      <div className="note-detail-shell__meta-grid">
+        <div className="note-detail-shell__meta-card">
+          <span>分类</span>
+          <strong>{getNoteBucketLabel(item.item.bucket)}</strong>
+        </div>
+        <div className="note-detail-shell__meta-card">
+          <span>事项类型</span>
+          <strong>{experience.typeLabel}</strong>
+        </div>
+        <div className="note-detail-shell__meta-card">
+          <span>时间信息</span>
+          <strong>{experience.timeHint}</strong>
+        </div>
+        <div className="note-detail-shell__meta-card">
+          <span>Agent 建议</span>
+          <strong>{experience.agentSuggestion.label}</strong>
+        </div>
+      </div>
+
+      <ScrollArea className="note-detail-shell__scroll">
+        <div className="note-detail-shell__body">
+          <section className="note-detail-card note-detail-card--spotlight">
+            <div className="note-detail-card__header">
+              <p className="note-detail-card__eyebrow">备注</p>
+              <h3 className="note-detail-card__title">这条事项的背景与说明</h3>
+            </div>
+            <p className="note-detail-card__copy">{experience.noteText}</p>
+          </section>
+
+          <div className="note-detail-grid">
+            <section className="note-detail-card">
+              <div className="note-detail-card__header">
+                <p className="note-detail-card__eyebrow">时间</p>
+                <h3 className="note-detail-card__title">时间与状态</h3>
+              </div>
+              <div className="note-detail-list">
+                {experience.plannedAt ? (
+                  <article className="note-detail-list__item">
+                    <CalendarClock className="h-4 w-4" />
+                    <div>
+                      <p className="note-detail-list__label">计划时间</p>
+                      <p className="note-detail-list__value">{formatTimestamp(experience.plannedAt)}</p>
+                    </div>
+                  </article>
+                ) : null}
+
+                {experience.nextOccurrenceAt ? (
+                  <article className="note-detail-list__item">
+                    <Repeat className="h-4 w-4" />
+                    <div>
+                      <p className="note-detail-list__label">下次发生</p>
+                      <p className="note-detail-list__value">{formatTimestamp(experience.nextOccurrenceAt)}</p>
+                    </div>
+                  </article>
+                ) : null}
+
+                {experience.endedAt ? (
+                  <article className="note-detail-list__item">
+                    <CalendarClock className="h-4 w-4" />
+                    <div>
+                      <p className="note-detail-list__label">结束时间</p>
+                      <p className="note-detail-list__value">{formatTimestamp(experience.endedAt)}</p>
+                    </div>
+                  </article>
+                ) : null}
+
+                <article className="note-detail-list__item">
+                  <Sparkles className="h-4 w-4" />
+                  <div>
+                    <p className="note-detail-list__label">状态说明</p>
+                    <p className="note-detail-list__value">{experience.detailStatus}</p>
+                  </div>
+                </article>
+              </div>
+            </section>
+
+            <section className="note-detail-card">
+              <div className="note-detail-card__header">
+                <p className="note-detail-card__eyebrow">条件与规则</p>
+                <h3 className="note-detail-card__title">前置条件和重复范围</h3>
+              </div>
+              <div className="note-detail-list">
+                {experience.prerequisite ? (
+                  <article className="note-detail-list__item">
+                    <Sparkles className="h-4 w-4" />
+                    <div>
+                      <p className="note-detail-list__label">前置条件</p>
+                      <p className="note-detail-list__value">{experience.prerequisite}</p>
+                    </div>
+                  </article>
+                ) : null}
+                {experience.repeatRule ? (
+                  <article className="note-detail-list__item">
+                    <Repeat className="h-4 w-4" />
+                    <div>
+                      <p className="note-detail-list__label">重复规则</p>
+                      <p className="note-detail-list__value">{experience.repeatRule}</p>
+                    </div>
+                  </article>
+                ) : null}
+                {experience.recentInstanceStatus ? (
+                  <article className="note-detail-list__item">
+                    <Repeat className="h-4 w-4" />
+                    <div>
+                      <p className="note-detail-list__label">最近一次状态</p>
+                      <p className="note-detail-list__value">{experience.recentInstanceStatus}</p>
+                    </div>
+                  </article>
+                ) : null}
+                {experience.effectiveScope ? (
+                  <article className="note-detail-list__item">
+                    <Repeat className="h-4 w-4" />
+                    <div>
+                      <p className="note-detail-list__label">生效范围</p>
+                      <p className="note-detail-list__value">{experience.effectiveScope}</p>
+                    </div>
+                  </article>
+                ) : null}
+              </div>
+            </section>
+          </div>
+
+          <section className="note-detail-card">
+            <div className="note-detail-card__header">
+              <p className="note-detail-card__eyebrow">Agent 建议</p>
+              <h3 className="note-detail-card__title">下一步怎么做更合适</h3>
+            </div>
+            <p className="note-detail-card__copy">{experience.agentSuggestion.detail}</p>
+          </section>
+
+          <section className="note-detail-card">
+            <div className="note-detail-card__header">
+              <p className="note-detail-card__eyebrow">相关资料</p>
+              <h3 className="note-detail-card__title">当前事项关联的入口</h3>
+            </div>
+            <div className="note-detail-resource-list">
+              {experience.relatedResources.length > 0 ? (
+                experience.relatedResources.map((resource) => (
+                  <article key={resource.id} className="note-detail-resource-item">
+                    <FolderOpen className="h-4 w-4" />
+                    <div>
+                      <p className="note-detail-resource-item__title">{resource.label}</p>
+                      <p className="note-detail-resource-item__meta">{resource.type}</p>
+                      <p className="note-detail-resource-item__path">{resource.path}</p>
+                    </div>
+                  </article>
+                ))
+              ) : (
+                <p className="note-detail-card__copy">当前没有挂载相关资料，后续可以补充到这里。</p>
+              )}
+            </div>
+          </section>
+        </div>
+      </ScrollArea>
+
+      <NoteActionBar item={item} onAction={onAction} />
+    </motion.section>
+  );
+}

--- a/apps/desktop/src/features/dashboard/notes/components/NoteEmptyState.tsx
+++ b/apps/desktop/src/features/dashboard/notes/components/NoteEmptyState.tsx
@@ -1,0 +1,9 @@
+export function NoteEmptyState() {
+  return (
+    <div className="note-empty-state">
+      <p className="note-empty-state__eyebrow">暂无便签</p>
+      <h2 className="note-empty-state__title">这里还没有可协作的事项</h2>
+      <p className="note-empty-state__copy">等你把想记住的事情交给便签协作后，这里会按近期要做、后续安排、重复事项和已结束四组方式整理出来。</p>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/dashboard/notes/components/NotePreviewCard.tsx
+++ b/apps/desktop/src/features/dashboard/notes/components/NotePreviewCard.tsx
@@ -1,0 +1,36 @@
+import { motion } from "motion/react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/utils/cn";
+import { describeNotePreview, getNoteStatusBadgeClass } from "../notePage.mapper";
+import type { NoteListItem } from "../notePage.types";
+
+type NotePreviewCardProps = {
+  isActive: boolean;
+  item: NoteListItem;
+  onSelect: (itemId: string) => void;
+};
+
+export function NotePreviewCard({ isActive, item, onSelect }: NotePreviewCardProps) {
+  return (
+    <motion.button
+      className={cn("note-preview-card", isActive && "note-preview-card--active", item.item.bucket === "closed" && "note-preview-card--closed")}
+      onClick={() => onSelect(item.item.item_id)}
+      type="button"
+      whileHover={{ y: -2 }}
+      whileTap={{ scale: 0.995 }}
+    >
+      <div className="note-preview-card__top">
+        <div>
+          <h3 className="note-preview-card__title">{item.item.title}</h3>
+          <p className="note-preview-card__subtitle">{describeNotePreview(item.item, item.experience)}</p>
+        </div>
+        <Badge className={cn("border-0 px-3 py-1 text-[0.72rem] ring-1", getNoteStatusBadgeClass(item.item.status))}>{item.experience.previewStatus}</Badge>
+      </div>
+      <div className="note-preview-card__footer">
+        <span>{item.experience.typeLabel}</span>
+        <span>{item.experience.summaryLabel}</span>
+      </div>
+      {item.item.agent_suggestion ? <p className="note-preview-card__suggestion">{item.item.agent_suggestion}</p> : null}
+    </motion.button>
+  );
+}

--- a/apps/desktop/src/features/dashboard/notes/components/NotePreviewSection.tsx
+++ b/apps/desktop/src/features/dashboard/notes/components/NotePreviewSection.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import type { NoteListItem } from "../notePage.types";
+import { NotePreviewCard } from "./NotePreviewCard";
+
+type NotePreviewSectionProps = {
+  activeItemId: string | null;
+  description: string;
+  items: NoteListItem[];
+  onSelect: (itemId: string) => void;
+  title: string;
+  trailing?: ReactNode;
+  variant?: "default" | "hint";
+};
+
+export function NotePreviewSection({ activeItemId, description, items, onSelect, title, trailing, variant = "default" }: NotePreviewSectionProps) {
+  return (
+    <article className={cn("dashboard-card note-preview-shell", variant === "hint" && "note-preview-shell--hint")}>
+      <div className="note-preview-shell__header">
+        <div>
+          <p className="dashboard-card__kicker">{title}</p>
+          <p className="note-preview-shell__description">{description}</p>
+        </div>
+        {trailing}
+      </div>
+
+      <div className="note-preview-shell__list">
+        {items.map((item) => (
+          <NotePreviewCard key={item.item.item_id} isActive={item.item.item_id === activeItemId} item={item} onSelect={onSelect} />
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/apps/desktop/src/features/dashboard/notes/notePage.css
+++ b/apps/desktop/src/features/dashboard/notes/notePage.css
@@ -1,0 +1,485 @@
+.note-preview-page {
+  --note-accent-soft: color-mix(in srgb, var(--note-accent, #f4b183) 16%, rgba(255, 255, 255, 0.82));
+  --note-accent-strong: color-mix(in srgb, var(--note-accent, #f4b183) 62%, #8a6843);
+  background:
+    radial-gradient(circle at 14% 16%, rgba(255, 255, 255, 0.84), transparent 24%),
+    radial-gradient(circle at 84% 10%, rgba(246, 220, 211, 0.4), transparent 20%),
+    radial-gradient(circle at 78% 24%, color-mix(in srgb, var(--note-accent, #f4b183) 12%, rgba(255, 255, 255, 0.18)) 0%, transparent 18%),
+    linear-gradient(180deg, #fbf6ef 0%, #f4ece2 56%, #ece5db 100%);
+  min-height: 100vh;
+  overflow: hidden;
+  padding: 0;
+  position: relative;
+}
+
+.app-shell.note-preview-page {
+  padding: 0;
+}
+
+.note-preview-page__frame {
+  display: grid;
+  gap: 1rem;
+  height: 100vh;
+  margin: 0 auto;
+  max-width: 1560px;
+  overflow: hidden;
+  padding: clamp(1rem, 2vw, 1.5rem);
+}
+
+.note-preview-page .dashboard-page__topbar,
+.note-preview-page .dashboard-page__hero,
+.note-preview-page .dashboard-page__grid {
+  position: relative;
+  z-index: 2;
+}
+
+.note-preview-page .dashboard-page__home-link,
+.note-preview-page .dashboard-page__module-link {
+  background: color-mix(in srgb, var(--note-paper-strong, rgba(255, 247, 238, 0.9)) 88%, var(--note-accent, #f4b183) 12%);
+  border: 1px solid color-mix(in srgb, var(--note-line, rgba(156, 133, 113, 0.18)) 76%, var(--note-accent, #f4b183) 24%);
+  color: var(--note-ink, #5f544b);
+}
+
+.note-preview-page .dashboard-page__home-link:hover,
+.note-preview-page .dashboard-page__module-link:hover,
+.note-preview-page .dashboard-page__module-link.is-active {
+  background: color-mix(in srgb, var(--note-paper-strong, rgba(255, 247, 238, 0.9)) 78%, var(--note-accent, #f4b183) 22%);
+  border-color: color-mix(in srgb, var(--note-accent, #f4b183) 36%, rgba(194, 174, 154, 0.42));
+}
+
+.note-preview-page .dashboard-page__hero-copy,
+.note-preview-page .dashboard-card,
+.note-detail-shell,
+.note-empty-state {
+  backdrop-filter: blur(14px);
+  background:
+    linear-gradient(180deg, rgba(255, 253, 249, 0.92), rgba(247, 240, 231, 0.86)),
+    var(--note-paper, rgba(255, 251, 245, 0.8));
+  border: 1px solid color-mix(in srgb, var(--note-line, rgba(156, 133, 113, 0.18)) 74%, var(--note-accent, #f4b183) 26%);
+  box-shadow: 0 24px 60px -46px rgba(120, 108, 95, 0.12);
+}
+
+.note-preview-page .dashboard-page__title-row h1,
+.note-preview-page .dashboard-page__description,
+.note-preview-page .dashboard-card p,
+.note-preview-page .dashboard-card li,
+.note-preview-page .dashboard-card span,
+.note-preview-page .dashboard-card__kicker {
+  color: var(--note-ink, #5f544b);
+}
+
+.note-preview-page .dashboard-page__title-icon {
+  color: var(--note-accent-strong);
+}
+
+.note-preview-page .dashboard-card__list li {
+  background: color-mix(in srgb, var(--note-paper-strong, rgba(255, 247, 238, 0.9)) 82%, var(--note-accent, #f4b183) 18%);
+}
+
+.note-preview-page__hero-status {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.note-preview-page__summary-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.note-preview-page__summary-item {
+  background: color-mix(in srgb, var(--note-paper, rgba(255, 251, 245, 0.8)) 84%, var(--note-accent, #f4b183) 16%);
+  border-radius: 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.85rem 0.95rem;
+}
+
+.note-preview-page__summary-item span {
+  color: var(--note-copy, rgba(95, 84, 75, 0.68));
+  font-size: 0.74rem;
+}
+
+.note-preview-page__summary-item strong {
+  color: var(--note-ink, #5f544b);
+  font-size: 1.14rem;
+  letter-spacing: -0.04em;
+}
+
+.note-preview-page__grid {
+  align-items: stretch;
+  margin-top: 1.5rem;
+}
+
+.note-preview-page__grid .dashboard-card {
+  display: flex;
+  flex-direction: column;
+  height: 30rem;
+  min-height: 30rem;
+  overflow: hidden;
+}
+
+.note-preview-shell__header {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.8rem;
+  justify-content: space-between;
+}
+
+.note-preview-shell__description,
+.note-preview-finished-group__description {
+  color: var(--note-copy, rgba(95, 84, 75, 0.68));
+  font-size: 0.82rem;
+  line-height: 1.55;
+  margin: 0.12rem 0 0;
+}
+
+.note-preview-shell__count {
+  align-items: center;
+  background: color-mix(in srgb, var(--note-paper-strong, rgba(255, 247, 238, 0.9)) 82%, var(--note-accent, #f4b183) 18%);
+  border-radius: 999px;
+  color: var(--note-ink, #5f544b);
+  display: inline-flex;
+  font-size: 0.82rem;
+  font-weight: 700;
+  justify-content: center;
+  min-width: 2.1rem;
+  padding: 0.42rem 0.75rem;
+}
+
+.note-preview-shell__toggle,
+.note-detail-actions__button {
+  background: color-mix(in srgb, var(--note-paper, rgba(255, 251, 245, 0.8)) 82%, var(--note-accent, #f4b183) 18%);
+  border: 1px solid color-mix(in srgb, var(--note-line, rgba(156, 133, 113, 0.18)) 76%, var(--note-accent, #f4b183) 24%);
+  border-radius: 999px;
+  box-shadow: 0 14px 30px -24px rgba(120, 108, 95, 0.12);
+  color: var(--note-ink, #5f544b);
+}
+
+.note-preview-shell__list,
+.note-preview-finished-groups,
+.note-detail-shell__scroll {
+  min-height: 0;
+  overflow: auto;
+  padding-right: 0.3rem;
+  scrollbar-color: color-mix(in srgb, var(--note-accent, #f4b183) 30%, rgba(156, 133, 113, 0.22)) transparent;
+  scrollbar-width: thin;
+}
+
+.note-preview-shell__list,
+.note-preview-finished-groups,
+.note-detail-list,
+.note-detail-resource-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.note-preview-shell__list::-webkit-scrollbar,
+.note-preview-finished-groups::-webkit-scrollbar,
+.note-detail-shell__scroll::-webkit-scrollbar {
+  width: 8px;
+}
+
+.note-preview-shell__list::-webkit-scrollbar-track,
+.note-preview-finished-groups::-webkit-scrollbar-track,
+.note-detail-shell__scroll::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+}
+
+.note-preview-shell__list::-webkit-scrollbar-thumb,
+.note-preview-finished-groups::-webkit-scrollbar-thumb,
+.note-detail-shell__scroll::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--note-accent, #f4b183) 28%, rgba(156, 133, 113, 0.22));
+  border-radius: 999px;
+}
+
+.note-preview-card {
+  background:
+    linear-gradient(180deg, rgba(255, 252, 247, 0.9), rgba(246, 239, 231, 0.86)),
+    color-mix(in srgb, var(--note-paper, rgba(255, 251, 245, 0.8)) 88%, var(--note-accent, #f4b183) 12%);
+  border: 1px solid color-mix(in srgb, var(--note-line, rgba(156, 133, 113, 0.18)) 76%, var(--note-accent, #f4b183) 24%);
+  border-radius: 1.45rem;
+  display: grid;
+  gap: 0.7rem;
+  padding: 0.95rem;
+  text-align: left;
+}
+
+.note-preview-card--active {
+  border-color: color-mix(in srgb, var(--note-accent, #f4b183) 36%, rgba(194, 174, 154, 0.42));
+  box-shadow: 0 18px 36px -28px color-mix(in srgb, var(--note-accent, #f4b183) 18%, rgba(120, 108, 95, 0.12));
+}
+
+.note-preview-card--closed {
+  background:
+    linear-gradient(180deg, rgba(251, 246, 239, 0.84), rgba(244, 236, 227, 0.8)),
+    color-mix(in srgb, var(--note-paper, rgba(255, 251, 245, 0.8)) 94%, var(--note-accent, #f4b183) 6%);
+}
+
+.note-preview-card__top {
+  display: flex;
+  gap: 0.8rem;
+  justify-content: space-between;
+}
+
+.note-preview-card__title,
+.note-detail-shell__title,
+.note-detail-card__title,
+.note-detail-list__value,
+.note-detail-resource-item__title,
+.note-empty-state__title {
+  color: var(--note-ink, #5f544b);
+}
+
+.note-preview-card__title {
+  font-size: 0.98rem;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.35;
+  margin: 0;
+}
+
+.note-preview-card__subtitle,
+.note-empty-state__copy,
+.note-detail-shell__subtitle,
+.note-detail-card__copy,
+.note-detail-list__label,
+.note-detail-resource-item__meta,
+.note-detail-resource-item__path,
+.note-preview-card__footer,
+.note-empty-state__eyebrow,
+.note-detail-shell__eyebrow,
+.note-detail-card__eyebrow {
+  color: var(--note-copy, rgba(95, 84, 75, 0.68));
+}
+
+.note-preview-card__subtitle,
+.note-preview-card__suggestion {
+  font-size: 0.84rem;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.note-preview-card__footer {
+  display: flex;
+  font-size: 0.78rem;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.note-preview-card__suggestion {
+  border-top: 1px dashed color-mix(in srgb, var(--note-line, rgba(156, 133, 113, 0.18)) 64%, var(--note-accent, #f4b183) 36%);
+  padding-top: 0.7rem;
+}
+
+.note-preview-finished-group__title {
+  color: var(--note-ink, #5f544b);
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.note-detail-modal__backdrop {
+  background: rgba(189, 185, 178, 0.3);
+  border: 0;
+  inset: 0;
+  position: fixed;
+  z-index: 60;
+}
+
+.note-detail-modal {
+  inset: clamp(1rem, 3vw, 2rem);
+  position: fixed;
+  z-index: 70;
+}
+
+.note-detail-shell {
+  display: grid;
+  gap: 1rem;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  height: 100%;
+  margin: 0 auto;
+  max-width: 1080px;
+  padding: 1.2rem;
+}
+
+.note-detail-shell__header {
+  align-items: start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.note-detail-shell__status-wrap {
+  align-items: end;
+  display: grid;
+  gap: 0.65rem;
+  justify-items: end;
+}
+
+.note-detail-shell__close {
+  background: color-mix(in srgb, var(--note-paper-strong, rgba(255, 247, 238, 0.9)) 86%, var(--note-accent, #f4b183) 14%);
+  border: 1px solid color-mix(in srgb, var(--note-line, rgba(156, 133, 113, 0.18)) 74%, var(--note-accent, #f4b183) 26%);
+  border-radius: 999px;
+}
+
+.note-detail-shell__feedback {
+  background: rgba(255, 244, 236, 0.9);
+  border: 1px solid rgba(244, 194, 153, 0.6);
+  border-radius: 999px;
+  color: #b66b2b;
+  display: inline-flex;
+  font-size: 0.76rem;
+  padding: 0.45rem 0.8rem;
+}
+
+.note-detail-shell__meta-grid,
+.note-detail-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.note-detail-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.note-detail-shell__meta-card,
+.note-detail-card,
+.note-detail-list__item,
+.note-detail-resource-item,
+.note-empty-state {
+  background:
+    linear-gradient(180deg, rgba(255, 252, 247, 0.9), rgba(246, 239, 231, 0.86)),
+    color-mix(in srgb, var(--note-paper, rgba(255, 251, 245, 0.8)) 90%, var(--note-accent, #f4b183) 10%);
+  border: 1px solid color-mix(in srgb, var(--note-line, rgba(156, 133, 113, 0.18)) 76%, var(--note-accent, #f4b183) 24%);
+  border-radius: 1.3rem;
+}
+
+.note-detail-shell__meta-card {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.82rem 0.92rem;
+}
+
+.note-detail-shell__meta-card span {
+  color: var(--note-copy, rgba(95, 84, 75, 0.68));
+  font-size: 0.75rem;
+}
+
+.note-detail-shell__meta-card strong {
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.note-detail-shell__scroll {
+  min-height: 0;
+}
+
+.note-detail-shell__body {
+  display: grid;
+  gap: 1rem;
+  padding-right: 0.25rem;
+}
+
+.note-detail-card {
+  padding: 1rem;
+}
+
+.note-detail-card--spotlight {
+  background:
+    linear-gradient(180deg, rgba(255, 249, 242, 0.92), rgba(245, 239, 231, 0.88)),
+    color-mix(in srgb, var(--note-paper, rgba(255, 251, 245, 0.8)) 82%, var(--note-accent, #f4b183) 18%);
+}
+
+.note-detail-card__header {
+  margin-bottom: 0.85rem;
+}
+
+.note-detail-card__copy,
+.note-empty-state__copy {
+  line-height: 1.65;
+  margin: 0;
+}
+
+.note-detail-list__item,
+.note-detail-resource-item {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+}
+
+.note-detail-list__label,
+.note-detail-resource-item__meta,
+.note-detail-resource-item__path {
+  font-size: 0.8rem;
+  line-height: 1.55;
+  margin: 0.18rem 0 0;
+}
+
+.note-detail-list__value,
+.note-detail-resource-item__title,
+.note-empty-state__title {
+  font-size: 0.96rem;
+  font-weight: 600;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.note-detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.note-empty-state {
+  display: grid;
+  gap: 0.65rem;
+  max-width: 34rem;
+  padding: 1.4rem;
+}
+
+.note-preview-page__header--loading,
+.note-preview-page__grid--loading {
+  animation: notePulse 1.6s ease-in-out infinite;
+}
+
+@keyframes notePulse {
+  0%, 100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.55;
+  }
+}
+
+@media (max-width: 1180px) {
+  .note-preview-page__summary-grid,
+  .note-detail-shell__meta-grid,
+  .note-detail-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .note-detail-modal {
+    inset: 1rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .note-preview-page__frame {
+    padding: 0.9rem;
+  }
+
+  .note-preview-page__summary-grid,
+  .note-detail-shell__meta-grid,
+  .note-detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .note-detail-modal {
+    inset: 0.75rem;
+  }
+}

--- a/apps/desktop/src/features/dashboard/notes/notePage.mapper.ts
+++ b/apps/desktop/src/features/dashboard/notes/notePage.mapper.ts
@@ -1,0 +1,123 @@
+import type { TodoBucket, TodoItem, TodoStatus } from "@cialloclaw/protocol";
+import { formatTimestamp } from "@/utils/formatters";
+import type { NoteDetailExperience, NoteListItem, NotePreviewGroupKey, NoteSummary } from "./notePage.types";
+
+export function getNoteBucketLabel(bucket: TodoBucket) {
+  const labels: Record<TodoBucket, string> = {
+    closed: "已结束",
+    later: "后续安排",
+    recurring_rule: "重复事项",
+    upcoming: "近期要做",
+  };
+
+  return labels[bucket];
+}
+
+export function getNoteStatusBadgeClass(status: TodoStatus) {
+  const classes: Record<TodoStatus, string> = {
+    normal: "bg-[#EAD7C2]/70 text-[#875D39] ring-[#E2C4A6]/70",
+    due_today: "bg-[#F4D2B0]/72 text-[#8A5A22] ring-[#E9B883]/72",
+    overdue: "bg-[#F0C7BE]/76 text-[#9D4A46] ring-[#E6AAA3]/72",
+    completed: "bg-[#D7E4D7]/72 text-[#52745C] ring-[#BED1BF]/72",
+    cancelled: "bg-[#DDD4CF]/72 text-[#706661] ring-[#CBC0BA]/72",
+  };
+
+  return classes[status];
+}
+
+export function sortNotesByUrgency(items: NoteListItem[]) {
+  return [...items].sort((left, right) => {
+    const leftTime = left.item.due_at ? new Date(left.item.due_at).getTime() : Number.MAX_SAFE_INTEGER;
+    const rightTime = right.item.due_at ? new Date(right.item.due_at).getTime() : Number.MAX_SAFE_INTEGER;
+    return leftTime - rightTime;
+  });
+}
+
+export function sortClosedNotes(items: NoteListItem[]) {
+  return [...items].sort((left, right) => {
+    const leftTime = left.experience.endedAt ? new Date(left.experience.endedAt).getTime() : Date.now();
+    const rightTime = right.experience.endedAt ? new Date(right.experience.endedAt).getTime() : Date.now();
+    return rightTime - leftTime;
+  });
+}
+
+export function describeNotePreview(item: TodoItem, experience: NoteDetailExperience) {
+  if (item.bucket === "upcoming") {
+    return `${experience.previewStatus} · ${experience.timeHint}`;
+  }
+
+  if (item.bucket === "later") {
+    return `未到时间 · ${experience.timeHint}`;
+  }
+
+  if (item.bucket === "recurring_rule") {
+    return `${experience.repeatRule ?? "重复规则"} · 下次 ${experience.timeHint}`;
+  }
+
+  return `${experience.previewStatus} · ${experience.timeHint}`;
+}
+
+export function buildNoteSummary(groups: Pick<Record<NotePreviewGroupKey, NoteListItem[]>, "upcoming" | "recurring_rule">) {
+  const dueToday = groups.upcoming.filter((item) => item.item.status === "due_today").length;
+  const overdue = groups.upcoming.filter((item) => item.item.status === "overdue").length;
+  const recurringToday = groups.recurring_rule.filter((item) => item.experience.timeHint.includes("今天")).length;
+  const readyForAgent = groups.upcoming.filter((item) => item.experience.canConvertToTask).length;
+
+  return {
+    dueToday,
+    overdue,
+    readyForAgent,
+    recurringToday,
+  } satisfies NoteSummary;
+}
+
+export function groupClosedNotes(items: NoteListItem[], expanded: boolean) {
+  const now = Date.now();
+  const recent: NoteListItem[] = [];
+  const weekly: NoteListItem[] = [];
+  const older: NoteListItem[] = [];
+
+  items.forEach((item) => {
+    const endedAt = item.experience.endedAt ? new Date(item.experience.endedAt).getTime() : now;
+    const diffDays = (now - endedAt) / (1000 * 60 * 60 * 24);
+
+    if (diffDays <= 3) {
+      recent.push(item);
+      return;
+    }
+
+    if (diffDays <= 7) {
+      weekly.push(item);
+      return;
+    }
+
+    older.push(item);
+  });
+
+  const groups: Array<{ key: "recent" | "weekly" | "older"; title: string; description: string; items: NoteListItem[] }> = [
+    { key: "recent" as const, title: "近 3 天", description: "最近完成或取消的事项。", items: recent },
+    { key: "weekly" as const, title: "近 7 天", description: "一周内结束的记录。", items: weekly },
+  ];
+
+  if (expanded && older.length > 0) {
+    groups.push({ key: "older" as const, title: "更多", description: "更早结束的事项。", items: older });
+  }
+
+  return groups.filter((group) => group.items.length > 0);
+}
+
+export function getNoteActionLabel(action: NotePreviewGroupKey, canConvertToTask: boolean) {
+  if (action === "upcoming") {
+    return canConvertToTask ? "转交给 Agent" : "继续安排";
+  }
+
+  if (action === "later") {
+    return canConvertToTask ? "提前并转任务" : "提前到近期";
+  }
+
+  if (action === "recurring_rule") {
+    return "查看规则";
+  }
+
+  return "查看记录";
+}

--- a/apps/desktop/src/features/dashboard/notes/notePage.mapper.ts
+++ b/apps/desktop/src/features/dashboard/notes/notePage.mapper.ts
@@ -1,5 +1,4 @@
 import type { TodoBucket, TodoItem, TodoStatus } from "@cialloclaw/protocol";
-import { formatTimestamp } from "@/utils/formatters";
 import type { NoteDetailExperience, NoteListItem, NotePreviewGroupKey, NoteSummary } from "./notePage.types";
 
 export function getNoteBucketLabel(bucket: TodoBucket) {
@@ -60,7 +59,21 @@ export function describeNotePreview(item: TodoItem, experience: NoteDetailExperi
 export function buildNoteSummary(groups: Pick<Record<NotePreviewGroupKey, NoteListItem[]>, "upcoming" | "recurring_rule">) {
   const dueToday = groups.upcoming.filter((item) => item.item.status === "due_today").length;
   const overdue = groups.upcoming.filter((item) => item.item.status === "overdue").length;
-  const recurringToday = groups.recurring_rule.filter((item) => item.experience.timeHint.includes("今天")).length;
+  const recurringToday = groups.recurring_rule.filter((item) => {
+    const occurrence = item.experience.nextOccurrenceAt ?? item.experience.plannedAt ?? item.item.due_at;
+    if (!occurrence) {
+      return false;
+    }
+
+    const date = new Date(occurrence);
+    const now = new Date();
+
+    return (
+      date.getFullYear() === now.getFullYear() &&
+      date.getMonth() === now.getMonth() &&
+      date.getDate() === now.getDate()
+    );
+  }).length;
   const readyForAgent = groups.upcoming.filter((item) => item.experience.canConvertToTask).length;
 
   return {

--- a/apps/desktop/src/features/dashboard/notes/notePage.mock.ts
+++ b/apps/desktop/src/features/dashboard/notes/notePage.mock.ts
@@ -1,0 +1,388 @@
+import type { TodoItem } from "@cialloclaw/protocol";
+import type { NoteBucketsData, NoteConvertOutcome, NoteDetailExperience, NoteListItem } from "./notePage.types";
+
+const now = Date.now();
+const HOUR = 1000 * 60 * 60;
+const DAY = HOUR * 24;
+
+function iso(offset: number) {
+  return new Date(now + offset).toISOString();
+}
+
+function clone<T>(value: T) {
+  return structuredClone(value);
+}
+
+const mockItems: TodoItem[] = [
+  {
+    item_id: "note_upcoming_001",
+    title: "今天下班前把周报模板整理出来",
+    bucket: "upcoming",
+    status: "due_today",
+    type: "template",
+    due_at: iso(5 * HOUR),
+    agent_suggestion: "先打开上周模板，再把这周数据补进去。",
+  },
+  {
+    item_id: "note_upcoming_002",
+    title: "联系设计师确认首页球体交互排期",
+    bucket: "upcoming",
+    status: "normal",
+    type: "follow_up",
+    due_at: iso(2 * DAY),
+    agent_suggestion: "先整理你想确认的 3 个问题，再发过去。",
+  },
+  {
+    item_id: "note_upcoming_003",
+    title: "给安全页补一版风险摘要文案",
+    bucket: "upcoming",
+    status: "overdue",
+    type: "reminder",
+    due_at: iso(-8 * HOUR),
+    agent_suggestion: "先把当前失败案例整理成 3 条摘要，再决定是否交给 Agent。",
+  },
+  {
+    item_id: "note_later_001",
+    title: "月底前整理一次桌面端 UI token",
+    bucket: "later",
+    status: "normal",
+    type: "reminder",
+    due_at: iso(11 * DAY),
+    agent_suggestion: "先继续积累最近页面里的可复用 token，再统一整理。",
+  },
+  {
+    item_id: "note_later_002",
+    title: "等镜子页稳定后补跨页联动演示",
+    bucket: "later",
+    status: "normal",
+    type: "follow_up",
+    due_at: iso(18 * DAY),
+    agent_suggestion: "等镜子页数据结构稳定，再开始串 dashboard 联动。",
+  },
+  {
+    item_id: "note_recurring_001",
+    title: "每周一整理周报",
+    bucket: "recurring_rule",
+    status: "normal",
+    type: "recurring",
+    due_at: null,
+    agent_suggestion: "周一早上先汇总材料，中午前生成初稿。",
+  },
+  {
+    item_id: "note_recurring_002",
+    title: "工作日 09:00 巡检邮件",
+    bucket: "recurring_rule",
+    status: "normal",
+    type: "recurring",
+    due_at: null,
+    agent_suggestion: "只保留重要邮件，其余自动归档。",
+  },
+  {
+    item_id: "note_closed_001",
+    title: "输出铃兰首页交互版截图",
+    bucket: "closed",
+    status: "completed",
+    type: "archive",
+    due_at: iso(-2 * DAY),
+    agent_suggestion: "已完成，可作为后续任务的素材来源。",
+  },
+  {
+    item_id: "note_closed_002",
+    title: "整理旧 prototype 的引用关系",
+    bucket: "closed",
+    status: "cancelled",
+    type: "archive",
+    due_at: iso(-4 * DAY),
+    agent_suggestion: "已取消，后续重新审计后再继续。",
+  },
+];
+
+const noteExperiences: Record<string, NoteDetailExperience> = {
+  note_upcoming_001: {
+    title: "今天下班前把周报模板整理出来",
+    previewStatus: "今天要做",
+    timeHint: "今天 18:00 前",
+    detailStatus: "即将到来",
+    detailStatusTone: "warn",
+    typeLabel: "模板整理",
+    noteType: "template",
+    noteText: "这次周报想先把固定结构整理干净，后续每周只需要替换数据与结论。",
+    prerequisite: "先确认这周重点结论和图表截图已经齐全。",
+    relatedResources: [
+      { id: "res_001", label: "上周周报模板", path: "workspace/templates/weekly-report.md", type: "模板" },
+      { id: "res_002", label: "本周数据草稿", path: "workspace/drafts/weekly-report-data.md", type: "草稿" },
+    ],
+    agentSuggestion: {
+      label: "下一步建议",
+      detail: "先打开上周模板，再把这周的重点数据补进去，确认后可直接转交给 Agent 起草。",
+    },
+    nextOccurrenceAt: null,
+    repeatRule: null,
+    recentInstanceStatus: null,
+    effectiveScope: null,
+    plannedAt: iso(5 * HOUR),
+    endedAt: null,
+    isRecurringEnabled: false,
+    canConvertToTask: true,
+    summaryLabel: "今天待处理",
+  },
+  note_upcoming_002: {
+    title: "联系设计师确认首页球体交互排期",
+    previewStatus: "最近几天要处理",
+    timeHint: "还剩 2 天",
+    detailStatus: "即将到来",
+    detailStatusTone: "normal",
+    typeLabel: "沟通跟进",
+    noteType: "follow-up",
+    noteText: "主要是确认长按语音、事件球调度和入口球拖动这三块的视觉打磨排期。",
+    prerequisite: "先整理出想确认的 3 个问题和期望结果。",
+    relatedResources: [
+      { id: "res_003", label: "首页交互说明", path: "docs/home-interaction-notes.md", type: "说明" },
+    ],
+    agentSuggestion: {
+      label: "下一步建议",
+      detail: "先把你想确认的问题整理成一条清晰消息，之后可以一键转任务。",
+    },
+    nextOccurrenceAt: null,
+    repeatRule: null,
+    recentInstanceStatus: null,
+    effectiveScope: null,
+    plannedAt: iso(2 * DAY),
+    endedAt: null,
+    isRecurringEnabled: false,
+    canConvertToTask: true,
+    summaryLabel: "近期沟通",
+  },
+  note_upcoming_003: {
+    title: "给安全页补一版风险摘要文案",
+    previewStatus: "已逾期",
+    timeHint: "逾期 8 小时",
+    detailStatus: "已逾期",
+    detailStatusTone: "overdue",
+    typeLabel: "文案补充",
+    noteType: "reminder",
+    noteText: "当前风险摘要仍然偏技术表达，需要再压缩成更容易理解的一版。",
+    prerequisite: "先明确今天最重要的风险提示语气。",
+    relatedResources: [
+      { id: "res_004", label: "安全页草稿", path: "apps/desktop/src/features/dashboard/safety/SecurityApp.tsx", type: "页面" },
+    ],
+    agentSuggestion: {
+      label: "下一步建议",
+      detail: "先写 3 条简版风险摘要，再选择其中一条作为页面主文案。",
+    },
+    nextOccurrenceAt: null,
+    repeatRule: null,
+    recentInstanceStatus: null,
+    effectiveScope: null,
+    plannedAt: iso(-8 * HOUR),
+    endedAt: null,
+    isRecurringEnabled: false,
+    canConvertToTask: true,
+    summaryLabel: "需要优先处理",
+  },
+  note_later_001: {
+    title: "月底前整理一次桌面端 UI token",
+    previewStatus: "未到时间",
+    timeHint: "还没到处理窗口",
+    detailStatus: "尚未开始",
+    detailStatusTone: "normal",
+    typeLabel: "长期整理",
+    noteType: "reminder",
+    noteText: "这件事已记下，但不需要现在处理，等本月 dashboard 子页样式稳定后再统一梳理。",
+    prerequisite: "先积累任务页、便签页、镜子页的视觉 token。",
+    relatedResources: [
+      { id: "res_005", label: "UI token 草稿", path: "docs/ui-token-notes.md", type: "草稿" },
+    ],
+    agentSuggestion: {
+      label: "下一步建议",
+      detail: "先继续积累页面样式，月底前再统一整理成设计 token。",
+    },
+    nextOccurrenceAt: null,
+    repeatRule: null,
+    recentInstanceStatus: null,
+    effectiveScope: null,
+    plannedAt: iso(11 * DAY),
+    endedAt: null,
+    isRecurringEnabled: false,
+    canConvertToTask: false,
+    summaryLabel: "后续安排",
+  },
+  note_later_002: {
+    title: "等镜子页稳定后补跨页联动演示",
+    previewStatus: "未到时间",
+    timeHint: "后续安排",
+    detailStatus: "尚未开始",
+    detailStatusTone: "normal",
+    typeLabel: "后续演示",
+    noteType: "follow-up",
+    noteText: "跨页联动的演示要等镜子页和任务页都稳定之后再做。",
+    prerequisite: "镜子页、任务页交互和样式都已收口。",
+    relatedResources: [
+      { id: "res_006", label: "镜子页入口", path: "apps/desktop/src/features/dashboard/memory/MirrorApp.tsx", type: "页面" },
+    ],
+    agentSuggestion: {
+      label: "下一步建议",
+      detail: "暂时继续观察，等镜子页状态稳定后再转成正式任务。",
+    },
+    nextOccurrenceAt: null,
+    repeatRule: null,
+    recentInstanceStatus: null,
+    effectiveScope: null,
+    plannedAt: iso(18 * DAY),
+    endedAt: null,
+    isRecurringEnabled: false,
+    canConvertToTask: false,
+    summaryLabel: "先记住即可",
+  },
+  note_recurring_001: {
+    title: "每周一整理周报",
+    previewStatus: "规则生效中",
+    timeHint: "下次：下周一 09:00",
+    detailStatus: "重复规则开启中",
+    detailStatusTone: "normal",
+    typeLabel: "重复事项",
+    noteType: "recurring",
+    noteText: "每周一固定整理一次周报，若当天进入处理窗口，就会在“近期要做”中生成当天实例。",
+    prerequisite: "周日晚上或周一早上先汇总本周数据。",
+    relatedResources: [
+      { id: "res_007", label: "周报模板", path: "workspace/templates/weekly-report.md", type: "模板" },
+    ],
+    agentSuggestion: {
+      label: "流程化建议",
+      detail: "这类事项已经很稳定，适合进一步整理成固定模板并在周一自动提醒。",
+    },
+    nextOccurrenceAt: iso(DAY * 3),
+    repeatRule: "每周一 09:00",
+    recentInstanceStatus: "上次已完成",
+    effectiveScope: "工作周内持续生效",
+    plannedAt: null,
+    endedAt: null,
+    isRecurringEnabled: true,
+    canConvertToTask: false,
+    summaryLabel: "规则本身",
+  },
+  note_recurring_002: {
+    title: "工作日 09:00 巡检邮件",
+    previewStatus: "规则生效中",
+    timeHint: "下次：明天 09:00",
+    detailStatus: "重复规则开启中",
+    detailStatusTone: "normal",
+    typeLabel: "重复事项",
+    noteType: "recurring",
+    noteText: "每天 09:00 做一轮邮件巡检，重要邮件进入近期要做，其余归档。",
+    prerequisite: "需要邮箱接入和当前白名单规则已生效。",
+    relatedResources: [
+      { id: "res_008", label: "邮件巡检说明", path: "docs/mail-inspection.md", type: "说明" },
+    ],
+    agentSuggestion: {
+      label: "流程化建议",
+      detail: "如果你长期保留这条规则，可以考虑把归档和提醒模板固定下来。",
+    },
+    nextOccurrenceAt: iso(DAY),
+    repeatRule: "工作日 09:00",
+    recentInstanceStatus: "今天实例已处理",
+    effectiveScope: "仅工作日生效",
+    plannedAt: null,
+    endedAt: null,
+    isRecurringEnabled: true,
+    canConvertToTask: false,
+    summaryLabel: "规则本身",
+  },
+  note_closed_001: {
+    title: "输出铃兰首页交互版截图",
+    previewStatus: "已完成",
+    timeHint: "已结束",
+    detailStatus: "已完成",
+    detailStatusTone: "done",
+    typeLabel: "已结束记录",
+    noteType: "archive",
+    noteText: "这条事项对应的首页交互截图已经完成并归档，可作为后续风格参考。",
+    prerequisite: null,
+    relatedResources: [
+      { id: "res_009", label: "铃兰截图目录", path: "workspace/exports/lily-home", type: "文件夹" },
+    ],
+    agentSuggestion: {
+      label: "后续建议",
+      detail: "如果还会反复用到这组素材，可以整理成模板或直接转为新的任务。",
+    },
+    nextOccurrenceAt: null,
+    repeatRule: null,
+    recentInstanceStatus: null,
+    effectiveScope: null,
+    plannedAt: iso(-2 * DAY),
+    endedAt: iso(-2 * DAY + 2 * HOUR),
+    isRecurringEnabled: false,
+    canConvertToTask: true,
+    summaryLabel: "可复用成果",
+  },
+  note_closed_002: {
+    title: "整理旧 prototype 的引用关系",
+    previewStatus: "已取消",
+    timeHint: "已结束",
+    detailStatus: "已取消",
+    detailStatusTone: "done",
+    typeLabel: "已结束记录",
+    noteType: "archive",
+    noteText: "这件事已取消，原因是当前阶段不适合扩大重构范围。",
+    prerequisite: null,
+    relatedResources: [
+      { id: "res_010", label: "原型文件清单", path: "docs/prototype-audit.md", type: "清单" },
+    ],
+    agentSuggestion: {
+      label: "后续建议",
+      detail: "下次如果重启，先做引用审计再继续推进。",
+    },
+    nextOccurrenceAt: null,
+    repeatRule: null,
+    recentInstanceStatus: null,
+    effectiveScope: null,
+    plannedAt: iso(-4 * DAY),
+    endedAt: iso(-4 * DAY + 3 * HOUR),
+    isRecurringEnabled: false,
+    canConvertToTask: true,
+    summaryLabel: "后续可重启",
+  },
+};
+
+let itemsState = clone(mockItems);
+
+export function getMockNoteBuckets(): NoteBucketsData {
+  const notes: NoteListItem[] = itemsState.map((item) => ({
+    experience: noteExperiences[item.item_id],
+    item,
+  }));
+
+  return {
+    closed: notes.filter((item) => item.item.bucket === "closed"),
+    later: notes.filter((item) => item.item.bucket === "later"),
+    recurring_rule: notes.filter((item) => item.item.bucket === "recurring_rule"),
+    source: "mock",
+    upcoming: notes.filter((item) => item.item.bucket === "upcoming"),
+  };
+}
+
+export function getMockNoteExperience(itemId: string) {
+  return clone(noteExperiences[itemId]);
+}
+
+export function runMockConvertNoteToTask(itemId: string): NoteConvertOutcome {
+  const item = itemsState.find((entry) => entry.item_id === itemId) ?? itemsState[0];
+
+  return {
+    result: {
+      task: {
+        current_step: "awaiting_confirmation",
+        finished_at: null,
+        intent: { name: "converted_note", arguments: { item_id: item.item_id } },
+        risk_level: "green",
+        source_type: "todo",
+        started_at: new Date().toISOString(),
+        status: "processing",
+        task_id: `task_from_${item.item_id}`,
+        title: item.title,
+        updated_at: new Date().toISOString(),
+      },
+    },
+    source: "mock",
+  };
+}

--- a/apps/desktop/src/features/dashboard/notes/notePage.service.ts
+++ b/apps/desktop/src/features/dashboard/notes/notePage.service.ts
@@ -1,0 +1,102 @@
+import type {
+  AgentNotepadConvertToTaskParams,
+  AgentNotepadListParams,
+  RequestMeta,
+  TodoBucket,
+} from "@cialloclaw/protocol";
+import { convertNotepadToTask, listNotepad } from "@/rpc/methods";
+import { getMockNoteBuckets, getMockNoteExperience, runMockConvertNoteToTask } from "./notePage.mock";
+import type { NoteBucketsData, NoteConvertOutcome, NoteDetailExperience, NoteListItem } from "./notePage.types";
+
+function createRequestMeta(scope: string): RequestMeta {
+  return {
+    client_time: new Date().toISOString(),
+    trace_id: `trace_${scope}_${Date.now()}`,
+  };
+}
+
+function createFallbackExperience(item: NoteListItem["item"]): NoteDetailExperience {
+  return {
+    agentSuggestion: {
+      detail: item.agent_suggestion ?? "当前仅拿到协议里的基础数据，建议先补充说明后再转交给 Agent。",
+      label: "下一步建议",
+    },
+    canConvertToTask: item.bucket !== "closed",
+    detailStatus: item.bucket === "closed" ? "已结束" : "待处理",
+    detailStatusTone: item.status === "overdue" ? "overdue" : item.status === "completed" || item.status === "cancelled" ? "done" : "normal",
+    effectiveScope: null,
+    endedAt: item.status === "completed" || item.status === "cancelled" ? item.due_at : null,
+    isRecurringEnabled: item.bucket === "recurring_rule",
+    nextOccurrenceAt: item.bucket === "recurring_rule" ? item.due_at : null,
+    noteText: item.title,
+    noteType: item.bucket === "recurring_rule" ? "recurring" : item.bucket === "closed" ? "archive" : "reminder",
+    plannedAt: item.due_at,
+    previewStatus: item.bucket === "closed" ? (item.status === "completed" ? "已完成" : "已取消") : item.status === "overdue" ? "已逾期" : item.status === "due_today" ? "今天要做" : item.bucket === "later" ? "未到时间" : item.bucket === "recurring_rule" ? "规则生效中" : "近期要做",
+    prerequisite: null,
+    recentInstanceStatus: null,
+    relatedResources: [],
+    repeatRule: item.bucket === "recurring_rule" ? "重复规则待补充" : null,
+    summaryLabel: item.bucket,
+    timeHint: item.due_at ? new Date(item.due_at).toLocaleString() : "未设置时间",
+    title: item.title,
+    typeLabel: item.type,
+  };
+}
+
+function mapItems(items: Awaited<ReturnType<typeof listNotepad>>["items"]): NoteListItem[] {
+  return items.map((item) => ({
+    experience: getMockNoteExperience(item.item_id) ?? createFallbackExperience(item),
+    item,
+  }));
+}
+
+async function listNotepadByBucket(group: TodoBucket) {
+  const params: AgentNotepadListParams = {
+    group,
+    limit: group === "closed" ? 24 : 12,
+    offset: 0,
+    request_meta: createRequestMeta(`notepad_${group}`),
+  };
+
+  return listNotepad(params);
+}
+
+export async function loadNoteBuckets(): Promise<NoteBucketsData> {
+  try {
+    const [upcomingResult, laterResult, recurringResult, closedResult] = await Promise.all([
+      listNotepadByBucket("upcoming"),
+      listNotepadByBucket("later"),
+      listNotepadByBucket("recurring_rule"),
+      listNotepadByBucket("closed"),
+    ]);
+
+    return {
+      closed: mapItems(closedResult.items),
+      later: mapItems(laterResult.items),
+      recurring_rule: mapItems(recurringResult.items),
+      source: "rpc",
+      upcoming: mapItems(upcomingResult.items),
+    };
+  } catch (error) {
+    console.warn("Notepad RPC unavailable, using local mock fallback.", error);
+    return getMockNoteBuckets();
+  }
+}
+
+export async function convertNoteToTask(itemId: string): Promise<NoteConvertOutcome> {
+  const params: AgentNotepadConvertToTaskParams = {
+    confirmed: true,
+    item_id: itemId,
+    request_meta: createRequestMeta(`notepad_convert_${itemId}`),
+  };
+
+  try {
+    return {
+      result: await convertNotepadToTask(params),
+      source: "rpc",
+    };
+  } catch (error) {
+    console.warn("Convert note to task RPC unavailable, using local mock fallback.", error);
+    return runMockConvertNoteToTask(itemId);
+  }
+}

--- a/apps/desktop/src/features/dashboard/notes/notePage.service.ts
+++ b/apps/desktop/src/features/dashboard/notes/notePage.service.ts
@@ -3,6 +3,7 @@ import type {
   AgentNotepadListParams,
   RequestMeta,
   TodoBucket,
+  TodoItem,
 } from "@cialloclaw/protocol";
 import { convertNotepadToTask, listNotepad } from "@/rpc/methods";
 import { getMockNoteBuckets, getMockNoteExperience, runMockConvertNoteToTask } from "./notePage.mock";
@@ -15,31 +16,200 @@ function createRequestMeta(scope: string): RequestMeta {
   };
 }
 
-function createFallbackExperience(item: NoteListItem["item"]): NoteDetailExperience {
+function isTransportUnavailableError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+
+  return (
+    message.includes("named pipe transport is not wired") ||
+    message.includes("failed to fetch") ||
+    message.includes("networkerror") ||
+    message.includes("load failed")
+  );
+}
+
+function formatAbsoluteTime(value: string) {
+  return new Date(value).toLocaleString("zh-CN", {
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "numeric",
+  });
+}
+
+function formatRelativeTime(value: string) {
+  const targetTime = new Date(value).getTime();
+  const diffMs = targetTime - Date.now();
+  const absHours = Math.round(Math.abs(diffMs) / (1000 * 60 * 60));
+  const absDays = Math.round(Math.abs(diffMs) / (1000 * 60 * 60 * 24));
+
+  if (absHours < 1) {
+    return diffMs >= 0 ? "1 小时内" : "刚刚超时";
+  }
+
+  if (absHours < 24) {
+    return diffMs >= 0 ? `还剩 ${absHours} 小时` : `逾期 ${absHours} 小时`;
+  }
+
+  return diffMs >= 0 ? `还剩 ${absDays} 天` : `逾期 ${absDays} 天`;
+}
+
+function getPreviewStatus(item: TodoItem) {
+  if (item.bucket === "closed") {
+    return item.status === "completed" ? "已完成" : "已取消";
+  }
+
+  if (item.bucket === "recurring_rule") {
+    return "规则生效中";
+  }
+
+  if (item.status === "overdue") {
+    return "已逾期";
+  }
+
+  if (item.status === "due_today") {
+    return "今天要做";
+  }
+
+  return item.bucket === "later" ? "未到时间" : "近期要做";
+}
+
+function getDetailStatus(item: TodoItem) {
+  if (item.bucket === "closed") {
+    return item.status === "completed" ? "已结束" : "已取消";
+  }
+
+  if (item.bucket === "recurring_rule") {
+    return "重复规则开启中";
+  }
+
+  if (item.status === "overdue") {
+    return "已逾期";
+  }
+
+  if (item.status === "due_today") {
+    return "今日待处理";
+  }
+
+  return item.bucket === "later" ? "尚未开始" : "即将到来";
+}
+
+function getTimeHint(item: TodoItem) {
+  if (!item.due_at) {
+    return item.bucket === "recurring_rule" ? "规则时间待补充" : "未设置时间";
+  }
+
+  if (item.bucket === "closed") {
+    return formatAbsoluteTime(item.due_at);
+  }
+
+  if (item.bucket === "recurring_rule") {
+    return formatAbsoluteTime(item.due_at);
+  }
+
+  if (item.status === "due_today" || item.status === "overdue") {
+    return formatRelativeTime(item.due_at);
+  }
+
+  return formatAbsoluteTime(item.due_at);
+}
+
+function getSummaryLabel(item: TodoItem) {
+  if (item.bucket === "closed") {
+    return item.status === "completed" ? "已归档" : "已取消";
+  }
+
+  if (item.bucket === "recurring_rule") {
+    return "重复提醒";
+  }
+
+  if (item.bucket === "later") {
+    return "后续安排";
+  }
+
+  return item.status === "overdue" ? "优先处理" : "待进入执行";
+}
+
+function getTypeLabel(item: TodoItem) {
+  const normalizedType = item.type.replace(/[_-]/g, " ").trim();
+
+  if (!normalizedType) {
+    return item.bucket === "recurring_rule" ? "重复事项" : "便签事项";
+  }
+
+  return normalizedType
+    .split(/\s+/)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+function createResourceHints(item: TodoItem) {
+  const normalizedTitle = item.title.toLowerCase();
+  const resources = [];
+
+  if (normalizedTitle.includes("模板")) {
+    resources.push({
+      id: `${item.item_id}_template`,
+      label: "关联模板",
+      path: "workspace/templates",
+      type: "模板目录",
+    });
+  }
+
+  if (normalizedTitle.includes("周报") || normalizedTitle.includes("报告")) {
+    resources.push({
+      id: `${item.item_id}_report`,
+      label: "文档草稿区",
+      path: "workspace/drafts",
+      type: "草稿目录",
+    });
+  }
+
+  if (normalizedTitle.includes("设计") || normalizedTitle.includes("交互") || normalizedTitle.includes("页面")) {
+    resources.push({
+      id: `${item.item_id}_ui`,
+      label: "Dashboard 前端目录",
+      path: "apps/desktop/src/features/dashboard",
+      type: "代码目录",
+    });
+  }
+
+  return resources;
+}
+
+function createFallbackExperience(item: TodoItem): NoteDetailExperience {
+  const previewStatus = getPreviewStatus(item);
+  const detailStatus = getDetailStatus(item);
+
   return {
     agentSuggestion: {
-      detail: item.agent_suggestion ?? "当前仅拿到协议里的基础数据，建议先补充说明后再转交给 Agent。",
+      detail: item.agent_suggestion ?? "当前拿到的是协议中的基础便签数据，建议补一条更明确的上下文后再决定是否转交给 Agent。",
       label: "下一步建议",
     },
     canConvertToTask: item.bucket !== "closed",
-    detailStatus: item.bucket === "closed" ? "已结束" : "待处理",
+    detailStatus,
     detailStatusTone: item.status === "overdue" ? "overdue" : item.status === "completed" || item.status === "cancelled" ? "done" : "normal",
-    effectiveScope: null,
+    effectiveScope: item.bucket === "recurring_rule" ? "规则持续生效，直到手动暂停或取消。" : null,
     endedAt: item.status === "completed" || item.status === "cancelled" ? item.due_at : null,
     isRecurringEnabled: item.bucket === "recurring_rule",
     nextOccurrenceAt: item.bucket === "recurring_rule" ? item.due_at : null,
-    noteText: item.title,
+    noteText: item.agent_suggestion
+      ? `${item.title}。当前已同步到便签页，建议先按提示整理上下文，再视情况转成正式任务。`
+      : `${item.title}。当前只返回了基础便签字段，页面用最小默认说明承接这条事项。`,
     noteType: item.bucket === "recurring_rule" ? "recurring" : item.bucket === "closed" ? "archive" : "reminder",
     plannedAt: item.due_at,
-    previewStatus: item.bucket === "closed" ? (item.status === "completed" ? "已完成" : "已取消") : item.status === "overdue" ? "已逾期" : item.status === "due_today" ? "今天要做" : item.bucket === "later" ? "未到时间" : item.bucket === "recurring_rule" ? "规则生效中" : "近期要做",
-    prerequisite: null,
+    previewStatus,
+    prerequisite: item.bucket === "later" ? "当前还没进入处理窗口，先保留上下文即可。" : item.bucket === "recurring_rule" ? "确认这条规则仍然需要继续生效。" : null,
     recentInstanceStatus: null,
-    relatedResources: [],
-    repeatRule: item.bucket === "recurring_rule" ? "重复规则待补充" : null,
-    summaryLabel: item.bucket,
-    timeHint: item.due_at ? new Date(item.due_at).toLocaleString() : "未设置时间",
+    relatedResources: createResourceHints(item),
+    repeatRule: item.bucket === "recurring_rule" ? "协议暂未返回具体重复规则，当前只展示规则条目。" : null,
+    summaryLabel: getSummaryLabel(item),
+    timeHint: getTimeHint(item),
     title: item.title,
-    typeLabel: item.type,
+    typeLabel: getTypeLabel(item),
   };
 }
 
@@ -62,25 +232,41 @@ async function listNotepadByBucket(group: TodoBucket) {
 }
 
 export async function loadNoteBuckets(): Promise<NoteBucketsData> {
-  try {
-    const [upcomingResult, laterResult, recurringResult, closedResult] = await Promise.all([
-      listNotepadByBucket("upcoming"),
-      listNotepadByBucket("later"),
-      listNotepadByBucket("recurring_rule"),
-      listNotepadByBucket("closed"),
-    ]);
+  const buckets: TodoBucket[] = ["upcoming", "later", "recurring_rule", "closed"];
+  const results = await Promise.allSettled(buckets.map((bucket) => listNotepadByBucket(bucket)));
+  const fulfilledCount = results.filter((result) => result.status === "fulfilled").length;
 
-    return {
-      closed: mapItems(closedResult.items),
-      later: mapItems(laterResult.items),
-      recurring_rule: mapItems(recurringResult.items),
-      source: "rpc",
-      upcoming: mapItems(upcomingResult.items),
-    };
-  } catch (error) {
-    console.warn("Notepad RPC unavailable, using local mock fallback.", error);
+  if (results.every((result) => result.status === "rejected" && isTransportUnavailableError(result.reason))) {
+    console.warn("Notepad RPC transport unavailable, using local mock fallback.", results.map((result) => (result.status === "rejected" ? result.reason : null)));
     return getMockNoteBuckets();
   }
+
+  if (fulfilledCount === 0) {
+    const firstError = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
+    throw firstError?.reason ?? new Error("Failed to load notepad buckets.");
+  }
+
+  const bucketItems = {
+    closed: [] as NoteListItem[],
+    later: [] as NoteListItem[],
+    recurring_rule: [] as NoteListItem[],
+    upcoming: [] as NoteListItem[],
+  };
+
+  results.forEach((result, index) => {
+    const bucket = buckets[index];
+    if (result.status === "fulfilled") {
+      bucketItems[bucket] = mapItems(result.value.items);
+      return;
+    }
+
+    console.warn(`Failed to load notepad bucket: ${bucket}`, result.reason);
+  });
+
+  return {
+    ...bucketItems,
+    source: "rpc",
+  };
 }
 
 export async function convertNoteToTask(itemId: string): Promise<NoteConvertOutcome> {
@@ -96,7 +282,11 @@ export async function convertNoteToTask(itemId: string): Promise<NoteConvertOutc
       source: "rpc",
     };
   } catch (error) {
-    console.warn("Convert note to task RPC unavailable, using local mock fallback.", error);
-    return runMockConvertNoteToTask(itemId);
+    if (isTransportUnavailableError(error)) {
+      console.warn("Convert note to task RPC transport unavailable, using local mock fallback.", error);
+      return runMockConvertNoteToTask(itemId);
+    }
+
+    throw error;
   }
 }

--- a/apps/desktop/src/features/dashboard/notes/notePage.types.ts
+++ b/apps/desktop/src/features/dashboard/notes/notePage.types.ts
@@ -1,0 +1,84 @@
+import type { AgentNotepadConvertToTaskResult, TodoBucket, TodoItem, TodoStatus } from "@cialloclaw/protocol";
+
+export type NoteDataSource = "rpc" | "mock";
+export type NotePreviewGroupKey = "upcoming" | "later" | "recurring_rule" | "closed";
+export type NoteDetailAction =
+  | "complete"
+  | "cancel"
+  | "skip-once"
+  | "edit"
+  | "open-resource"
+  | "move-upcoming"
+  | "toggle-recurring"
+  | "cancel-recurring"
+  | "restore"
+  | "delete"
+  | "convert-to-task";
+
+export type NoteType = "reminder" | "follow-up" | "template" | "recurring" | "archive";
+
+export type NoteResource = {
+  id: string;
+  label: string;
+  path: string;
+  type: string;
+};
+
+export type NoteAgentSuggestion = {
+  label: string;
+  detail: string;
+};
+
+export type NoteDetailExperience = {
+  title: string;
+  previewStatus: string;
+  timeHint: string;
+  detailStatus: string;
+  detailStatusTone: "normal" | "warn" | "overdue" | "done";
+  typeLabel: string;
+  noteType: NoteType;
+  noteText: string;
+  prerequisite: string | null;
+  relatedResources: NoteResource[];
+  agentSuggestion: NoteAgentSuggestion;
+  nextOccurrenceAt: string | null;
+  repeatRule: string | null;
+  recentInstanceStatus: string | null;
+  effectiveScope: string | null;
+  plannedAt: string | null;
+  endedAt: string | null;
+  isRecurringEnabled: boolean;
+  canConvertToTask: boolean;
+  summaryLabel: string;
+};
+
+export type NoteListItem = {
+  item: TodoItem;
+  experience: NoteDetailExperience;
+};
+
+export type NoteBucketsData = {
+  closed: NoteListItem[];
+  later: NoteListItem[];
+  recurring_rule: NoteListItem[];
+  source: NoteDataSource;
+  upcoming: NoteListItem[];
+};
+
+export type NoteSummary = {
+  dueToday: number;
+  overdue: number;
+  readyForAgent: number;
+  recurringToday: number;
+};
+
+export type NoteConvertOutcome = {
+  result: AgentNotepadConvertToTaskResult;
+  source: NoteDataSource;
+};
+
+export type NoteActionShortcut = {
+  id: string;
+  label: string;
+  tooltip: string;
+};

--- a/apps/desktop/src/features/dashboard/tasks/TaskPage.tsx
+++ b/apps/desktop/src/features/dashboard/tasks/TaskPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
-import { Link, NavLink, useNavigate } from "react-router-dom";
+import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, CircleDashed, LayoutList } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
@@ -15,6 +15,7 @@ import { TaskPreviewCard } from "./components/TaskPreviewCard";
 import "./taskPage.css";
 
 export function TaskPage() {
+  const location = useLocation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
@@ -51,6 +52,16 @@ export function TaskPage() {
       return;
     }
 
+    const focusTaskId = (location.state as { focusTaskId?: string; openDetail?: boolean } | null)?.focusTaskId;
+    if (focusTaskId && allTasks.some((item) => item.task.task_id === focusTaskId)) {
+      setSelectedTaskId(focusTaskId);
+      if ((location.state as { openDetail?: boolean } | null)?.openDetail) {
+        setDetailOpen(true);
+      }
+      navigate(location.pathname, { replace: true, state: null });
+      return;
+    }
+
     const selectedExists = selectedTaskId ? allTasks.some((item) => item.task.task_id === selectedTaskId) : false;
     if (selectedExists) {
       return;
@@ -58,7 +69,7 @@ export function TaskPage() {
 
     const nextTask = unfinishedTasks.find((item) => item.task.status === "processing") ?? unfinishedTasks[0] ?? finishedTasks[0];
     setSelectedTaskId(nextTask.task.task_id);
-  }, [finishedTasks, selectedTaskId, unfinishedTasks]);
+  }, [finishedTasks, location.pathname, location.state, navigate, selectedTaskId, unfinishedTasks]);
 
   const taskDetailQuery = useQuery({
     enabled: Boolean(selectedTaskId),

--- a/apps/desktop/src/rpc/methods.ts
+++ b/apps/desktop/src/rpc/methods.ts
@@ -1,4 +1,8 @@
 import type {
+  AgentNotepadConvertToTaskParams,
+  AgentNotepadConvertToTaskResult,
+  AgentNotepadListParams,
+  AgentNotepadListResult,
   AgentSettingsGetParams,
   AgentSettingsGetResult,
   AgentSettingsUpdateParams,
@@ -53,6 +57,14 @@ export function getTaskDetail(params: AgentTaskDetailGetParams) {
 
 export function controlTask(params: AgentTaskControlParams) {
   return rpcClient.request<AgentTaskControlResult>(RPC_METHODS.AGENT_TASK_CONTROL, params);
+}
+
+export function listNotepad(params: AgentNotepadListParams) {
+  return rpcClient.request<AgentNotepadListResult>(RPC_METHODS.AGENT_NOTEPAD_LIST, params);
+}
+
+export function convertNotepadToTask(params: AgentNotepadConvertToTaskParams) {
+  return rpcClient.request<AgentNotepadConvertToTaskResult>(RPC_METHODS.AGENT_NOTEPAD_CONVERT_TO_TASK, params);
 }
 
 export function getMirrorOverview(params: AgentMirrorOverviewGetParams) {


### PR DESCRIPTION
- add a real notes page with grouped previews for upcoming, later, recurring, and closed items
- add modal note details with timing, rules, resources, agent suggestions, and note actions
- integrate notepad list and convert-to-task RPC methods with local mock fallbacks
- allow converting notes into tasks and jump directly to the generated task detail view