### PR TITLE
Add Go coverage reporting to the check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,5 +24,8 @@ jobs:
       - name: Download Go modules
         run: go mod download
 
-      - name: Test Go code
-        run: go test -v  ./...
+      - name: Test Go code with coverage
+        run: go test -v -race -covermode=atomic -coverprofile=coverage.out ./...
+
+      - name: Report Go coverage summary
+        run: go tool cover -func=coverage.out


### PR DESCRIPTION
## Summary
- update the GitHub Actions check workflow to run Go tests with coverage enabled
- generate `coverage.out` during the existing test job
- print the Go coverage summary in workflow logs with `go tool cover -func=coverage.out`
- keep the solution fully local to GitHub Actions without introducing Codecov integration or a `codecov.yml` file

## Unified Item Impact
- affects CI workflow behavior only
- does not add new protocol fields
- does not add new JSON-RPC methods
- does not add new error codes

## Main Flow Impact
- no runtime behavior change
- improves CI visibility for backend test coverage in pull requests and push checks

## Platform Abstraction Impact
- no

## Memory / Model / Stronghold Impact
- no memory backend change
- no model SDK change
- no Stronghold change

## AI Usage
- generated with AI assistance and manually cleaned up
- manually reviewed workflow scope and coverage command changes

## Testing
- not run locally after the final workflow-only update
- intended validation path is GitHub Actions on the PR
