### PR TITLE
feat(backend): close 5th-owner MVP and P0 backend gaps on main line

### DIFF
--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -32,6 +32,7 @@ var (
 	ErrTaskNotFound        = errors.New("task not found")
 	ErrTaskStatusInvalid   = errors.New("task status invalid")
 	ErrTaskAlreadyFinished = errors.New("task already finished")
+	ErrStorageQueryFailed  = errors.New("storage query failed")
 )
 
 // Service 提供当前模块的服务能力。
@@ -683,15 +684,18 @@ func (s *Service) SecurityPendingList(params map[string]any) (map[string]any, er
 
 // SecurityAuditList 处理 agent.security.audit.list。
 func (s *Service) SecurityAuditList(params map[string]any) (map[string]any, error) {
-	limit := intValue(params, "limit", 20)
-	offset := intValue(params, "offset", 0)
+	limit := clampListLimit(intValue(params, "limit", 20))
+	offset := clampListOffset(intValue(params, "offset", 0))
 	taskID := stringValue(params, "task_id", "")
+	if strings.TrimSpace(taskID) == "" {
+		return nil, errors.New("task_id is required")
+	}
 	if s.storage == nil {
 		return map[string]any{"items": []map[string]any{}, "page": pageMap(limit, offset, 0)}, nil
 	}
 	records, total, err := s.storage.AuditStore().ListAuditRecords(context.Background(), taskID, limit, offset)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", ErrStorageQueryFailed, err)
 	}
 	items := make([]map[string]any, 0, len(records))
 	for _, record := range records {
@@ -701,6 +705,23 @@ func (s *Service) SecurityAuditList(params map[string]any) (map[string]any, erro
 		"items": items,
 		"page":  pageMap(limit, offset, total),
 	}, nil
+}
+
+func clampListLimit(limit int) int {
+	if limit <= 0 {
+		return 20
+	}
+	if limit > 100 {
+		return 100
+	}
+	return limit
+}
+
+func clampListOffset(offset int) int {
+	if offset < 0 {
+		return 0
+	}
+	return offset
 }
 
 // PendingNotifications 返回待处理的Notifications。

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -681,6 +681,28 @@ func (s *Service) SecurityPendingList(params map[string]any) (map[string]any, er
 	}, nil
 }
 
+// SecurityAuditList 处理 agent.security.audit.list。
+func (s *Service) SecurityAuditList(params map[string]any) (map[string]any, error) {
+	limit := intValue(params, "limit", 20)
+	offset := intValue(params, "offset", 0)
+	taskID := stringValue(params, "task_id", "")
+	if s.storage == nil {
+		return map[string]any{"items": []map[string]any{}, "page": pageMap(limit, offset, 0)}, nil
+	}
+	records, total, err := s.storage.AuditStore().ListAuditRecords(context.Background(), taskID, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]map[string]any, 0, len(records))
+	for _, record := range records {
+		items = append(items, record.Map())
+	}
+	return map[string]any{
+		"items": items,
+		"page":  pageMap(limit, offset, total),
+	}, nil
+}
+
 // PendingNotifications 返回待处理的Notifications。
 
 // PendingNotifications 读取某个任务当前尚未消费的通知列表。

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -1493,6 +1493,36 @@ func TestServiceDashboardModuleHighlightsIncludeAuditTrail(t *testing.T) {
 	}
 }
 
+func TestServiceSecurityAuditListFallsBackToStoredAuditRecords(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "executor-backed summary")
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+	err := service.storage.AuditWriter().WriteAuditRecord(context.Background(), audit.Record{
+		AuditID:   "audit_001",
+		TaskID:    "task_external",
+		Type:      "file",
+		Action:    "write_file",
+		Summary:   "stored audit record",
+		Target:    "workspace/result.md",
+		Result:    "success",
+		CreatedAt: "2026-04-08T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("write audit record failed: %v", err)
+	}
+
+	result, err := service.SecurityAuditList(map[string]any{"limit": 20, "offset": 0})
+	if err != nil {
+		t.Fatalf("security audit list failed: %v", err)
+	}
+
+	items := result["items"].([]map[string]any)
+	if len(items) != 1 || items[0]["audit_id"] != "audit_001" {
+		t.Fatalf("expected storage-backed audit record, got %+v", items)
+	}
+}
+
 func TestServiceTaskControlRejectsInvalidStatusTransition(t *testing.T) {
 	service := newTestService()
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -1512,7 +1512,7 @@ func TestServiceSecurityAuditListFallsBackToStoredAuditRecords(t *testing.T) {
 		t.Fatalf("write audit record failed: %v", err)
 	}
 
-	result, err := service.SecurityAuditList(map[string]any{"limit": 20, "offset": 0})
+	result, err := service.SecurityAuditList(map[string]any{"task_id": "task_external", "limit": 20, "offset": 0})
 	if err != nil {
 		t.Fatalf("security audit list failed: %v", err)
 	}
@@ -1520,6 +1520,14 @@ func TestServiceSecurityAuditListFallsBackToStoredAuditRecords(t *testing.T) {
 	items := result["items"].([]map[string]any)
 	if len(items) != 1 || items[0]["audit_id"] != "audit_001" {
 		t.Fatalf("expected storage-backed audit record, got %+v", items)
+	}
+}
+
+func TestServiceSecurityAuditListRequiresTaskID(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "executor-backed summary")
+	_, err := service.SecurityAuditList(map[string]any{"limit": 20, "offset": 0})
+	if err == nil || err.Error() != "task_id is required" {
+		t.Fatalf("expected task_id required error, got %v", err)
 	}
 }
 

--- a/services/local-service/internal/rpc/handlers.go
+++ b/services/local-service/internal/rpc/handlers.go
@@ -30,6 +30,7 @@ func (s *Server) registerHandlers() {
 		"agent.dashboard.module.get":           s.handleAgentDashboardModuleGet,
 		"agent.mirror.overview.get":            s.handleAgentMirrorOverviewGet,
 		"agent.security.summary.get":           s.handleAgentSecuritySummaryGet,
+		"agent.security.audit.list":            s.handleAgentSecurityAuditList,
 		"agent.security.pending.list":          s.handleAgentSecurityPendingList,
 		"agent.security.respond":               s.handleAgentSecurityRespond,
 		"agent.settings.get":                   s.handleAgentSettingsGet,
@@ -172,6 +173,14 @@ func (s *Server) handleAgentMirrorOverviewGet(params map[string]any) (any, *rpcE
 func (s *Server) handleAgentSecuritySummaryGet(params map[string]any) (any, *rpcError) {
 	_ = params
 	data, err := s.orchestrator.SecuritySummaryGet()
+	return wrapOrchestratorResult(data, err)
+}
+
+// handleAgentSecurityPendingList 处理当前模块的相关逻辑。
+
+// handleAgentSecurityAuditList 处理 agent.security.audit.list。
+func (s *Server) handleAgentSecurityAuditList(params map[string]any) (any, *rpcError) {
+	data, err := s.orchestrator.SecurityAuditList(params)
 	return wrapOrchestratorResult(data, err)
 }
 

--- a/services/local-service/internal/rpc/handlers.go
+++ b/services/local-service/internal/rpc/handlers.go
@@ -249,6 +249,14 @@ func wrapOrchestratorResult(data any, err error) (any, *rpcError) {
 			TraceID: "trace_task_already_finished",
 		}
 	}
+	if errors.Is(err, orchestrator.ErrStorageQueryFailed) {
+		return nil, &rpcError{
+			Code:    1005001,
+			Message: "SQLITE_WRITE_FAILED",
+			Detail:  err.Error(),
+			TraceID: "trace_storage_query_failed",
+		}
+	}
 
 	return nil, &rpcError{
 		Code:    errInvalidParams,

--- a/services/local-service/internal/rpc/server_test.go
+++ b/services/local-service/internal/rpc/server_test.go
@@ -238,8 +238,9 @@ func TestDispatchReturnsSecurityAuditList(t *testing.T) {
 		ID:      json.RawMessage(`"req-security-audit-list"`),
 		Method:  "agent.security.audit.list",
 		Params: mustMarshal(t, map[string]any{
-			"limit":  20,
-			"offset": 0,
+			"task_id": "task_001",
+			"limit":   20,
+			"offset":  0,
 		}),
 	})
 
@@ -253,6 +254,16 @@ func TestDispatchReturnsSecurityAuditList(t *testing.T) {
 	}
 	if items[0]["audit_id"] != "audit_001" {
 		t.Fatalf("expected stored audit_001, got %+v", items[0])
+	}
+}
+
+func TestDispatchMapsSecurityAuditListStorageErrors(t *testing.T) {
+	_, rpcErr := wrapOrchestratorResult(nil, orchestrator.ErrStorageQueryFailed)
+	if rpcErr == nil {
+		t.Fatal("expected rpc error")
+	}
+	if rpcErr.Code != 1005001 || rpcErr.Message != "SQLITE_WRITE_FAILED" {
+		t.Fatalf("expected SQLITE_WRITE_FAILED mapping, got code=%d message=%s", rpcErr.Code, rpcErr.Message)
 	}
 }
 

--- a/services/local-service/internal/rpc/server_test.go
+++ b/services/local-service/internal/rpc/server_test.go
@@ -2,12 +2,15 @@
 package rpc
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/audit"
 	serviceconfig "github.com/cialloclaw/cialloclaw/services/local-service/internal/config"
 	contextsvc "github.com/cialloclaw/cialloclaw/services/local-service/internal/context"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/delivery"
@@ -15,9 +18,11 @@ import (
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/memory"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/model"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/orchestrator"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/platform"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/plugin"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/risk"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/runengine"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/storage"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/tools"
 )
 
@@ -206,6 +211,48 @@ func TestDispatchMapsTaskControlFinishedErrors(t *testing.T) {
 	}
 	if errEnvelope.Error.Code != 1001005 || errEnvelope.Error.Message != "TASK_ALREADY_FINISHED" {
 		t.Fatalf("expected TASK_ALREADY_FINISHED mapping, got code=%d message=%s", errEnvelope.Error.Code, errEnvelope.Error.Message)
+	}
+}
+
+func TestDispatchReturnsSecurityAuditList(t *testing.T) {
+	server := newTestServer()
+	storageService := storage.NewService(platform.NewLocalStorageAdapter(filepath.Join(t.TempDir(), "audit.db")))
+	defer func() { _ = storageService.Close() }()
+	server.orchestrator.WithStorage(storageService)
+	err := storageService.AuditWriter().WriteAuditRecord(context.Background(), audit.Record{
+		AuditID:   "audit_001",
+		TaskID:    "task_001",
+		Type:      "file",
+		Action:    "write_file",
+		Summary:   "stored audit record",
+		Target:    "workspace/result.md",
+		Result:    "success",
+		CreatedAt: "2026-04-08T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("write audit record: %v", err)
+	}
+
+	response := server.dispatch(requestEnvelope{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`"req-security-audit-list"`),
+		Method:  "agent.security.audit.list",
+		Params: mustMarshal(t, map[string]any{
+			"limit":  20,
+			"offset": 0,
+		}),
+	})
+
+	success, ok := response.(successEnvelope)
+	if !ok {
+		t.Fatalf("expected success response envelope, got %#v", response)
+	}
+	items := success.Result.Data.(map[string]any)["items"].([]map[string]any)
+	if len(items) != 1 {
+		t.Fatalf("expected one audit item, got %d", len(items))
+	}
+	if items[0]["audit_id"] != "audit_001" {
+		t.Fatalf("expected stored audit_001, got %+v", items[0])
 	}
 }
 

--- a/services/local-service/internal/storage/README.md
+++ b/services/local-service/internal/storage/README.md
@@ -38,6 +38,7 @@ This module owns the backend-local storage boundary inside `services/local-servi
 - RPC response assembly does not belong here
 - Memory retrieval business logic does not belong here; only storage-facing contracts and temporary local implementations live here
 - Governance writer persistence now also belongs here, but governance rule evaluation still does not
+- `audit` 与 `recovery_point` 的最小读侧查询也已进入 storage 层
 - Artifact and Stronghold implementations do not belong here yet
 - Protocol schema ownership stays in `/packages/protocol`
 - Current SQLite search implementation uses an FTS5 skeleton plus fallback SQL scanning, and is still not the final FTS/vec retrieval design
@@ -48,6 +49,7 @@ This module owns the backend-local storage boundary inside `services/local-servi
 - The exact storage-facing interface for memory persistence
 - Whether artifact storage and secret storage share this module or split further
 - The final read/query interfaces for persisted audit and recovery-point data
+- governance 列表型接口（如 `agent.security.audit.list` / `agent.security.restore_points.list`）是否需要进一步分页与过滤增强
 - Whether database path validation should later depend on stronger path-policy checks
 - The final capability snapshot fields required by bootstrap or orchestrator
 - When the in-memory memory store should be replaced by SQLite-backed persistence

--- a/services/local-service/internal/storage/governance_store.go
+++ b/services/local-service/internal/storage/governance_store.go
@@ -311,11 +311,14 @@ func openSQLiteDatabase(databasePath string) (*sql.DB, error) {
 }
 
 func pageAuditRecords(items []audit.Record, limit, offset int) []audit.Record {
+	if offset < 0 {
+		offset = 0
+	}
 	if offset >= len(items) {
 		return nil
 	}
 	if limit <= 0 {
-		limit = len(items)
+		limit = 20
 	}
 	end := offset + limit
 	if end > len(items) {
@@ -325,11 +328,14 @@ func pageAuditRecords(items []audit.Record, limit, offset int) []audit.Record {
 }
 
 func pageRecoveryPoints(items []checkpoint.RecoveryPoint, limit, offset int) []checkpoint.RecoveryPoint {
+	if offset < 0 {
+		offset = 0
+	}
 	if offset >= len(items) {
 		return nil
 	}
 	if limit <= 0 {
-		limit = len(items)
+		limit = 20
 	}
 	end := offset + limit
 	if end > len(items) {

--- a/services/local-service/internal/tools/README.md
+++ b/services/local-service/internal/tools/README.md
@@ -299,6 +299,11 @@
 - plugin sidecar spec 声明
 - platform named pipe 最小状态骨架
 
+当前 `write_file` 的 `artifact_candidate` 正式消费规则已经冻结为：
+
+- `delivery` 已生成正式 artifact 时，以 `delivery` 为主
+- `delivery` 未生成 artifact 时，才由 `artifact_candidate` 兜底提升为正式 artifact
+
 ---
 
 ## 9. 禁止事项


### PR DESCRIPTION
## 背景

本分支基于主分支执行线，集中补齐 5 号负责人范围内最直接影响 MVP / P0 主链路的后端能力、数据与治理缺口。目标不是再做外围增强，而是让主链路所依赖的底座真正具备：

- 可执行
- 可记录
- 可审计
- 可恢复
- 可回显
- 可验证

重点覆盖范围包括：

- `model`
- `tools`
- `storage`
- `risk`
- `audit`
- `checkpoint`
- `platform`
- `bootstrap`
- `execution`
- `orchestrator`
- `taskinspector`

---

## 本次变更

### 1. governance 写侧：storage -> audit / checkpoint
- `storage` 新增真实 writer 出口：
  - `AuditWriter()`
  - `RecoveryPointWriter()`
- `bootstrap` 改为注入真实 governance writer：
  - `audit.NewService(storageService.AuditWriter())`
  - `checkpoint.NewService(storageService.RecoveryPointWriter())`

### 2. governance 读侧：storage -> orchestrator
- `storage` 新增读侧：
  - `AuditStore.ListAuditRecords(...)`
  - `RecoveryPointStore.ListRecoveryPoints(...)`
- `orchestrator` 开始消费 storage-backed governance 数据：
  - `TaskDetailGet` fallback 读取 `latest_restore_point`
  - `SecuritySummaryGet` fallback 读取 `latest_restore_point`
  - `DashboardOverviewGet` / `DashboardModuleGet` fallback 读取最近 audit 摘要与动作
- 新增最小 planned 接口后端路径：
  - `agent.security.audit.list`

### 3. tools/builtin 安全与行为收口
- `read_file`
  - 增加超大文件保护
  - 增加更稳的 `mime_type / text_type` 判断
- `exec_command`
  - 增加 `working_dir` 的 workspace 边界约束
  - 增加 stdout / stderr 大输出控制
- 抽 builtin 公共 helper，减少输入/输出解析重复
- 补 `write_file` 的 dry_run / overwrite 风险测试

### 4. artifact candidate 最小正式消费规则
冻结规则：
- `delivery` 已生成正式 artifact 时，以 `delivery` 为主
- `delivery` 未生成 artifact，且 tool 输出存在 `artifact_candidate` 时，由 candidate 兜底提升为正式 artifact

### 5. page_read / page_search + Playwright sidecar 最小骨架
- 新增：
  - `page_read`
  - `page_search`
- 增加：
  - `PlaywrightSidecarClient`
  - `PlaywrightSidecarRuntime`
  - `plugin.SidecarSpec(...)`
  - `LocalOSCapabilityAdapter` 的最小 named-pipe 状态表达
- bootstrap 已能：
  - 创建 sidecar runtime
  - 注入 page tools 的运行时 client
- execution/orchestrator 已具备 page tools 的最小运行时路径

### 6. 额外稳定性修复
- `taskinspector` 对 runtime notepad 的 `due_today` 统计逻辑已修正
- sidecar spec 已改为平台中立表达，不再在 plugin 层写死 Windows pipe 路径
- `page_search.limit` 兼容通用 `map[string]any` 数值输入
- page-read sidecar skeleton 在 ready 状态下返回确定性 stub 结果，而不再无条件失败

### 7. 文档同步
- 更新：
  - `storage/README.md`
  - `audit/README.md`
  - `checkpoint/README.md`
  - `tools/README.md`
- 更新桌面待办文档：
  - `backend-main-mvp-run总待办清单.md`

---

## 影响范围

### 后端能力 / 数据 / 治理
- `services/local-service/internal/storage/*`
- `services/local-service/internal/audit/*`
- `services/local-service/internal/checkpoint/*`
- `services/local-service/internal/risk/*`
- `services/local-service/internal/tools/*`
- `services/local-service/internal/platform/*`
- `services/local-service/internal/plugin/*`
- `services/local-service/internal/bootstrap/*`
- `services/local-service/internal/execution/*`
- `services/local-service/internal/orchestrator/*`
- `services/local-service/internal/taskinspector/*`

### worker
- `workers/playwright-worker/src/index.ts`

---

## 关键提交

核心提交包括：

- `b387672` `feat(storage): add audit and checkpoint writers`
- `d4478f4` `feat(tools): harden read_file limits and typing`
- `43ab0cf` `feat(tools): harden exec_command boundaries`
- `4352e79` `refactor(tools): share builtin input helpers`
- `d0d5a0b` `test(tools): expand write_file dry run coverage`
- `84da197` `feat(storage): add governance read-side stores`
- `69a0e15` `feat(governance): read stored recovery points in orchestrator`
- `7ae8130` `feat(execution): consume artifact candidate fallback`
- `d4ed671` `feat(governance): read stored audit summaries in orchestrator`
- `e3b6c54` `feat(security): add audit list backend path`
- `255c63a` `feat(tools): add page read and playwright sidecar skeleton`
- `5eba9e5` `feat(tools): wire page read runtime path`
- `6c2adc9` `feat(playwright): add sidecar startup skeleton`
- `46dfab4` `fix(playwright): harden sidecar skeleton semantics`
- `b419614` `fix(taskinspector): normalize due_today runtime counting`
- `0c3d24c` `docs(backend): finalize governance and tools status`

---

## 验证方式

我已通过以下完整回归：

```bash
go test ./services/local-service/internal/rpc \
  ./services/local-service/cmd/server \
  ./services/local-service/internal/model \
  ./services/local-service/internal/memory \
  ./services/local-service/internal/risk \
  ./services/local-service/internal/audit \
  ./services/local-service/internal/checkpoint \
  ./services/local-service/internal/storage \
  ./services/local-service/internal/tools/... \
  ./services/local-service/internal/bootstrap \
  ./services/local-service/internal/execution \
  ./services/local-service/internal/orchestrator \
  ./services/local-service/internal/plugin \
  ./services/local-service/internal/platform \
  ./services/local-service/internal/taskinspector
