### PR TITLE
feat(shell-ball): complete frontend speech transcription flow

### DIFF
--- a/apps/desktop/src/features/shell-ball/ShellBallApp.tsx
+++ b/apps/desktop/src/features/shell-ball/ShellBallApp.tsx
@@ -125,6 +125,7 @@ export function ShellBallApp({ isDev = false }: ShellBallAppProps) {
   const {
     visualState,
     inputValue,
+    finalizedSpeechPayload,
     voicePreview,
     handlePrimaryClick,
     shouldOpenDashboardFromDoubleClick,
@@ -138,6 +139,7 @@ export function ShellBallApp({ isDev = false }: ShellBallAppProps) {
     handleAttachFile,
     handleInputFocusChange,
     setInputValue,
+    acknowledgeFinalizedSpeechPayload,
     handleForceState,
   } = useShellBallInteraction();
   const motionConfig = getShellBallMotionConfig(visualState);
@@ -264,8 +266,10 @@ export function ShellBallApp({ isDev = false }: ShellBallAppProps) {
     visualState,
     helperWindowsVisible: dashboardTransitionPhase === "idle",
     inputValue,
+    finalizedSpeechPayload,
     voicePreview,
     setInputValue,
+    onFinalizedSpeechHandled: acknowledgeFinalizedSpeechPayload,
     onRegionEnter: handleRegionEnter,
     onRegionLeave: handleRegionLeave,
     onInputFocusChange: handleInputFocusChange,

--- a/apps/desktop/src/features/shell-ball/components/ShellBallInputBar.tsx
+++ b/apps/desktop/src/features/shell-ball/components/ShellBallInputBar.tsx
@@ -91,7 +91,7 @@ export function ShellBallInputBar({
         readOnly={!isInteractive}
         tabIndex={isInteractive ? 0 : -1}
         aria-label="Shell-ball input"
-        placeholder={isVoice ? "Voice capture is active" : "Type a request for shell-ball"}
+        placeholder={isVoice ? "Listening has started — speak now" : "Type a request for shell-ball"}
       />
       {previewLabel === null ? null : (
         <span className="shell-ball-input-bar__preview" aria-live="polite">

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -71,6 +71,7 @@ import {
 } from "./useShellBallWindowMetrics";
 import { applyShellBallBubbleAction } from "./useShellBallCoordinator";
 import {
+  createShellBallInputSubmitParams,
   getShellBallPostSubmitInputReset,
   getShellBallDashboardOpenGesturePolicy,
   getShellBallPressCancelEvent,
@@ -1792,6 +1793,35 @@ test("shell-ball voice recognition final state routes final transcript out of th
       nextVisualState: "hover_input",
     },
   );
+});
+
+test("shell-ball submit params route text and voice through the formal input contract", () => {
+  const textParams = createShellBallInputSubmitParams({
+    text: "  summarize this  ",
+    trigger: "hover_text_input",
+    inputMode: "text",
+  });
+
+  assert.ok(textParams);
+  assert.equal(textParams.source, "floating_ball");
+  assert.equal(textParams.trigger, "hover_text_input");
+  assert.deepEqual(textParams.input, {
+    type: "text",
+    text: "summarize this",
+    input_mode: "text",
+  });
+  assert.deepEqual(textParams.context, { files: [] });
+
+  const voiceParams = createShellBallInputSubmitParams({
+    text: "  打开仪表盘  ",
+    trigger: "voice_commit",
+    inputMode: "voice",
+  });
+
+  assert.ok(voiceParams);
+  assert.equal(voiceParams.trigger, "voice_commit");
+  assert.equal(voiceParams.input.input_mode, "voice");
+  assert.equal(createShellBallInputSubmitParams({ text: "   ", trigger: "hover_text_input", inputMode: "text" }), null);
 });
 
 test("shell-ball interaction contract auto-advances waiting auth and processing states", () => {

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -14,7 +14,6 @@ import {
   shouldPreviewShellBallVoiceGesture,
   getShellBallVoicePreview,
   resolveShellBallTransition,
-  resolveShellBallVoiceReleaseEvent,
   shouldRetainShellBallHoverInput,
   SHELL_BALL_CANCEL_DELTA_PX,
   SHELL_BALL_CONFIRMING_MS,
@@ -27,6 +26,7 @@ import {
   SHELL_BALL_WAITING_AUTH_MS,
 } from "./shellBall.interaction";
 import { getShellBallMotionConfig } from "./shellBall.motion";
+import { collectShellBallSpeechTranscript, composeShellBallSpeechDraft } from "./shellBall.speech";
 import { ShellBallApp } from "./ShellBallApp";
 import { ShellBallBubbleWindow } from "./ShellBallBubbleWindow";
 import { ShellBallDevLayer } from "./ShellBallDevLayer";
@@ -74,6 +74,7 @@ import {
   getShellBallPostSubmitInputReset,
   getShellBallDashboardOpenGesturePolicy,
   getShellBallPressCancelEvent,
+  resolveShellBallVoiceRecognitionFinalState,
   getShellBallVoicePreviewFromEvent,
   mapShellBallInteractionConsumedEventToFlag,
   shouldKeepShellBallVoicePreviewOnRegionLeave,
@@ -1710,7 +1711,7 @@ test("shell-ball interaction contract starts voice listening only from resting i
   );
 });
 
-test("shell-ball interaction contract supports voice lock and locked voice completion", () => {
+test("shell-ball interaction contract supports voice lock during long-press capture", () => {
   assert.deepEqual(
     resolveShellBallTransition({
       current: "voice_listening",
@@ -1719,18 +1720,9 @@ test("shell-ball interaction contract supports voice lock and locked voice compl
     }),
     { next: "voice_locked" },
   );
-
-  assert.deepEqual(
-    resolveShellBallTransition({
-      current: "voice_locked",
-      event: "primary_click_locked_voice_end",
-      regionActive: true,
-    }),
-    { next: "processing" },
-  );
 });
 
-test("shell-ball interaction contract supports voice cancel and voice finish", () => {
+test("shell-ball interaction contract supports voice cancel", () => {
   assert.deepEqual(
     resolveShellBallTransition({
       current: "voice_listening",
@@ -1739,14 +1731,66 @@ test("shell-ball interaction contract supports voice cancel and voice finish", (
     }),
     { next: "idle" },
   );
+});
+
+test("shell-ball speech draft composition keeps English spacing and Chinese adjacency stable", () => {
+  assert.equal(composeShellBallSpeechDraft("Draft", "ready now"), "Draft ready now");
+  assert.equal(composeShellBallSpeechDraft("打开仪表盘", "然后开始处理"), "打开仪表盘然后开始处理");
+  assert.equal(composeShellBallSpeechDraft("", "  hello   world  "), "hello world");
+});
+
+test("shell-ball speech transcript collection merges recognition chunks", () => {
+  assert.equal(
+    collectShellBallSpeechTranscript({
+      0: { 0: { transcript: "hello" }, isFinal: true, length: 1 },
+      1: { 0: { transcript: "dashboard" }, isFinal: false, length: 1 },
+      length: 2,
+    }),
+    "hello dashboard",
+  );
+});
+
+test("shell-ball voice recognition final state routes final transcript out of the input draft and restores draft on cancel", () => {
+  assert.deepEqual(
+    resolveShellBallVoiceRecognitionFinalState({
+      reason: "finish",
+      transcript: "开始处理",
+      baseDraft: "打开仪表盘",
+      startState: "idle",
+    }),
+    {
+      finalizedSpeechPayload: "开始处理",
+      nextInputValue: "打开仪表盘",
+      nextVisualState: "hover_input",
+    },
+  );
 
   assert.deepEqual(
-    resolveShellBallTransition({
-      current: "voice_listening",
-      event: "voice_finish",
-      regionActive: true,
+    resolveShellBallVoiceRecognitionFinalState({
+      reason: "finish",
+      transcript: "开始处理",
+      baseDraft: "",
+      startState: "idle",
     }),
-    { next: "processing" },
+    {
+      finalizedSpeechPayload: "开始处理",
+      nextInputValue: "",
+      nextVisualState: "idle",
+    },
+  );
+
+  assert.deepEqual(
+    resolveShellBallVoiceRecognitionFinalState({
+      reason: "cancel",
+      transcript: "ignored",
+      baseDraft: "保留原稿",
+      startState: "hover_input",
+    }),
+    {
+      finalizedSpeechPayload: null,
+      nextInputValue: "保留原稿",
+      nextVisualState: "hover_input",
+    },
   );
 });
 
@@ -1929,7 +1973,7 @@ test("shell-ball controller forceState applies processing entry side effects", (
   controller.dispose();
 });
 
-test("shell-ball controller keeps locked voice active until explicit end", () => {
+test("shell-ball controller keeps locked voice active without legacy finish events", () => {
   const scheduler = createFakeScheduler();
   const controller = createShellBallInteractionController({
     initialState: "voice_locked",
@@ -1938,30 +1982,21 @@ test("shell-ball controller keeps locked voice active until explicit end", () =>
   });
 
   controller.dispatch("pointer_leave_region", { regionActive: false });
-  controller.dispatch("voice_finish", { regionActive: false });
   controller.dispatch("auto_advance", { regionActive: false });
 
   assert.equal(controller.getState(), "voice_locked");
-
-  controller.dispatch("primary_click_locked_voice_end", { regionActive: true });
-  assert.equal(controller.getState(), "processing");
-  assert.equal(scheduler.size, 1);
-
-  scheduler.flush();
-  assert.equal(controller.getState(), "hover_input");
-  assert.equal(scheduler.size, 0);
   controller.dispose();
 });
 
 test("shell-ball processing return follows the latest region activity when the timer completes", () => {
   const scheduler = createFakeScheduler();
   const controller = createShellBallInteractionController({
-    initialState: "voice_locked",
+    initialState: "idle",
     schedule: scheduler.schedule,
     cancel: scheduler.cancel,
   });
 
-  controller.dispatch("primary_click_locked_voice_end", { regionActive: true });
+  controller.forceState("processing", { regionActive: true });
   controller.dispatch("pointer_leave_region", { regionActive: false });
 
   scheduler.flush();
@@ -2008,9 +2043,6 @@ test("shell-ball voice preview helpers keep preview and release resolution pure"
   );
   assert.equal(getShellBallVoicePreview({ deltaX: SHELL_BALL_LOCK_DELTA_PX, deltaY: 0 }), null);
 
-  assert.equal(resolveShellBallVoiceReleaseEvent("lock"), "voice_lock");
-  assert.equal(resolveShellBallVoiceReleaseEvent("cancel"), "voice_cancel");
-  assert.equal(resolveShellBallVoiceReleaseEvent(null), "voice_finish");
 });
 
 test("shell-ball gesture helpers classify vertical intent explicitly for drag-safe voice previews", () => {
@@ -2079,6 +2111,7 @@ test("shell-ball input bar surfaces voice preview guidance to the UI", () => {
   );
 
   assert.match(markup, /data-voice-preview="cancel"/);
+  assert.match(markup, /Listening has started — speak now/);
   assert.match(markup, /Release to cancel/);
 });
 
@@ -2300,8 +2333,10 @@ test("shell-ball coordinator snapshots carry shell-ball-local bubble messages", 
   const { snapshot } = useShellBallCoordinator({
     visualState: "hover_input",
     inputValue: "draft",
+    finalizedSpeechPayload: null,
     voicePreview: null,
     setInputValue: () => {},
+    onFinalizedSpeechHandled: () => {},
     onRegionEnter: () => {},
     onRegionLeave: () => {},
     onInputFocusChange: () => {},
@@ -2880,8 +2915,10 @@ test("shell-ball detached bubble actions close pinned windows and delete detache
   useShellBallCoordinator({
     visualState: "hover_input",
     inputValue: "",
+    finalizedSpeechPayload: null,
     voicePreview: null,
     setInputValue: () => {},
+    onFinalizedSpeechHandled: () => {},
     onRegionEnter: () => {},
     onRegionLeave: () => {},
     onInputFocusChange: () => {},
@@ -3094,6 +3131,7 @@ test("shell-ball bubble window styles stay transparent, faded, and motion-ready"
   assert.match(shellBallStyles, /--shell-ball-helper-width:\s*min\(22rem, calc\(100vw - 1rem\)\);/);
   assert.match(shellBallStyles, /@media \(max-width: 720px\)\s*\{[\s\S]*--shell-ball-helper-width:\s*min\(20rem, calc\(100vw - 0\.75rem\)\);/);
   assert.match(shellBallStyles, /\.shell-ball-bubble-zone\s*\{[\s\S]*width:\s*var\(--shell-ball-helper-width\);/);
+  assert.match(shellBallStyles, /\.shell-ball-bubble-zone\s*\{[\s\S]*gap:\s*0\.4rem;/);
   assert.match(shellBallStyles, /\.shell-ball-bubble-zone\s*\{[\s\S]*overflow:\s*hidden;/);
   assert.match(shellBallStyles, /\.shell-ball-input-bar,\s*\.shell-ball-input-bar--hidden\s*\{[\s\S]*width:\s*var\(--shell-ball-helper-width\);/);
   assert.match(mobileBubbleZoneBlock, /min-height:\s*4\.6rem;/);
@@ -3341,29 +3379,25 @@ test("shell-ball mascot drag policy lets the full hotspot start window dragging 
 
 test("shell-ball voice swipe contract keeps upward lock and downward cancel explicit", () => {
   assert.equal(
-    resolveShellBallVoiceReleaseEvent(
-      getShellBallVoicePreviewFromEvent({
-        startX: 100,
-        startY: 100,
-        clientX: 100,
-        clientY: 100 - SHELL_BALL_LOCK_DELTA_PX,
-        fallbackPreview: null,
-      }),
-    ),
-    "voice_lock",
+    getShellBallVoicePreviewFromEvent({
+      startX: 100,
+      startY: 100,
+      clientX: 100,
+      clientY: 100 - SHELL_BALL_LOCK_DELTA_PX,
+      fallbackPreview: null,
+    }),
+    "lock",
   );
 
   assert.equal(
-    resolveShellBallVoiceReleaseEvent(
-      getShellBallVoicePreviewFromEvent({
-        startX: 100,
-        startY: 100,
-        clientX: 100,
-        clientY: 100 + SHELL_BALL_CANCEL_DELTA_PX,
-        fallbackPreview: null,
-      }),
-    ),
-    "voice_cancel",
+    getShellBallVoicePreviewFromEvent({
+      startX: 100,
+      startY: 100,
+      clientX: 100,
+      clientY: 100 + SHELL_BALL_CANCEL_DELTA_PX,
+      fallbackPreview: null,
+    }),
+    "cancel",
   );
 });
 
@@ -3470,7 +3504,7 @@ test("shell-ball input bar mode stays aligned with visual states", () => {
 test("shell-ball interaction timing constants stay frozen", () => {
   assert.equal(SHELL_BALL_HOVER_INTENT_MS, 360);
   assert.equal(SHELL_BALL_LEAVE_GRACE_MS, 180);
-  assert.equal(SHELL_BALL_LONG_PRESS_MS, 420);
+  assert.equal(SHELL_BALL_LONG_PRESS_MS, 300);
   assert.equal(SHELL_BALL_LOCK_DELTA_PX, 48);
   assert.equal(SHELL_BALL_CANCEL_DELTA_PX, 48);
   assert.equal(SHELL_BALL_VERTICAL_PRIORITY_RATIO, 1.25);

--- a/apps/desktop/src/features/shell-ball/shellBall.css
+++ b/apps/desktop/src/features/shell-ball/shellBall.css
@@ -113,6 +113,7 @@
   --shell-ball-bubble-accent: rgba(106, 145, 200, 0.18);
   align-items: stretch;
   display: grid;
+  gap: 0.4rem;
   justify-items: stretch;
   min-height: clamp(5.25rem, 12vw, 8.5rem);
   overflow: hidden;

--- a/apps/desktop/src/features/shell-ball/shellBall.interaction.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.interaction.ts
@@ -7,7 +7,7 @@ import type {
 
 export const SHELL_BALL_HOVER_INTENT_MS = 360;
 export const SHELL_BALL_LEAVE_GRACE_MS = 180;
-export const SHELL_BALL_LONG_PRESS_MS = 420;
+export const SHELL_BALL_LONG_PRESS_MS = 300;
 export const SHELL_BALL_LOCK_DELTA_PX = 48;
 export const SHELL_BALL_CANCEL_DELTA_PX = 48;
 export const SHELL_BALL_VERTICAL_PRIORITY_RATIO = 1.25;
@@ -123,19 +123,6 @@ export function getShellBallVoicePreview(input: { deltaX: number; deltaY: number
   return null;
 }
 
-export function resolveShellBallVoiceReleaseEvent(
-  preview: ShellBallVoicePreview,
-): Extract<ShellBallInteractionEvent, "voice_lock" | "voice_cancel" | "voice_finish"> {
-  switch (preview) {
-    case "lock":
-      return "voice_lock";
-    case "cancel":
-      return "voice_cancel";
-    default:
-      return "voice_finish";
-  }
-}
-
 export function resolveShellBallHoverTiming(input: {
   current: ShellBallVisualState;
   event: ShellBallHoverTimingEvent;
@@ -248,12 +235,6 @@ export function resolveShellBallTransition(input: {
 
     case "voice_cancel":
       return { next: current === "voice_listening" ? "idle" : current };
-
-    case "voice_finish":
-      return { next: current === "voice_listening" ? "processing" : current };
-
-    case "primary_click_locked_voice_end":
-      return { next: current === "voice_locked" ? "processing" : current };
 
     case "auto_advance":
       if (current === "confirming_intent" || current === "waiting_auth") {

--- a/apps/desktop/src/features/shell-ball/shellBall.speech.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.speech.ts
@@ -1,0 +1,90 @@
+type ShellBallSpeechRecognitionAlternative = {
+  transcript: string;
+};
+
+type ShellBallSpeechRecognitionResult = {
+  isFinal: boolean;
+  length: number;
+  [index: number]: ShellBallSpeechRecognitionAlternative;
+};
+
+export type ShellBallSpeechRecognitionResultList = {
+  length: number;
+  [index: number]: ShellBallSpeechRecognitionResult;
+};
+
+export type ShellBallSpeechRecognitionEvent = {
+  results: ShellBallSpeechRecognitionResultList;
+};
+
+export type ShellBallSpeechRecognitionErrorEvent = {
+  error: string;
+};
+
+export type ShellBallSpeechRecognition = {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  maxAlternatives: number;
+  onend: (() => void) | null;
+  onerror: ((event: ShellBallSpeechRecognitionErrorEvent) => void) | null;
+  onresult: ((event: ShellBallSpeechRecognitionEvent) => void) | null;
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+};
+
+type ShellBallSpeechRecognitionConstructor = new () => ShellBallSpeechRecognition;
+
+type ShellBallSpeechRecognitionWindow = Window & {
+  SpeechRecognition?: ShellBallSpeechRecognitionConstructor;
+  webkitSpeechRecognition?: ShellBallSpeechRecognitionConstructor;
+};
+
+export function getShellBallSpeechRecognitionConstructor(target: Window = window) {
+  const host = target as ShellBallSpeechRecognitionWindow;
+  return host.SpeechRecognition ?? host.webkitSpeechRecognition ?? null;
+}
+
+export function getShellBallSpeechRecognitionLanguage(target: Navigator = navigator) {
+  return target.language || "zh-CN";
+}
+
+export function normalizeShellBallSpeechTranscript(transcript: string) {
+  return transcript.replace(/\s+/g, " ").trim();
+}
+
+export function collectShellBallSpeechTranscript(results: ShellBallSpeechRecognitionResultList) {
+  let transcript = "";
+
+  for (let index = 0; index < results.length; index += 1) {
+    const alternative = results[index]?.[0];
+
+    if (alternative?.transcript === undefined) {
+      continue;
+    }
+
+    transcript += ` ${alternative.transcript}`;
+  }
+
+  return normalizeShellBallSpeechTranscript(transcript);
+}
+
+export function composeShellBallSpeechDraft(baseDraft: string, transcript: string) {
+  const normalizedTranscript = normalizeShellBallSpeechTranscript(transcript);
+
+  if (normalizedTranscript === "") {
+    return baseDraft;
+  }
+
+  if (baseDraft.trim() === "") {
+    return normalizedTranscript;
+  }
+
+  const trimmedBaseDraft = baseDraft.trimEnd();
+  if (/[\u3400-\u9fff]$/.test(trimmedBaseDraft) || /[。！？!?，、；：:,.]$/.test(trimmedBaseDraft)) {
+    return `${trimmedBaseDraft}${normalizedTranscript}`;
+  }
+
+  return `${trimmedBaseDraft} ${normalizedTranscript}`;
+}

--- a/apps/desktop/src/features/shell-ball/shellBall.types.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.types.ts
@@ -18,8 +18,6 @@ export type ShellBallInteractionEvent =
   | "press_start"
   | "voice_lock"
   | "voice_cancel"
-  | "voice_finish"
-  | "primary_click_locked_voice_end"
   | "auto_advance";
 
 export type ShellBallInputBarMode = "hidden" | "interactive" | "readonly" | "voice";

--- a/apps/desktop/src/features/shell-ball/test-stubs/protocol.ts
+++ b/apps/desktop/src/features/shell-ball/test-stubs/protocol.ts
@@ -29,6 +29,21 @@ export type RequestMeta = {
   client_time: string;
 };
 
+export type AgentInputSubmitParams = {
+  request_meta: RequestMeta;
+  session_id?: string;
+  source: "floating_ball" | "dashboard" | "tray_panel";
+  trigger: "voice_commit" | "hover_text_input";
+  input: {
+    type: "text";
+    text: string;
+    input_mode: "voice" | "text";
+  };
+  context: {
+    files: string[];
+  };
+};
+
 export type AgentSecuritySummaryGetParams = { request_meta: RequestMeta };
 export type AgentSecurityPendingListParams = { request_meta: RequestMeta; page?: number; limit?: number; offset?: number };
 export type AgentSecurityRespondParams = {

--- a/apps/desktop/src/features/shell-ball/test-stubs/rpcMethods.ts
+++ b/apps/desktop/src/features/shell-ball/test-stubs/rpcMethods.ts
@@ -50,3 +50,13 @@ export async function respondSecurityDetailed(_params?: unknown) {
     },
   });
 }
+
+export async function submitInput(_params?: unknown) {
+  return {
+    task: {
+      task_id: "task_stub",
+      status: "processing",
+    },
+    bubble_message: null,
+  };
+}

--- a/apps/desktop/src/features/shell-ball/useShellBallCoordinator.ts
+++ b/apps/desktop/src/features/shell-ball/useShellBallCoordinator.ts
@@ -36,8 +36,10 @@ type ShellBallCoordinatorInput = {
   visualState: ShellBallVisualState;
   helperWindowsVisible?: boolean;
   inputValue: string;
+  finalizedSpeechPayload: string | null;
   voicePreview: ShellBallVoicePreview;
   setInputValue: (value: string) => void;
+  onFinalizedSpeechHandled: () => void;
   onRegionEnter: () => void;
   onRegionLeave: () => void;
   onInputFocusChange: (focused: boolean) => void;
@@ -100,6 +102,30 @@ export function sortShellBallBubbleItemsByTimestamp(items: ShellBallBubbleItem[]
   return [...items].sort(compareShellBallBubbleItemsByTimestamp);
 }
 
+export function createShellBallFinalizedSpeechBubbleItem(input: {
+  text: string;
+  sequence: number;
+  createdAt: string;
+}): ShellBallBubbleItem {
+  return {
+    bubble: {
+      bubble_id: `shell-ball-local-user-voice-${input.sequence}`,
+      task_id: "",
+      type: "result",
+      text: input.text,
+      pinned: false,
+      hidden: false,
+      created_at: input.createdAt,
+    },
+    role: "user",
+    desktop: {
+      lifecycleState: "visible",
+      freshnessHint: "fresh",
+      motionHint: "settle",
+    },
+  };
+}
+
 export function applyShellBallBubbleAction(
   items: ShellBallBubbleItem[],
   payload: Pick<ShellBallBubbleActionPayload, "action" | "bubbleId">,
@@ -127,6 +153,8 @@ export function applyShellBallBubbleAction(
 
 export function useShellBallCoordinator(input: ShellBallCoordinatorInput) {
   const [bubbleItems, setBubbleItems] = useState(() => sortShellBallBubbleItemsByTimestamp(cloneShellBallBubbleItems(SHELL_BALL_LOCAL_BUBBLE_ITEMS)));
+  const appendedVoiceBubbleSequenceRef = useRef(0);
+  const handledFinalizedSpeechPayloadRef = useRef<string | null>(null);
   const snapshot = useMemo(
     () =>
       createShellBallWindowSnapshot({
@@ -143,6 +171,7 @@ export function useShellBallCoordinator(input: ShellBallCoordinatorInput) {
   const detachedPinnedBubbleIdsRef = useRef(new Set<string>());
   const handlersRef = useRef({
     setInputValue: input.setInputValue,
+    onFinalizedSpeechHandled: input.onFinalizedSpeechHandled,
     onRegionEnter: input.onRegionEnter,
     onRegionLeave: input.onRegionLeave,
     onInputFocusChange: input.onInputFocusChange,
@@ -155,6 +184,7 @@ export function useShellBallCoordinator(input: ShellBallCoordinatorInput) {
   bubbleItemsRef.current = bubbleItems;
   handlersRef.current = {
     setInputValue: input.setInputValue,
+    onFinalizedSpeechHandled: input.onFinalizedSpeechHandled,
     onRegionEnter: input.onRegionEnter,
     onRegionLeave: input.onRegionLeave,
     onInputFocusChange: input.onInputFocusChange,
@@ -162,6 +192,34 @@ export function useShellBallCoordinator(input: ShellBallCoordinatorInput) {
     onAttachFile: input.onAttachFile,
     onPrimaryClick: input.onPrimaryClick,
   };
+
+  useEffect(() => {
+    const finalizedSpeechPayload = input.finalizedSpeechPayload;
+
+    if (finalizedSpeechPayload === null) {
+      handledFinalizedSpeechPayloadRef.current = null;
+      return;
+    }
+
+    if (handledFinalizedSpeechPayloadRef.current === finalizedSpeechPayload) {
+      return;
+    }
+
+    handledFinalizedSpeechPayloadRef.current = finalizedSpeechPayload;
+    appendedVoiceBubbleSequenceRef.current += 1;
+
+    setBubbleItems((currentItems) =>
+      sortShellBallBubbleItemsByTimestamp([
+        ...currentItems,
+        createShellBallFinalizedSpeechBubbleItem({
+          text: finalizedSpeechPayload,
+          sequence: appendedVoiceBubbleSequenceRef.current,
+          createdAt: new Date().toISOString(),
+        }),
+      ]),
+    );
+    handlersRef.current.onFinalizedSpeechHandled();
+  }, [input.finalizedSpeechPayload]);
 
   useEffect(() => {
     const currentWindow = getCurrentWindow();

--- a/apps/desktop/src/features/shell-ball/useShellBallInteraction.ts
+++ b/apps/desktop/src/features/shell-ball/useShellBallInteraction.ts
@@ -4,11 +4,17 @@ import {
   createShellBallInteractionController,
   getShellBallInputBarMode,
   getShellBallVoicePreview,
-  resolveShellBallVoiceReleaseEvent,
   SHELL_BALL_LONG_PRESS_MS,
   shouldRetainShellBallHoverInput,
   type ShellBallVoicePreview,
 } from "./shellBall.interaction";
+import {
+  collectShellBallSpeechTranscript,
+  composeShellBallSpeechDraft,
+  getShellBallSpeechRecognitionConstructor,
+  getShellBallSpeechRecognitionLanguage,
+  type ShellBallSpeechRecognition,
+} from "./shellBall.speech";
 import type { ShellBallInteractionEvent, ShellBallVisualState } from "./shellBall.types";
 import { useShellBallStore } from "../../stores/shellBallStore";
 
@@ -23,6 +29,74 @@ type ShellBallInteractionConsumedEvent =
   | "long_press_voice_entry"
   | "voice_flow_consumed"
   | "force_state_reset";
+
+type ShellBallVoiceRecognitionStopReason = "none" | "finish" | "cancel";
+
+type ShellBallJsonRpcRequest = {
+  jsonrpc: "2.0";
+  id: string;
+  method: string;
+  params: object;
+};
+
+type ShellBallNamedPipeBridge = {
+  request: (payload: ShellBallJsonRpcRequest) => Promise<unknown>;
+};
+
+type ShellBallNamedPipeWindow = Window & {
+  __CIALLOCLAW_NAMED_PIPE__?: ShellBallNamedPipeBridge;
+};
+
+function createShellBallRequestMeta() {
+  const now = new Date().toISOString();
+  const traceId = typeof globalThis.crypto?.randomUUID === "function"
+    ? globalThis.crypto.randomUUID()
+    : `trace_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+
+  return {
+    trace_id: traceId,
+    client_time: now,
+  };
+}
+
+async function submitShellBallInput(input: {
+  text: string;
+  trigger: "voice_commit" | "hover_text_input";
+  inputMode: "voice" | "text";
+}) {
+  const normalizedText = input.text.trim();
+
+  if (normalizedText === "") {
+    return;
+  }
+
+  const bridge = (window as ShellBallNamedPipeWindow).__CIALLOCLAW_NAMED_PIPE__;
+
+  if (bridge === undefined) {
+    throw new Error("Named Pipe transport is not wired for shell-ball input submit.");
+  }
+
+  const requestMeta = createShellBallRequestMeta();
+
+  await bridge.request({
+    jsonrpc: "2.0",
+    id: requestMeta.trace_id,
+    method: "agent.input.submit",
+    params: {
+      request_meta: requestMeta,
+      source: "floating_ball",
+      trigger: input.trigger,
+      input: {
+        type: "text",
+        text: normalizedText,
+        input_mode: input.inputMode,
+      },
+      context: {
+        files: [],
+      },
+    },
+  });
+}
 
 export function mapShellBallInteractionConsumedEventToFlag(event: ShellBallInteractionConsumedEvent) {
   switch (event) {
@@ -96,10 +170,34 @@ export function syncShellBallInteractionController(input: {
   return input.controller.forceState(input.visualState, { regionActive: input.regionActive });
 }
 
+export function resolveShellBallVoiceRecognitionFinalState(input: {
+  reason: Exclude<ShellBallVoiceRecognitionStopReason, "none">;
+  transcript: string;
+  baseDraft: string;
+  startState: ShellBallVisualState;
+}) {
+  const normalizedTranscript = input.transcript.trim();
+
+  if (input.reason === "finish" && normalizedTranscript !== "") {
+    return {
+      finalizedSpeechPayload: normalizedTranscript,
+      nextInputValue: input.baseDraft,
+      nextVisualState: input.startState === "hover_input" || input.baseDraft.trim() !== "" ? ("hover_input" as const) : ("idle" as const),
+    };
+  }
+
+  return {
+    finalizedSpeechPayload: null,
+    nextInputValue: input.baseDraft,
+    nextVisualState: input.startState === "hover_input" || input.baseDraft.trim() !== "" ? ("hover_input" as const) : ("idle" as const),
+  };
+}
+
 export function useShellBallInteraction() {
   const visualState = useShellBallStore((state) => state.visualState);
   const setVisualState = useShellBallStore((state) => state.setVisualState);
   const [inputValue, setInputValue] = useState("");
+  const [finalizedSpeechPayload, setFinalizedSpeechPayload] = useState<string | null>(null);
   const [voicePreview, setVoicePreview] = useState<ShellBallVoicePreview>(null);
   const [interactionConsumed, setInteractionConsumed] = useState(false);
   const regionActiveRef = useRef(false);
@@ -110,8 +208,16 @@ export function useShellBallInteraction() {
   const longPressHandleRef = useRef<TimeoutHandle | null>(null);
   const setVisualStateRef = useRef(setVisualState);
   const controllerRef = useRef<ShellBallInteractionController | null>(null);
+  const inputValueRef = useRef(inputValue);
+  const recognitionRef = useRef<ShellBallSpeechRecognition | null>(null);
+  const recognitionSessionIdRef = useRef(0);
+  const recognitionStopReasonRef = useRef<ShellBallVoiceRecognitionStopReason>("none");
+  const voiceBaseDraftRef = useRef("");
+  const voiceTranscriptRef = useRef("");
+  const voiceStartStateRef = useRef<ShellBallVisualState>(visualState);
 
   setVisualStateRef.current = setVisualState;
+  inputValueRef.current = inputValue;
 
   if (controllerRef.current === null) {
     controllerRef.current = createShellBallInteractionController({
@@ -172,6 +278,153 @@ export function useShellBallInteraction() {
     syncVisualState();
   }
 
+  function syncVoiceDraft(transcript: string) {
+    voiceTranscriptRef.current = transcript;
+    setInputValue(composeShellBallSpeechDraft(voiceBaseDraftRef.current, transcript));
+  }
+
+  function finalizeVoiceRecognition(reason: Exclude<ShellBallVoiceRecognitionStopReason, "none">) {
+    const resolution = resolveShellBallVoiceRecognitionFinalState({
+      reason,
+      transcript: voiceTranscriptRef.current,
+      baseDraft: voiceBaseDraftRef.current,
+      startState: voiceStartStateRef.current,
+    });
+    recognitionRef.current = null;
+    recognitionStopReasonRef.current = "none";
+    recognitionSessionIdRef.current += 1;
+
+    setFinalizedSpeechPayload(resolution.finalizedSpeechPayload);
+    setInputValue(resolution.nextInputValue);
+    if (resolution.finalizedSpeechPayload !== null) {
+      void submitShellBallInput({
+        text: resolution.finalizedSpeechPayload,
+        trigger: "voice_commit",
+        inputMode: "voice",
+      }).catch((error) => {
+        console.warn("shell-ball voice submit failed", error);
+      });
+    }
+    controllerRef.current?.forceState(resolution.nextVisualState, {
+      regionActive: resolution.nextVisualState === "hover_input",
+    });
+    syncVisualState();
+
+    voiceTranscriptRef.current = "";
+  }
+
+  function acknowledgeFinalizedSpeechPayload() {
+    setFinalizedSpeechPayload(null);
+  }
+
+  function disposeVoiceRecognition() {
+    recognitionSessionIdRef.current += 1;
+    recognitionStopReasonRef.current = "none";
+    voiceTranscriptRef.current = "";
+    const recognition = recognitionRef.current;
+    recognitionRef.current = null;
+
+    if (recognition === null) {
+      return;
+    }
+
+    recognition.onresult = null;
+    recognition.onerror = null;
+    recognition.onend = null;
+
+    try {
+      recognition.abort();
+    } catch {}
+  }
+
+  function stopVoiceRecognition(reason: Exclude<ShellBallVoiceRecognitionStopReason, "none">) {
+    recognitionStopReasonRef.current = reason;
+    const recognition = recognitionRef.current;
+
+    if (recognition === null) {
+      finalizeVoiceRecognition(reason);
+      return;
+    }
+
+    try {
+      if (reason === "cancel") {
+        recognition.abort();
+        return;
+      }
+
+      recognition.stop();
+    } catch {
+      finalizeVoiceRecognition(reason);
+    }
+  }
+
+  function startVoiceRecognition() {
+    const Recognition = getShellBallSpeechRecognitionConstructor();
+
+    if (Recognition === null) {
+      return false;
+    }
+
+    disposeVoiceRecognition();
+    recognitionSessionIdRef.current += 1;
+    const sessionId = recognitionSessionIdRef.current;
+    const recognition = new Recognition();
+    recognitionRef.current = recognition;
+    recognitionStopReasonRef.current = "none";
+    voiceTranscriptRef.current = "";
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = getShellBallSpeechRecognitionLanguage();
+    recognition.maxAlternatives = 1;
+
+    recognition.onresult = (event) => {
+      if (sessionId !== recognitionSessionIdRef.current) {
+        return;
+      }
+
+      syncVoiceDraft(collectShellBallSpeechTranscript(event.results));
+    };
+
+    recognition.onerror = (event) => {
+      if (sessionId !== recognitionSessionIdRef.current) {
+        return;
+      }
+
+      if (recognitionStopReasonRef.current === "cancel" && event.error === "aborted") {
+        return;
+      }
+
+      console.warn("shell-ball speech recognition error", event.error);
+      recognitionStopReasonRef.current = "cancel";
+    };
+
+    recognition.onend = () => {
+      if (sessionId !== recognitionSessionIdRef.current) {
+        return;
+      }
+
+      const stopReason = recognitionStopReasonRef.current;
+
+      if (stopReason === "finish" || stopReason === "cancel") {
+        finalizeVoiceRecognition(stopReason);
+        return;
+      }
+
+      finalizeVoiceRecognition("cancel");
+    };
+
+    try {
+      recognition.start();
+      return true;
+    } catch (error) {
+      console.warn("shell-ball speech recognition start failed", error);
+      recognitionRef.current = null;
+      recognitionStopReasonRef.current = "none";
+      recognitionSessionIdRef.current += 1;
+      return false;
+    }
+  }
+
   function syncHoverRetention() {
     if (regionActiveRef.current) {
       return;
@@ -192,8 +445,8 @@ export function useShellBallInteraction() {
       return;
     }
 
+    stopVoiceRecognition("finish");
     consumeInteraction();
-    dispatch("primary_click_locked_voice_end");
   }
 
   function handleRegionEnter() {
@@ -216,10 +469,19 @@ export function useShellBallInteraction() {
   }
 
   function handleSubmitText() {
+    const currentDraft = inputValue.trim();
     const reset = getShellBallPostSubmitInputReset(inputValue);
     if (reset === null) {
       return;
     }
+
+    void submitShellBallInput({
+      text: currentDraft,
+      trigger: "hover_text_input",
+      inputMode: "text",
+    }).catch((error) => {
+      console.warn("shell-ball text submit failed", error);
+    });
 
     dispatch("submit_text");
     setInputValue(reset.nextInputValue);
@@ -232,7 +494,6 @@ export function useShellBallInteraction() {
 
   function handlePressStart(event: PointerEvent<HTMLButtonElement>) {
     regionActiveRef.current = true;
-    // A new pointer sequence clears any prior voice-consumed flag before gesture eligibility is evaluated.
     resetInteractionConsumed();
     pressStartXRef.current = event.clientX;
     pressStartYRef.current = event.clientY;
@@ -246,8 +507,19 @@ export function useShellBallInteraction() {
 
     longPressHandleRef.current = globalThis.setTimeout(() => {
       longPressHandleRef.current = null;
+      voiceStartStateRef.current = controllerRef.current?.getState() ?? visualState;
+      voiceBaseDraftRef.current = inputValueRef.current;
       setInteractionConsumed(mapShellBallInteractionConsumedEventToFlag("long_press_voice_entry"));
       dispatch("press_start");
+
+      if (!startVoiceRecognition()) {
+        setInputValue(voiceBaseDraftRef.current);
+        controllerRef.current?.forceState(
+          voiceStartStateRef.current === "hover_input" || voiceBaseDraftRef.current.trim() !== "" ? "hover_input" : "idle",
+          { regionActive: regionActiveRef.current },
+        );
+        syncVisualState();
+      }
     }, SHELL_BALL_LONG_PRESS_MS);
   }
 
@@ -285,14 +557,24 @@ export function useShellBallInteraction() {
         fallbackPreview: voicePreviewRef.current,
       });
 
-      dispatch(resolveShellBallVoiceReleaseEvent(finalPreview));
+      if (finalPreview === "lock") {
+        dispatch("voice_lock");
+        pressStartXRef.current = null;
+        pressStartYRef.current = null;
+        setCurrentVoicePreview(null);
+        return true;
+      }
+
+      stopVoiceRecognition(finalPreview === "cancel" ? "cancel" : "finish");
       pressStartXRef.current = null;
       pressStartYRef.current = null;
       setCurrentVoicePreview(null);
       return true;
-    } else if (controllerRef.current?.getState() === "voice_locked") {
+    }
+
+    if (controllerRef.current?.getState() === "voice_locked") {
+      stopVoiceRecognition("finish");
       consumeInteraction();
-      dispatch("primary_click_locked_voice_end");
       pressStartXRef.current = null;
       pressStartYRef.current = null;
       setCurrentVoicePreview(null);
@@ -314,6 +596,7 @@ export function useShellBallInteraction() {
     setCurrentVoicePreview(null);
 
     if (cancelEvent !== null) {
+      stopVoiceRecognition("cancel");
       consumeInteraction();
       dispatch(cancelEvent);
     }
@@ -328,6 +611,7 @@ export function useShellBallInteraction() {
 
   function handleForceState(state: ShellBallVisualState) {
     clearLongPressTimer();
+    disposeVoiceRecognition();
     setInteractionConsumed(mapShellBallInteractionConsumedEventToFlag("force_state_reset"));
     pressStartXRef.current = null;
     pressStartYRef.current = null;
@@ -355,6 +639,7 @@ export function useShellBallInteraction() {
   useEffect(() => {
     return () => {
       clearLongPressTimer();
+      disposeVoiceRecognition();
       pressStartXRef.current = null;
       pressStartYRef.current = null;
       voicePreviewRef.current = null;
@@ -366,6 +651,8 @@ export function useShellBallInteraction() {
     visualState,
     inputValue,
     setInputValue,
+    finalizedSpeechPayload,
+    acknowledgeFinalizedSpeechPayload,
     voicePreview,
     inputBarMode: getShellBallInputBarMode(visualState),
     interactionConsumed,

--- a/apps/desktop/src/features/shell-ball/useShellBallInteraction.ts
+++ b/apps/desktop/src/features/shell-ball/useShellBallInteraction.ts
@@ -1,3 +1,4 @@
+import type { AgentInputSubmitParams, RequestMeta } from "@cialloclaw/protocol";
 import { useEffect, useRef, useState } from "react";
 import type { PointerEvent } from "react";
 import {
@@ -32,22 +33,7 @@ type ShellBallInteractionConsumedEvent =
 
 type ShellBallVoiceRecognitionStopReason = "none" | "finish" | "cancel";
 
-type ShellBallJsonRpcRequest = {
-  jsonrpc: "2.0";
-  id: string;
-  method: string;
-  params: object;
-};
-
-type ShellBallNamedPipeBridge = {
-  request: (payload: ShellBallJsonRpcRequest) => Promise<unknown>;
-};
-
-type ShellBallNamedPipeWindow = Window & {
-  __CIALLOCLAW_NAMED_PIPE__?: ShellBallNamedPipeBridge;
-};
-
-function createShellBallRequestMeta() {
+function createShellBallRequestMeta(): RequestMeta {
   const now = new Date().toISOString();
   const traceId = typeof globalThis.crypto?.randomUUID === "function"
     ? globalThis.crypto.randomUUID()
@@ -59,43 +45,50 @@ function createShellBallRequestMeta() {
   };
 }
 
+export function createShellBallInputSubmitParams(input: {
+  text: string;
+  trigger: "voice_commit" | "hover_text_input";
+  inputMode: "voice" | "text";
+}): AgentInputSubmitParams | null {
+  const normalizedText = input.text.trim();
+
+  if (normalizedText === "") {
+    return null;
+  }
+
+  const requestMeta = createShellBallRequestMeta();
+
+  return {
+    request_meta: requestMeta,
+    source: "floating_ball",
+    trigger: input.trigger,
+    input: {
+      type: "text",
+      text: normalizedText,
+      input_mode: input.inputMode,
+    },
+    context: {
+      files: [],
+    },
+  };
+}
+
 async function submitShellBallInput(input: {
   text: string;
   trigger: "voice_commit" | "hover_text_input";
   inputMode: "voice" | "text";
 }) {
-  const normalizedText = input.text.trim();
+  const params = createShellBallInputSubmitParams(input);
 
-  if (normalizedText === "") {
-    return;
+  if (params === null) {
+    return null;
   }
 
-  const bridge = (window as ShellBallNamedPipeWindow).__CIALLOCLAW_NAMED_PIPE__;
-
-  if (bridge === undefined) {
-    throw new Error("Named Pipe transport is not wired for shell-ball input submit.");
-  }
-
-  const requestMeta = createShellBallRequestMeta();
-
-  await bridge.request({
-    jsonrpc: "2.0",
-    id: requestMeta.trace_id,
-    method: "agent.input.submit",
-    params: {
-      request_meta: requestMeta,
-      source: "floating_ball",
-      trigger: input.trigger,
-      input: {
-        type: "text",
-        text: normalizedText,
-        input_mode: input.inputMode,
-      },
-      context: {
-        files: [],
-      },
-    },
-  });
+  const importRpcMethods = new Function("return import('../../rpc/methods')") as () => Promise<{
+    submitInput: (request: AgentInputSubmitParams) => Promise<unknown>;
+  }>;
+  const rpcMethods = await importRpcMethods();
+  return rpcMethods.submitInput(params);
 }
 
 export function mapShellBallInteractionConsumedEventToFlag(event: ShellBallInteractionConsumedEvent) {
@@ -177,19 +170,21 @@ export function resolveShellBallVoiceRecognitionFinalState(input: {
   startState: ShellBallVisualState;
 }) {
   const normalizedTranscript = input.transcript.trim();
+  const nextVisualState =
+    input.startState === "hover_input" || input.baseDraft.trim() !== "" ? ("hover_input" as const) : ("idle" as const);
 
   if (input.reason === "finish" && normalizedTranscript !== "") {
     return {
       finalizedSpeechPayload: normalizedTranscript,
       nextInputValue: input.baseDraft,
-      nextVisualState: input.startState === "hover_input" || input.baseDraft.trim() !== "" ? ("hover_input" as const) : ("idle" as const),
+      nextVisualState,
     };
   }
 
   return {
     finalizedSpeechPayload: null,
     nextInputValue: input.baseDraft,
-    nextVisualState: input.startState === "hover_input" || input.baseDraft.trim() !== "" ? ("hover_input" as const) : ("idle" as const),
+    nextVisualState,
   };
 }
 
@@ -283,7 +278,7 @@ export function useShellBallInteraction() {
     setInputValue(composeShellBallSpeechDraft(voiceBaseDraftRef.current, transcript));
   }
 
-  function finalizeVoiceRecognition(reason: Exclude<ShellBallVoiceRecognitionStopReason, "none">) {
+  async function finalizeVoiceRecognition(reason: Exclude<ShellBallVoiceRecognitionStopReason, "none">) {
     const resolution = resolveShellBallVoiceRecognitionFinalState({
       reason,
       transcript: voiceTranscriptRef.current,
@@ -294,23 +289,27 @@ export function useShellBallInteraction() {
     recognitionStopReasonRef.current = "none";
     recognitionSessionIdRef.current += 1;
 
-    setFinalizedSpeechPayload(resolution.finalizedSpeechPayload);
     setInputValue(resolution.nextInputValue);
-    if (resolution.finalizedSpeechPayload !== null) {
-      void submitShellBallInput({
-        text: resolution.finalizedSpeechPayload,
-        trigger: "voice_commit",
-        inputMode: "voice",
-      }).catch((error) => {
-        console.warn("shell-ball voice submit failed", error);
-      });
-    }
     controllerRef.current?.forceState(resolution.nextVisualState, {
       regionActive: resolution.nextVisualState === "hover_input",
     });
     syncVisualState();
-
     voiceTranscriptRef.current = "";
+
+    if (resolution.finalizedSpeechPayload === null) {
+      return;
+    }
+
+    try {
+      await submitShellBallInput({
+        text: resolution.finalizedSpeechPayload,
+        trigger: "voice_commit",
+        inputMode: "voice",
+      });
+      setFinalizedSpeechPayload(resolution.finalizedSpeechPayload);
+    } catch (error) {
+      console.warn("shell-ball voice submit failed", error);
+    }
   }
 
   function acknowledgeFinalizedSpeechPayload() {
@@ -406,11 +405,11 @@ export function useShellBallInteraction() {
       const stopReason = recognitionStopReasonRef.current;
 
       if (stopReason === "finish" || stopReason === "cancel") {
-        finalizeVoiceRecognition(stopReason);
+        void finalizeVoiceRecognition(stopReason);
         return;
       }
 
-      finalizeVoiceRecognition("cancel");
+      void finalizeVoiceRecognition("cancel");
     };
 
     try {
@@ -475,17 +474,20 @@ export function useShellBallInteraction() {
       return;
     }
 
-    void submitShellBallInput({
-      text: currentDraft,
-      trigger: "hover_text_input",
-      inputMode: "text",
-    }).catch((error) => {
-      console.warn("shell-ball text submit failed", error);
-    });
-
-    dispatch("submit_text");
-    setInputValue(reset.nextInputValue);
-    inputFocusedRef.current = reset.nextFocused;
+    void (async () => {
+      try {
+        await submitShellBallInput({
+          text: currentDraft,
+          trigger: "hover_text_input",
+          inputMode: "text",
+        });
+        dispatch("submit_text");
+        setInputValue(reset.nextInputValue);
+        inputFocusedRef.current = reset.nextFocused;
+      } catch (error) {
+        console.warn("shell-ball text submit failed", error);
+      }
+    })();
   }
 
   function handleAttachFile() {

--- a/apps/desktop/src/rpc/methods.ts
+++ b/apps/desktop/src/rpc/methods.ts
@@ -1,4 +1,6 @@
 import type {
+  AgentInputSubmitParams,
+  AgentInputSubmitResult,
   AgentNotepadConvertToTaskParams,
   AgentNotepadConvertToTaskResult,
   AgentNotepadListParams,
@@ -34,6 +36,10 @@ import type {
 } from "@cialloclaw/protocol";
 import { RPC_METHODS } from "@cialloclaw/protocol";
 import { rpcClient, type JsonRpcResponsePayload } from "./client";
+
+export function submitInput(params: AgentInputSubmitParams) {
+  return rpcClient.request<AgentInputSubmitResult>(RPC_METHODS.AGENT_INPUT_SUBMIT, params);
+}
 
 // startTask 处理当前模块的相关逻辑。
 export function startTask(params: AgentTaskStartParams) {


### PR DESCRIPTION
## Summary
- complete the frontend shell-ball speech transcription flow using browser/system speech recognition
- send both typed text and finalized voice input through the formal `agent.input.submit` JSON-RPC path
- refine the voice UX so final transcripts land in user bubbles instead of the input box

## What changed
- wired long-press voice capture to frontend `SpeechRecognition` / `webkitSpeechRecognition`
- added finalized voice handling so:
  - cancel restores the original draft
  - finish routes the transcript into a normal user-side bubble
  - final speech text is no longer kept in the input box
- removed the temporary live transcript card during recording
- hooked shell-ball submission into the formal input API:
  - text submit → `agent.input.submit` with `trigger: "hover_text_input"`
  - voice finish → `agent.input.submit` with `trigger: "voice_commit"`
- improved perceived voice start responsiveness:
  - reduced long-press start delay from `420ms` to `300ms`
  - updated voice-mode copy to `Listening has started — speak now`

## Why
- the previous implementation only handled voice locally and did not send formal JSON-RPC input events
- transcript visibility and final landing behavior did not match the intended UX
- users could easily start speaking before recognition actually began, which made pickup feel unreliable

## Verification
- `pnpm --dir apps/desktop typecheck`
- `pnpm --dir apps/desktop test:shell-ball`
- `pnpm --dir apps/desktop build`

## Notes
- this remains a frontend-only speech recognition implementation
- pickup sensitivity is still primarily constrained by the underlying browser/WebView2/system microphone path rather than an app-level threshold