### PR TITLE
feat(security): tighten governance control and merge restore apply flow

### DIFF
--- a/docs/protocol-design.md
+++ b/docs/protocol-design.md
@@ -482,6 +482,8 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
 - `agent.dashboard.module.get`
 - `agent.mirror.overview.get`
 - `agent.security.summary.get`
+- `agent.security.restore_points.list`
+- `agent.security.restore.apply`
 - `agent.security.pending.list`
 - `agent.security.respond`
 
@@ -493,8 +495,6 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
 ### 7.2 planned
 
 - `agent.security.audit.list`
-- `agent.security.restore_points.list`
-- `agent.security.restore.apply`
 - `agent.mirror.memory.manage`
 - `agent.task.artifact.list`
 - `agent.task.artifact.open`
@@ -2132,6 +2132,183 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
     },
     "meta": {
       "server_time": "2026-04-07T11:04:01+08:00"
+    },
+    "warnings": []
+  }
+}
+```
+
+---
+
+### 8.3.7 `agent.security.restore_points.list`
+
+- **请求方式**：JSON-RPC 2.0
+- **接口调用时机**：用户在安全卫士或任务详情中查看恢复点列表时
+- **系统处理**：按任务或全局范围返回恢复点列表
+- **入参**：可选任务 ID、分页参数
+- **出参**：恢复点列表、分页信息
+
+### agent.security.restore_points.list 入参说明
+
+| 字段      | 中文说明        |
+| --------- | --------------- |
+| `task_id` | 可选的任务 ID   |
+| `limit`   | 每页条数        |
+| `offset`  | 分页偏移        |
+
+### agent.security.restore_points.list 入参示例
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req_security_restore_points_001",
+  "method": "agent.security.restore_points.list",
+  "params": {
+    "request_meta": {
+      "trace_id": "trace_security_restore_points_001",
+      "client_time": "2026-04-07T11:05:00+08:00"
+    },
+    "task_id": "task_301",
+    "limit": 20,
+    "offset": 0
+  }
+}
+```
+
+### agent.security.restore_points.list 出参说明
+
+| 字段                             | 中文说明     |
+| -------------------------------- | ------------ |
+| `data.items`                     | 恢复点列表   |
+| `data.items[].recovery_point_id` | 恢复点 ID    |
+| `data.items[].task_id`           | 关联任务 ID  |
+| `data.items[].summary`           | 恢复点说明   |
+| `data.items[].objects`           | 关联对象清单 |
+| `data.page`                      | 分页信息     |
+
+### agent.security.restore_points.list 出参示例
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req_security_restore_points_001",
+  "result": {
+    "data": {
+      "items": [
+        {
+          "recovery_point_id": "rp_001",
+          "task_id": "task_301",
+          "summary": "write_file_before_change",
+          "created_at": "2026-04-07T11:04:30+08:00",
+          "objects": ["workspace/notes/output.md"]
+        }
+      ],
+      "page": {
+        "limit": 20,
+        "offset": 0,
+        "total": 1,
+        "has_more": false
+      }
+    },
+    "meta": {
+      "server_time": "2026-04-07T11:05:01+08:00"
+    },
+    "warnings": []
+  }
+}
+```
+
+---
+
+### 8.3.8 `agent.security.restore.apply`
+
+- **请求方式**：JSON-RPC 2.0
+- **接口调用时机**：用户选定某个恢复点并发起回滚时
+- **系统处理**：执行恢复点对应的工作区回滚，并回写任务、安全状态与审计记录
+- **入参**：可选任务 ID、恢复点 ID
+- **出参**：是否成功、更新后的任务、恢复点、审计记录、状态气泡
+
+### agent.security.restore.apply 入参说明
+
+| 字段                | 中文说明       |
+| ------------------- | -------------- |
+| `task_id`           | 可选的任务 ID  |
+| `recovery_point_id` | 目标恢复点 ID  |
+
+### agent.security.restore.apply 入参示例
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req_security_restore_apply_001",
+  "method": "agent.security.restore.apply",
+  "params": {
+    "request_meta": {
+      "trace_id": "trace_security_restore_apply_001",
+      "client_time": "2026-04-07T11:06:00+08:00"
+    },
+    "task_id": "task_301",
+    "recovery_point_id": "rp_001"
+  }
+}
+```
+
+### agent.security.restore.apply 出参说明
+
+| 字段                  | 中文说明         |
+| --------------------- | ---------------- |
+| `data.applied`        | 是否恢复成功     |
+| `data.task`           | 更新后的任务对象 |
+| `data.recovery_point` | 本次使用的恢复点 |
+| `data.audit_record`   | 恢复审计记录     |
+| `data.bubble_message` | 状态提示气泡     |
+
+### agent.security.restore.apply 错误说明
+
+| 错误码 | 错误名 | 中文说明 |
+| ------ | ------ | -------- |
+| `1005001` | `SQLITE_WRITE_FAILED` | 恢复点读取或持久化存储查询失败 |
+| `1005002` | `ARTIFACT_NOT_FOUND` | 指定恢复点不存在，或与目标任务不匹配 |
+
+### agent.security.restore.apply 出参示例
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req_security_restore_apply_001",
+  "result": {
+    "data": {
+      "applied": true,
+      "task": {
+        "task_id": "task_301",
+        "status": "completed"
+      },
+      "recovery_point": {
+        "recovery_point_id": "rp_001",
+        "task_id": "task_301",
+        "summary": "write_file_before_change",
+        "created_at": "2026-04-07T11:04:30+08:00",
+        "objects": ["workspace/notes/output.md"]
+      },
+      "audit_record": {
+        "audit_id": "audit_001",
+        "task_id": "task_301",
+        "type": "recovery",
+        "action": "restore_apply",
+        "summary": "已根据恢复点 rp_001 恢复 1 个对象。",
+        "target": "workspace/notes/output.md",
+        "result": "success",
+        "created_at": "2026-04-07T11:06:01+08:00"
+      },
+      "bubble_message": {
+        "bubble_id": "bubble_301",
+        "task_id": "task_301",
+        "type": "status",
+        "text": "已根据恢复点 rp_001 恢复 1 个对象。"
+      }
+    },
+    "meta": {
+      "server_time": "2026-04-07T11:06:01+08:00"
     },
     "warnings": []
   }

--- a/docs/protocol-design.md
+++ b/docs/protocol-design.md
@@ -2236,9 +2236,9 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
 
 - **请求方式**：JSON-RPC 2.0
 - **接口调用时机**：用户选定某个恢复点并发起回滚时
-- **系统处理**：执行恢复点对应的工作区回滚，并回写任务、安全状态与审计记录
+- **系统处理**：先进入高风险授权链路；授权通过后执行恢复点对应的工作区回滚，并回写任务、安全状态与审计记录
 - **入参**：可选任务 ID、恢复点 ID
-- **出参**：是否成功、更新后的任务、恢复点、审计记录、状态气泡
+- **出参**：首次调用返回待授权状态；授权通过后由 `agent.security.respond` 返回最终恢复结果
 
 ### agent.security.restore.apply 入参说明
 
@@ -2269,11 +2269,17 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
 
 | 字段                  | 中文说明         |
 | --------------------- | ---------------- |
-| `data.applied`        | 是否恢复成功     |
-| `data.task`           | 更新后的任务对象 |
+| `data.applied`        | 当前阶段是否已完成恢复；首次调用固定为 `false` |
+| `data.task`           | 更新后的任务对象；首次调用进入 `waiting_auth` |
 | `data.recovery_point` | 本次使用的恢复点 |
-| `data.audit_record`   | 恢复审计记录     |
+| `data.audit_record`   | 恢复审计记录；首次调用通常为 `null` |
 | `data.bubble_message` | 状态提示气泡     |
+
+### agent.security.restore.apply 两阶段说明
+
+1. 第一次调用 `agent.security.restore.apply` 只创建高风险授权请求，并返回 `waiting_auth`
+2. 用户确认后，再通过 `agent.security.respond` 执行真正的恢复动作
+3. 最终的恢复成功/失败、审计记录和状态气泡在 `agent.security.respond` 响应中返回
 
 ### agent.security.restore.apply 错误说明
 
@@ -2282,12 +2288,48 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
 | `1005001` | `SQLITE_WRITE_FAILED` | 恢复点读取或持久化存储查询失败 |
 | `1005002` | `ARTIFACT_NOT_FOUND` | 指定恢复点不存在，或与目标任务不匹配 |
 
-### agent.security.restore.apply 出参示例
+### agent.security.restore.apply 首次出参示例
 
 ```json
 {
   "jsonrpc": "2.0",
   "id": "req_security_restore_apply_001",
+  "result": {
+    "data": {
+      "applied": false,
+      "task": {
+        "task_id": "task_301",
+        "status": "waiting_auth"
+      },
+      "recovery_point": {
+        "recovery_point_id": "rp_001",
+        "task_id": "task_301",
+        "summary": "write_file_before_change",
+        "created_at": "2026-04-07T11:04:30+08:00",
+        "objects": ["workspace/notes/output.md"]
+      },
+      "audit_record": null,
+      "bubble_message": {
+        "bubble_id": "bubble_301",
+        "task_id": "task_301",
+        "type": "status",
+        "text": "恢复点回滚属于高风险操作，请先确认授权。"
+      }
+    },
+    "meta": {
+      "server_time": "2026-04-07T11:06:01+08:00"
+    },
+    "warnings": []
+  }
+}
+```
+
+### agent.security.respond 恢复完成出参示例
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req_security_respond_restore_001",
   "result": {
     "data": {
       "applied": true,
@@ -2318,11 +2360,7 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
         "type": "status",
         "text": "已根据恢复点 rp_001 恢复 1 个对象。"
       }
-    },
-    "meta": {
-      "server_time": "2026-04-07T11:06:01+08:00"
-    },
-    "warnings": []
+    }
   }
 }
 ```

--- a/packages/protocol/rpc/methods.ts
+++ b/packages/protocol/rpc/methods.ts
@@ -51,6 +51,7 @@ export const RPC_METHODS_STABLE = {
   AGENT_DASHBOARD_MODULE_GET: "agent.dashboard.module.get",
   AGENT_MIRROR_OVERVIEW_GET: "agent.mirror.overview.get",
   AGENT_SECURITY_SUMMARY_GET: "agent.security.summary.get",
+  AGENT_SECURITY_RESTORE_POINTS_LIST: "agent.security.restore_points.list",
   AGENT_SECURITY_PENDING_LIST: "agent.security.pending.list",
   AGENT_SECURITY_RESPOND: "agent.security.respond",
   AGENT_SETTINGS_GET: "agent.settings.get",
@@ -459,6 +460,20 @@ export interface AgentSecurityPendingListParams {
 // AgentSecurityPendingListResult 定义当前模块的接口约束。
 export interface AgentSecurityPendingListResult {
   items: ApprovalRequest[];
+  page: JsonRpcPage;
+}
+
+// AgentSecurityRestorePointsListParams 定义当前模块的接口约束。
+export interface AgentSecurityRestorePointsListParams {
+  request_meta: RequestMeta;
+  task_id?: string;
+  limit: number;
+  offset: number;
+}
+
+// AgentSecurityRestorePointsListResult 定义当前模块的接口约束。
+export interface AgentSecurityRestorePointsListResult {
+  items: RecoveryPoint[];
   page: JsonRpcPage;
 }
 

--- a/packages/protocol/rpc/methods.ts
+++ b/packages/protocol/rpc/methods.ts
@@ -52,6 +52,7 @@ export const RPC_METHODS_STABLE = {
   AGENT_MIRROR_OVERVIEW_GET: "agent.mirror.overview.get",
   AGENT_SECURITY_SUMMARY_GET: "agent.security.summary.get",
   AGENT_SECURITY_RESTORE_POINTS_LIST: "agent.security.restore_points.list",
+  AGENT_SECURITY_RESTORE_APPLY: "agent.security.restore.apply",
   AGENT_SECURITY_PENDING_LIST: "agent.security.pending.list",
   AGENT_SECURITY_RESPOND: "agent.security.respond",
   AGENT_SETTINGS_GET: "agent.settings.get",
@@ -61,8 +62,6 @@ export const RPC_METHODS_STABLE = {
 // RPC_METHODS_PLANNED 定义共享常量。
 export const RPC_METHODS_PLANNED = {
   AGENT_SECURITY_AUDIT_LIST: "agent.security.audit.list",
-  AGENT_SECURITY_RESTORE_POINTS_LIST: "agent.security.restore_points.list",
-  AGENT_SECURITY_RESTORE_APPLY: "agent.security.restore.apply",
   AGENT_MIRROR_MEMORY_MANAGE: "agent.mirror.memory.manage",
   AGENT_TASK_ARTIFACT_LIST: "agent.task.artifact.list",
   AGENT_TASK_ARTIFACT_OPEN: "agent.task.artifact.open",
@@ -475,6 +474,22 @@ export interface AgentSecurityRestorePointsListParams {
 export interface AgentSecurityRestorePointsListResult {
   items: RecoveryPoint[];
   page: JsonRpcPage;
+}
+
+// AgentSecurityRestoreApplyParams 定义当前模块的接口约束。
+export interface AgentSecurityRestoreApplyParams {
+  request_meta: RequestMeta;
+  task_id?: string;
+  recovery_point_id: string;
+}
+
+// AgentSecurityRestoreApplyResult 定义当前模块的接口约束。
+export interface AgentSecurityRestoreApplyResult {
+  applied: boolean;
+  task: Task;
+  recovery_point: RecoveryPoint;
+  audit_record: AuditRecord | null;
+  bubble_message: BubbleMessage | null;
 }
 
 // AgentSecurityRespondParams 定义当前模块的接口约束。

--- a/services/local-service/internal/audit/service.go
+++ b/services/local-service/internal/audit/service.go
@@ -301,6 +301,10 @@ func fallbackToolAuditCandidate(toolCall tools.ToolCallRecord, tokenUsage map[st
 		"target":  "main_flow",
 		"result":  "success",
 	}
+	if toolCall.Status != tools.ToolCallStatusSucceeded {
+		candidate["summary"] = "tool execution failed"
+		candidate["result"] = string(toolCall.Status)
+	}
 
 	switch toolCall.ToolName {
 	case "generate_text":
@@ -311,6 +315,15 @@ func fallbackToolAuditCandidate(toolCall tools.ToolCallRecord, tokenUsage map[st
 		candidate["summary"] = "write file output"
 		if pathValue := stringValue(toolCall.Input, "path", ""); pathValue != "" {
 			candidate["target"] = pathValue
+		}
+	case "exec_command":
+		candidate["type"] = "command"
+		candidate["summary"] = "command execution completed"
+		if workingDir := stringValue(toolCall.Input, "working_dir", ""); workingDir != "" {
+			candidate["target"] = workingDir
+		}
+		if toolCall.Status != tools.ToolCallStatusSucceeded {
+			candidate["summary"] = "command execution failed"
 		}
 	}
 

--- a/services/local-service/internal/checkpoint/service.go
+++ b/services/local-service/internal/checkpoint/service.go
@@ -3,8 +3,11 @@ package checkpoint
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
+	"path"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -14,12 +17,21 @@ var (
 	ErrTaskIDRequired   = errors.New("checkpoint: task_id is required")
 	ErrSummaryRequired  = errors.New("checkpoint: summary is required")
 	ErrCandidateInvalid = errors.New("checkpoint: candidate is invalid")
+	ErrSnapshotFSNil    = errors.New("checkpoint: snapshot file system is required")
+	ErrObjectsRequired  = errors.New("checkpoint: objects are required")
 )
+
+const snapshotRoot = ".recovery_points"
 
 type noopWriter struct{}
 
 func (noopWriter) WriteRecoveryPoint(_ context.Context, _ RecoveryPoint) error {
 	return nil
+}
+
+type snapshotPayload struct {
+	Exists  bool   `json:"exists"`
+	Content []byte `json:"content,omitempty"`
 }
 
 // Service 提供当前模块的服务能力。
@@ -115,6 +127,109 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (RecoveryPoint,
 	return point, nil
 }
 
+// CreateWithSnapshots 会在持久化 recovery_point 前先把目标对象快照落到工作区恢复目录。
+func (s *Service) CreateWithSnapshots(ctx context.Context, fileSystem SnapshotFileSystem, input CreateInput) (RecoveryPoint, error) {
+	if fileSystem == nil {
+		return RecoveryPoint{}, ErrSnapshotFSNil
+	}
+	point, err := s.BuildRecoveryPoint(input)
+	if err != nil {
+		return RecoveryPoint{}, err
+	}
+	if len(point.Objects) == 0 {
+		return RecoveryPoint{}, ErrObjectsRequired
+	}
+	for _, objectPath := range point.Objects {
+		normalizedObject := normalizeSnapshotObjectPath(objectPath)
+		if normalizedObject == "" {
+			return RecoveryPoint{}, ErrCandidateInvalid
+		}
+		payload := snapshotPayload{Exists: true}
+		content, err := fileSystem.ReadFile(normalizedObject)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				payload.Exists = false
+			} else {
+				return RecoveryPoint{}, fmt.Errorf("checkpoint: snapshot source %s: %w", normalizedObject, err)
+			}
+		} else {
+			payload.Content = content
+		}
+		encodedPayload, err := json.Marshal(payload)
+		if err != nil {
+			return RecoveryPoint{}, fmt.Errorf("checkpoint: encode snapshot %s: %w", normalizedObject, err)
+		}
+		if err := fileSystem.WriteFile(snapshotPath(point.RecoveryPointID, normalizedObject), encodedPayload); err != nil {
+			return RecoveryPoint{}, fmt.Errorf("checkpoint: write snapshot %s: %w", normalizedObject, err)
+		}
+	}
+	if err := s.writer.WriteRecoveryPoint(ctx, point); err != nil {
+		return RecoveryPoint{}, fmt.Errorf("checkpoint: write recovery point: %w", err)
+	}
+	return point, nil
+}
+
+// Apply 按 recovery_point 的对象清单恢复工作区快照。
+func (s *Service) Apply(ctx context.Context, fileSystem SnapshotFileSystem, point RecoveryPoint) (ApplyResult, error) {
+	_ = ctx
+	if fileSystem == nil {
+		return ApplyResult{}, ErrSnapshotFSNil
+	}
+	if strings.TrimSpace(point.RecoveryPointID) == "" {
+		return ApplyResult{}, ErrCandidateInvalid
+	}
+	if len(point.Objects) == 0 {
+		return ApplyResult{}, ErrObjectsRequired
+	}
+
+	backupPayloads := make(map[string]snapshotPayload, len(point.Objects))
+	restoreBackups := make(map[string]snapshotPayload, len(point.Objects))
+	orderedObjects := make([]string, 0, len(point.Objects))
+	for _, objectPath := range point.Objects {
+		normalizedObject := normalizeSnapshotObjectPath(objectPath)
+		if normalizedObject == "" {
+			return ApplyResult{}, ErrCandidateInvalid
+		}
+		content, err := fileSystem.ReadFile(snapshotPath(point.RecoveryPointID, normalizedObject))
+		if err != nil {
+			return ApplyResult{}, fmt.Errorf("checkpoint: read snapshot %s: %w", normalizedObject, err)
+		}
+		var payload snapshotPayload
+		if err := json.Unmarshal(content, &payload); err != nil {
+			return ApplyResult{}, fmt.Errorf("checkpoint: decode snapshot %s: %w", normalizedObject, err)
+		}
+		currentPayload := snapshotPayload{Exists: true}
+		currentContent, err := fileSystem.ReadFile(normalizedObject)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				currentPayload.Exists = false
+			} else {
+				return ApplyResult{}, fmt.Errorf("checkpoint: read current object %s: %w", normalizedObject, err)
+			}
+		} else {
+			currentPayload.Content = currentContent
+		}
+		backupPayloads[normalizedObject] = payload
+		restoreBackups[normalizedObject] = currentPayload
+		orderedObjects = append(orderedObjects, normalizedObject)
+	}
+
+	for _, objectPath := range orderedObjects {
+		if err := applySnapshotPayload(fileSystem, objectPath, backupPayloads[objectPath]); err != nil {
+			for rollbackIndex := len(orderedObjects) - 1; rollbackIndex >= 0; rollbackIndex-- {
+				rollbackPath := orderedObjects[rollbackIndex]
+				_ = applySnapshotPayload(fileSystem, rollbackPath, restoreBackups[rollbackPath])
+			}
+			return ApplyResult{}, fmt.Errorf("checkpoint: restore object %s: %w", objectPath, err)
+		}
+	}
+
+	return ApplyResult{
+		RecoveryPointID: point.RecoveryPointID,
+		RestoredObjects: orderedObjects,
+	}, nil
+}
+
 func validateCreateInput(input CreateInput) error {
 	if strings.TrimSpace(input.TaskID) == "" {
 		return ErrTaskIDRequired
@@ -130,4 +245,44 @@ var recoveryPointCounter uint64
 func nextRecoveryPointID() string {
 	seq := atomic.AddUint64(&recoveryPointCounter, 1)
 	return fmt.Sprintf("recovery_point_%d_%d", time.Now().UnixNano(), seq)
+}
+
+func snapshotPath(recoveryPointID, objectPath string) string {
+	normalizedObject := normalizeSnapshotObjectPath(objectPath)
+	if normalizedObject == "" {
+		return ""
+	}
+	return path.Join(snapshotRoot, recoveryPointID, normalizedObject)
+}
+
+func normalizeSnapshotObjectPath(objectPath string) string {
+	normalized := strings.TrimSpace(strings.ReplaceAll(objectPath, "\\", "/"))
+	if normalized == "" {
+		return ""
+	}
+	if strings.HasPrefix(normalized, "workspace/") {
+		normalized = strings.TrimPrefix(normalized, "workspace/")
+	}
+	normalized = strings.TrimPrefix(normalized, "./")
+	normalized = strings.TrimPrefix(normalized, "/")
+	if len(normalized) >= 2 && normalized[1] == ':' {
+		normalized = normalized[2:]
+		normalized = strings.TrimPrefix(normalized, "/")
+	}
+	cleaned := path.Clean(normalized)
+	if cleaned == "." || cleaned == "" || strings.HasPrefix(cleaned, "../") {
+		return ""
+	}
+	return cleaned
+}
+
+func applySnapshotPayload(fileSystem SnapshotFileSystem, objectPath string, payload snapshotPayload) error {
+	if payload.Exists {
+		return fileSystem.WriteFile(objectPath, payload.Content)
+	}
+	err := fileSystem.Remove(objectPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	return err
 }

--- a/services/local-service/internal/checkpoint/service_test.go
+++ b/services/local-service/internal/checkpoint/service_test.go
@@ -2,14 +2,27 @@ package checkpoint
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/platform"
 )
 
 type stubWriter struct {
 	points []RecoveryPoint
 	err    error
+}
+
+type failingSnapshotFS struct {
+	base         SnapshotFileSystem
+	failPath     string
+	failAfter    int
+	writesByPath map[string]int
 }
 
 func (s *stubWriter) WriteRecoveryPoint(_ context.Context, point RecoveryPoint) error {
@@ -18,6 +31,28 @@ func (s *stubWriter) WriteRecoveryPoint(_ context.Context, point RecoveryPoint) 
 	}
 	s.points = append(s.points, point)
 	return nil
+}
+
+func (s *failingSnapshotFS) ReadFile(path string) ([]byte, error) {
+	return s.base.ReadFile(path)
+}
+
+func (s *failingSnapshotFS) WriteFile(path string, content []byte) error {
+	if s.writesByPath == nil {
+		s.writesByPath = map[string]int{}
+	}
+	s.writesByPath[path]++
+	if path == s.failPath && s.writesByPath[path] == s.failAfter {
+		if err := s.base.WriteFile(path, []byte("partial content")); err != nil {
+			return err
+		}
+		return errors.New("forced write failure")
+	}
+	return s.base.WriteFile(path, content)
+}
+
+func (s *failingSnapshotFS) Remove(path string) error {
+	return s.base.Remove(path)
 }
 
 func TestServiceBuildRecoveryPoint(t *testing.T) {
@@ -125,5 +160,150 @@ func TestBuildCreateInputFromCandidate(t *testing.T) {
 				t.Fatalf("unexpected converted input: %+v", input)
 			}
 		})
+	}
+}
+
+func TestServiceCreateWithSnapshotsAndApply(t *testing.T) {
+	writer := &stubWriter{}
+	service := NewService(writer)
+
+	workspaceRoot := filepath.Join(t.TempDir(), "workspace")
+	pathPolicy, err := platform.NewLocalPathPolicy(workspaceRoot)
+	if err != nil {
+		t.Fatalf("new local path policy: %v", err)
+	}
+	fileSystem := platform.NewLocalFileSystemAdapter(pathPolicy)
+
+	if err := fileSystem.WriteFile("notes/report.md", []byte("before content")); err != nil {
+		t.Fatalf("seed source file: %v", err)
+	}
+
+	point, err := service.CreateWithSnapshots(context.Background(), fileSystem, CreateInput{
+		TaskID:  "task_001",
+		Summary: "before overwrite",
+		Objects: []string{"notes/report.md"},
+	})
+	if err != nil {
+		t.Fatalf("CreateWithSnapshots returned error: %v", err)
+	}
+	if len(writer.points) != 1 {
+		t.Fatalf("expected persisted recovery point, got %d", len(writer.points))
+	}
+	backupPath := filepath.Join(workspaceRoot, ".recovery_points", point.RecoveryPointID, "notes", "report.md")
+	backupContent, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("read backup file: %v", err)
+	}
+	var snapshot snapshotPayload
+	if err := json.Unmarshal(backupContent, &snapshot); err != nil {
+		t.Fatalf("decode snapshot payload: %v", err)
+	}
+	if !snapshot.Exists || string(snapshot.Content) != "before content" {
+		t.Fatalf("expected snapshot payload to preserve original content, got %+v", snapshot)
+	}
+
+	if err := fileSystem.WriteFile("notes/report.md", []byte("after content")); err != nil {
+		t.Fatalf("overwrite source file: %v", err)
+	}
+
+	applyResult, err := service.Apply(context.Background(), fileSystem, point)
+	if err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	if applyResult.RecoveryPointID != point.RecoveryPointID {
+		t.Fatalf("expected apply result to reference %s, got %+v", point.RecoveryPointID, applyResult)
+	}
+	if len(applyResult.RestoredObjects) != 1 || applyResult.RestoredObjects[0] != "notes/report.md" {
+		t.Fatalf("expected restored object notes/report.md, got %+v", applyResult.RestoredObjects)
+	}
+	restoredContent, err := os.ReadFile(filepath.Join(workspaceRoot, "notes", "report.md"))
+	if err != nil {
+		t.Fatalf("read restored file: %v", err)
+	}
+	if string(restoredContent) != "before content" {
+		t.Fatalf("expected restore to recover original content, got %q", string(restoredContent))
+	}
+}
+
+func TestServiceCreateWithSnapshotsHandlesNewFileRestore(t *testing.T) {
+	writer := &stubWriter{}
+	service := NewService(writer)
+
+	workspaceRoot := filepath.Join(t.TempDir(), "workspace")
+	pathPolicy, err := platform.NewLocalPathPolicy(workspaceRoot)
+	if err != nil {
+		t.Fatalf("new local path policy: %v", err)
+	}
+	fileSystem := platform.NewLocalFileSystemAdapter(pathPolicy)
+
+	point, err := service.CreateWithSnapshots(context.Background(), fileSystem, CreateInput{
+		TaskID:  "task_new_file",
+		Summary: "before create",
+		Objects: []string{"workspace/notes/new.md"},
+	})
+	if err != nil {
+		t.Fatalf("CreateWithSnapshots returned error: %v", err)
+	}
+	if err := fileSystem.WriteFile("notes/new.md", []byte("created later")); err != nil {
+		t.Fatalf("write new file: %v", err)
+	}
+	if _, err := fileSystem.Stat("notes/new.md"); err != nil {
+		t.Fatalf("expected new file to exist, got %v", err)
+	}
+	if _, err := service.Apply(context.Background(), fileSystem, point); err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	if _, err := fileSystem.Stat("notes/new.md"); !errors.Is(err, os.ErrNotExist) && !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("expected restore to remove newly created file, got %v", err)
+	}
+}
+
+func TestServiceApplyRollsBackEarlierObjectsWhenLaterRestoreFails(t *testing.T) {
+	writer := &stubWriter{}
+	service := NewService(writer)
+
+	workspaceRoot := filepath.Join(t.TempDir(), "workspace")
+	pathPolicy, err := platform.NewLocalPathPolicy(workspaceRoot)
+	if err != nil {
+		t.Fatalf("new local path policy: %v", err)
+	}
+	fileSystem := platform.NewLocalFileSystemAdapter(pathPolicy)
+	if err := fileSystem.WriteFile("notes/one.md", []byte("before one")); err != nil {
+		t.Fatalf("seed one: %v", err)
+	}
+	if err := fileSystem.WriteFile("notes/two.md", []byte("before two")); err != nil {
+		t.Fatalf("seed two: %v", err)
+	}
+	point, err := service.CreateWithSnapshots(context.Background(), fileSystem, CreateInput{
+		TaskID:  "task_multi",
+		Summary: "before overwrite",
+		Objects: []string{"workspace/notes/one.md", "workspace/notes/two.md"},
+	})
+	if err != nil {
+		t.Fatalf("CreateWithSnapshots returned error: %v", err)
+	}
+	if err := fileSystem.WriteFile("notes/one.md", []byte("after one")); err != nil {
+		t.Fatalf("overwrite one: %v", err)
+	}
+	if err := fileSystem.WriteFile("notes/two.md", []byte("after two")); err != nil {
+		t.Fatalf("overwrite two: %v", err)
+	}
+	failingFS := &failingSnapshotFS{base: fileSystem, failPath: "notes/two.md", failAfter: 1}
+	if _, err := service.Apply(context.Background(), failingFS, point); err == nil {
+		t.Fatal("expected apply to fail on second object")
+	}
+	oneContent, err := os.ReadFile(filepath.Join(workspaceRoot, "notes", "one.md"))
+	if err != nil {
+		t.Fatalf("read one after rollback: %v", err)
+	}
+	if string(oneContent) != "after one" {
+		t.Fatalf("expected first object to roll back to current content after failed restore, got %q", string(oneContent))
+	}
+	twoContent, err := os.ReadFile(filepath.Join(workspaceRoot, "notes", "two.md"))
+	if err != nil {
+		t.Fatalf("read two after rollback: %v", err)
+	}
+	if string(twoContent) != "after two" {
+		t.Fatalf("expected failed object to be restored to current content after rollback, got %q", string(twoContent))
 	}
 }

--- a/services/local-service/internal/checkpoint/types.go
+++ b/services/local-service/internal/checkpoint/types.go
@@ -23,9 +23,22 @@ type RecoveryPoint struct {
 	Objects         []string
 }
 
+// ApplyResult 描述一次恢复点应用成功后的最小结果。
+type ApplyResult struct {
+	RecoveryPointID string
+	RestoredObjects []string
+}
+
 // Writer 是恢复点输出边界。
 //
 // 当前不绑定数据库实现，后续由 storage 或其他持久化层注入。
 type Writer interface {
 	WriteRecoveryPoint(ctx context.Context, point RecoveryPoint) error
+}
+
+// SnapshotFileSystem 是 checkpoint 对工作区快照与恢复所需的最小文件接口。
+type SnapshotFileSystem interface {
+	ReadFile(path string) ([]byte, error)
+	WriteFile(path string, content []byte) error
+	Remove(path string) error
 }

--- a/services/local-service/internal/execution/service.go
+++ b/services/local-service/internal/execution/service.go
@@ -3,7 +3,9 @@ package execution
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"path"
 	"path/filepath"
 	"strings"
@@ -51,6 +53,7 @@ type Result struct {
 	DeliveryResult  map[string]any
 	Artifacts       []map[string]any
 	BubbleText      string
+	RecoveryPoint   map[string]any
 	ModelInvocation map[string]any
 	AuditRecord     map[string]any
 	ToolCalls       []tools.ToolCallRecord
@@ -252,6 +255,10 @@ func (s *Service) executeThroughToolExecutor(ctx context.Context, request Reques
 	if !ok || s.executor == nil {
 		return Result{}, false, nil
 	}
+	preWriteRecoveryPoint, err := s.prepareWriteFileRecoveryPoint(ctx, request, toolName, toolInput)
+	if err != nil {
+		return Result{}, false, err
+	}
 
 	workspacePath := workspacePathFromDeliveryResult(deliveryResult)
 	toolResult, err := s.executor.ExecuteToolWithContext(ctx, &tools.ToolExecuteContext{
@@ -265,11 +272,18 @@ func (s *Service) executeThroughToolExecutor(ctx context.Context, request Reques
 	if err != nil {
 		return Result{}, false, fmt.Errorf("execute tool %s: %w", toolName, err)
 	}
+	if len(preWriteRecoveryPoint) > 0 {
+		if toolResult.RawOutput == nil {
+			toolResult.RawOutput = map[string]any{}
+		}
+		toolResult.RawOutput["recovery_point"] = cloneOutput(preWriteRecoveryPoint)
+	}
 
 	result := Result{
 		Content:        outputText,
 		DeliveryResult: deliveryResult,
 		Artifacts:      toolArtifactsFromResult(request.TaskID, toolResult),
+		RecoveryPoint:  extractRecoveryPoint(toolResult.RawOutput),
 		ToolCalls:      []tools.ToolCallRecord{normalizeFilesystemToolCall(toolResult.ToolCall, toolInput)},
 		ToolName:       toolName,
 		ToolInput:      toolInput,
@@ -458,21 +472,23 @@ func (s *Service) consumeWriteFileCandidates(ctx context.Context, taskID string,
 	}
 
 	if checkpointCandidate, ok := rawOutput["checkpoint_candidate"].(map[string]any); ok && s.checkpoint != nil {
-		createInput, shouldCreate, err := checkpoint.BuildCreateInputFromCandidate(taskID, checkpointCandidate)
-		if err != nil {
-			return nil, nil, fmt.Errorf("build checkpoint input from candidate: %w", err)
-		}
-		if shouldCreate {
-			point, err := s.checkpoint.Create(ctx, createInput)
+		if _, hasRecoveryPoint := merged["recovery_point"].(map[string]any); !hasRecoveryPoint {
+			createInput, shouldCreate, err := checkpoint.BuildCreateInputFromCandidate(taskID, checkpointCandidate)
 			if err != nil {
-				return nil, nil, fmt.Errorf("create recovery point from candidate: %w", err)
+				return nil, nil, fmt.Errorf("build checkpoint input from candidate: %w", err)
 			}
-			merged["recovery_point"] = map[string]any{
-				"recovery_point_id": point.RecoveryPointID,
-				"task_id":           point.TaskID,
-				"summary":           point.Summary,
-				"created_at":        point.CreatedAt,
-				"objects":           point.Objects,
+			if shouldCreate {
+				point, err := s.checkpoint.Create(ctx, createInput)
+				if err != nil {
+					return nil, nil, fmt.Errorf("create recovery point from candidate: %w", err)
+				}
+				merged["recovery_point"] = map[string]any{
+					"recovery_point_id": point.RecoveryPointID,
+					"task_id":           point.TaskID,
+					"summary":           point.Summary,
+					"created_at":        point.CreatedAt,
+					"objects":           point.Objects,
+				}
 			}
 		}
 	}
@@ -489,6 +505,73 @@ func (s *Service) consumeWriteFileCandidates(ctx context.Context, taskID string,
 	}
 
 	return merged, artifact, nil
+}
+
+// ApplyRecoveryPoint 将某个恢复点对应的工作区快照重新写回目标对象。
+func (s *Service) ApplyRecoveryPoint(ctx context.Context, point checkpoint.RecoveryPoint) (checkpoint.ApplyResult, error) {
+	if s.checkpoint == nil {
+		return checkpoint.ApplyResult{}, fmt.Errorf("apply recovery point: checkpoint service unavailable")
+	}
+	if s.fileSystem == nil {
+		return checkpoint.ApplyResult{}, fmt.Errorf("apply recovery point: file system unavailable")
+	}
+	result, err := s.checkpoint.Apply(ctx, s.fileSystem, point)
+	if err != nil {
+		return checkpoint.ApplyResult{}, fmt.Errorf("apply recovery point %s: %w", point.RecoveryPointID, err)
+	}
+	return result, nil
+}
+
+func (s *Service) prepareWriteFileRecoveryPoint(ctx context.Context, request Request, toolName string, toolInput map[string]any) (map[string]any, error) {
+	if toolName != "write_file" || s.checkpoint == nil || s.fileSystem == nil {
+		return nil, nil
+	}
+	targetPath := stringValue(toolInput, "path", "")
+	if targetPath == "" {
+		return nil, nil
+	}
+	if _, err := s.fileSystem.Stat(targetPath); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("inspect write_file target %s: %w", targetPath, err)
+		}
+	}
+	point, err := s.checkpoint.CreateWithSnapshots(ctx, s.fileSystem, checkpoint.CreateInput{
+		TaskID:  request.TaskID,
+		Summary: "write_file_before_change",
+		Objects: []string{checkpointObjectPath(targetPath)},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create pre-write recovery point: %w", err)
+	}
+	return map[string]any{
+		"recovery_point_id": point.RecoveryPointID,
+		"task_id":           point.TaskID,
+		"summary":           point.Summary,
+		"created_at":        point.CreatedAt,
+		"objects":           append([]string(nil), point.Objects...),
+	}, nil
+}
+
+func extractRecoveryPoint(output map[string]any) map[string]any {
+	if len(output) == 0 {
+		return nil
+	}
+	recoveryPoint, ok := output["recovery_point"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return cloneOutput(recoveryPoint)
+}
+
+func checkpointObjectPath(targetPath string) string {
+	if targetPath == "" {
+		return ""
+	}
+	normalized := strings.TrimSpace(strings.ReplaceAll(targetPath, "\\", "/"))
+	if normalized == "" || strings.HasPrefix(normalized, "workspace/") {
+		return normalized
+	}
+	return path.Join("workspace", normalized)
 }
 
 func cloneOutput(input map[string]any) map[string]any {

--- a/services/local-service/internal/execution/service.go
+++ b/services/local-service/internal/execution/service.go
@@ -38,14 +38,16 @@ type Service struct {
 
 // Request 描述一次任务执行所需的最小输入。
 type Request struct {
-	TaskID          string
-	RunID           string
-	Title           string
-	Intent          map[string]any
-	Snapshot        contextsvc.TaskContextSnapshot
-	DeliveryType    string
-	ResultTitle     string
-	ApprovalGranted bool
+	TaskID               string
+	RunID                string
+	Title                string
+	Intent               map[string]any
+	Snapshot             contextsvc.TaskContextSnapshot
+	DeliveryType         string
+	ResultTitle          string
+	ApprovalGranted      bool
+	ApprovedOperation    string
+	ApprovedTargetObject string
 }
 
 // Result 描述执行完成后需要回填给 orchestrator 的交付与痕迹。
@@ -337,8 +339,7 @@ func (s *Service) executeThroughToolExecutor(ctx context.Context, request Reques
 		return Result{}, false, nil
 	}
 
-	workspacePath := workspacePathFromDeliveryResult(deliveryResult)
-	toolResult, recoveryPoint, err := s.executeTool(ctx, request, workspacePath, toolName, toolInput)
+	toolResult, recoveryPoint, err := s.executeTool(ctx, request, s.workspace, toolName, toolInput)
 	if err != nil {
 		failedResult := Result{
 			Content:        outputText,
@@ -1187,22 +1188,20 @@ func (s *Service) resolveGovernanceToolExecution(request Request) (string, map[s
 		return "", nil, nil, false, nil
 	}
 	toolName, toolInput := "write_file", map[string]any{"path": writePath, "content": ""}
-	workspacePath := s.workspace
-	if toolName == "write_file" {
-		workspacePath = workspacePathFromDeliveryResult(deliveryResult)
-	}
-	return toolName, toolInput, s.toolExecutionContext(workspacePath, request), true, nil
+	return toolName, toolInput, s.toolExecutionContext(s.workspace, request), true, nil
 }
 
 func (s *Service) toolExecutionContext(workspacePath string, request Request) *tools.ToolExecuteContext {
 	workspacePath = firstNonEmpty(strings.TrimSpace(workspacePath), s.workspace)
+	approvedOperation := firstNonEmpty(strings.TrimSpace(request.ApprovedOperation), stringValue(request.Intent, "name", ""))
+	approvedTargetObject := firstNonEmpty(strings.TrimSpace(request.ApprovedTargetObject), approvedTargetObject(request.Intent, s.workspace))
 	return &tools.ToolExecuteContext{
 		TaskID:               request.TaskID,
 		RunID:                request.RunID,
 		WorkspacePath:        workspacePath,
 		ApprovalGranted:      request.ApprovalGranted,
-		ApprovedOperation:    stringValue(request.Intent, "name", ""),
-		ApprovedTargetObject: approvedTargetObject(request.Intent, s.workspace),
+		ApprovedOperation:    approvedOperation,
+		ApprovedTargetObject: approvedTargetObject,
 		Platform:             s.fileSystem,
 		Execution:            s.execution,
 		Playwright:           s.playwright,
@@ -1230,22 +1229,7 @@ func (s *Service) prepareGovernanceRecoveryPoint(ctx context.Context, request Re
 		}
 		return recoveryPointMap(point), nil
 	case "exec_command":
-		targetObject := stringValue(input, "working_dir", "")
-		if strings.TrimSpace(targetObject) == "" {
-			targetObject = firstNonEmpty(strings.TrimSpace(workspacePath), s.workspace)
-		}
-		if strings.TrimSpace(targetObject) == "" {
-			return nil, nil
-		}
-		point, err := s.checkpoint.Create(ctx, checkpoint.CreateInput{
-			TaskID:  request.TaskID,
-			Summary: "exec_command_before_change",
-			Objects: []string{targetObject},
-		})
-		if err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrRecoveryPointPrepareFailed, err)
-		}
-		return recoveryPointMap(point), nil
+		return nil, nil
 	default:
 		return nil, nil
 	}

--- a/services/local-service/internal/execution/service.go
+++ b/services/local-service/internal/execution/service.go
@@ -3,7 +3,9 @@ package execution
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"path"
 	"path/filepath"
 	"strings"
@@ -36,13 +38,14 @@ type Service struct {
 
 // Request 描述一次任务执行所需的最小输入。
 type Request struct {
-	TaskID       string
-	RunID        string
-	Title        string
-	Intent       map[string]any
-	Snapshot     contextsvc.TaskContextSnapshot
-	DeliveryType string
-	ResultTitle  string
+	TaskID          string
+	RunID           string
+	Title           string
+	Intent          map[string]any
+	Snapshot        contextsvc.TaskContextSnapshot
+	DeliveryType    string
+	ResultTitle     string
+	ApprovalGranted bool
 }
 
 // Result 描述执行完成后需要回填给 orchestrator 的交付与痕迹。
@@ -51,6 +54,7 @@ type Result struct {
 	DeliveryResult  map[string]any
 	Artifacts       []map[string]any
 	BubbleText      string
+	RecoveryPoint   map[string]any
 	ModelInvocation map[string]any
 	AuditRecord     map[string]any
 	ToolCalls       []tools.ToolCallRecord
@@ -59,6 +63,21 @@ type Result struct {
 	ToolOutput      map[string]any
 	DurationMS      int64
 }
+
+// GovernanceAssessment 描述一次潜在高风险动作的预执行治理判断结果。
+type GovernanceAssessment struct {
+	OperationName      string
+	TargetObject       string
+	RiskLevel          string
+	ApprovalRequired   bool
+	CheckpointRequired bool
+	Deny               bool
+	Reason             string
+	ImpactScope        map[string]any
+}
+
+// ErrRecoveryPointPrepareFailed 表示执行前的恢复点准备失败。
+var ErrRecoveryPointPrepareFailed = errors.New("execution: recovery point prepare failed")
 
 type generationTrace struct {
 	OutputText       string
@@ -100,11 +119,55 @@ func NewService(
 	}
 }
 
+// AssessGovernance 在真正执行前，基于将要落地的工具调用做一次统一风险判断。
+func (s *Service) AssessGovernance(ctx context.Context, request Request) (GovernanceAssessment, bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	toolName, toolInput, execCtx, ok, err := s.resolveGovernanceToolExecution(request)
+	if err != nil {
+		return GovernanceAssessment{}, false, err
+	}
+	if !ok || s.tools == nil {
+		return GovernanceAssessment{}, false, nil
+	}
+	_, precheck, err := s.executor.PrecheckToolWithContext(ctx, execCtx, toolName, toolInput)
+	if err != nil {
+		return GovernanceAssessment{}, false, err
+	}
+	if precheck == nil {
+		return GovernanceAssessment{}, false, nil
+	}
+	reason := precheck.Reason
+	if reason == "" {
+		reason = precheck.DenyReason
+	}
+	if requireAuthorizationFlag(request.Intent) && !precheck.Deny {
+		precheck.ApprovalRequired = true
+		if precheck.RiskLevel == "" || precheck.RiskLevel == tools.RiskLevelGreen {
+			precheck.RiskLevel = tools.RiskLevelYellow
+		}
+		if reason == "" {
+			reason = "policy_requires_authorization"
+		}
+	}
+	return GovernanceAssessment{
+		OperationName:      toolName,
+		TargetObject:       governanceTargetObject(toolName, toolInput, execCtx),
+		RiskLevel:          precheck.RiskLevel,
+		ApprovalRequired:   precheck.ApprovalRequired,
+		CheckpointRequired: precheck.CheckpointRequired,
+		Deny:               precheck.Deny,
+		Reason:             reason,
+		ImpactScope:        cloneMap(precheck.ImpactScope),
+	}, true, nil
+}
+
 // Execute 执行当前任务的最小内容生成与落盘链路。
 func (s *Service) Execute(ctx context.Context, request Request) (Result, error) {
 	startedAt := time.Now()
 	if result, ok, err := s.executeDirectBuiltinTool(ctx, request); err != nil {
-		return Result{}, err
+		return result, err
 	} else if ok {
 		result.DurationMS = time.Since(startedAt).Milliseconds()
 		return result, nil
@@ -138,7 +201,7 @@ func (s *Service) Execute(ctx context.Context, request Request) (Result, error) 
 	}
 
 	if toolResult, ok, err := s.executeThroughToolExecutor(ctx, request, deliveryResult, trace.OutputText); err != nil {
-		return Result{}, err
+		return toolResult, err
 	} else if ok {
 		toolResult.ToolCalls = append(append([]tools.ToolCallRecord(nil), result.ToolCalls...), toolResult.ToolCalls...)
 		// 当请求已走 ToolExecutor 路径时，保留真实工具输入，
@@ -159,19 +222,32 @@ func (s *Service) Execute(ctx context.Context, request Request) (Result, error) 
 			return Result{}, fmt.Errorf("workspace delivery requires writable workspace path")
 		}
 
-		writeResult, err := s.executeTool(ctx, request, "write_file", map[string]any{
+		writeResult, recoveryPoint, err := s.executeTool(ctx, request, workspacePathFromDeliveryResult(deliveryResult), "write_file", map[string]any{
 			"path":    targetPath,
 			"content": documentContent,
 		})
 		if err != nil {
-			return Result{}, fmt.Errorf("write workspace output: %w", err)
+			failedResult := result
+			failedResult.RecoveryPoint = cloneMap(recoveryPoint)
+			if writeResult != nil {
+				failedResult.ToolCalls = append(failedResult.ToolCalls, writeResult.ToolCall)
+				failedResult.ToolName = writeResult.ToolCall.ToolName
+				failedResult.ToolInput = cloneMap(writeResult.ToolCall.Input)
+				failedResult.ToolOutput = cloneMap(writeResult.ToolCall.Output)
+			}
+			return failedResult, fmt.Errorf("write workspace output: %w", err)
 		}
 
 		result.ToolCalls = append(result.ToolCalls, writeResult.ToolCall)
+		result.RecoveryPoint = cloneMap(recoveryPoint)
 		result.Content = documentContent
 		result.Artifacts = s.delivery.BuildArtifact(request.TaskID, request.ResultTitle, deliveryResult)
 		result.BubbleText = fmt.Sprintf("结果已写入 %s，可直接查看。", targetPath)
 		assignLatestToolTrace(&result, writeResult.ToolCall)
+		if len(recoveryPoint) > 0 {
+			enrichToolTrace(&result, map[string]any{"recovery_point": cloneMap(recoveryPoint)})
+			enrichLatestToolCall(&result, map[string]any{"recovery_point": cloneMap(recoveryPoint)})
+		}
 		enrichToolTrace(&result, map[string]any{
 			"path":             targetPath,
 			"artifact_count":   len(result.Artifacts),
@@ -218,16 +294,23 @@ func (s *Service) executeDirectBuiltinTool(ctx context.Context, request Request)
 		return Result{}, false, nil
 	}
 	args := mapValue(request.Intent, "arguments")
-	toolResult, err := s.executor.ExecuteToolWithContext(ctx, &tools.ToolExecuteContext{
-		TaskID:        request.TaskID,
-		RunID:         request.RunID,
-		WorkspacePath: ".",
-		Platform:      s.fileSystem,
-		Execution:     s.execution,
-		Playwright:    s.playwright,
-	}, intentName, args)
+	toolResult, recoveryPoint, err := s.executeTool(ctx, request, s.workspace, intentName, args)
 	if err != nil {
-		return Result{}, false, fmt.Errorf("execute builtin tool %s: %w", intentName, err)
+		failedResult := Result{
+			RecoveryPoint: cloneMap(recoveryPoint),
+		}
+		if toolResult != nil {
+			failedResult.ToolCalls = []tools.ToolCallRecord{normalizeFilesystemToolCall(toolResult.ToolCall, map[string]any{"path": stringValue(args, "path", "")})}
+			failedResult.ToolName = intentName
+			failedResult.ToolInput = mergeToolInputs(args, map[string]any{
+				"intent_name":     intentName,
+				"delivery_type":   "bubble",
+				"available_tools": s.availableToolNames(),
+				"workers":         s.availableWorkers(),
+			})
+			failedResult.ToolOutput = normalizeFilesystemToolOutput(intentName, mergeToolOutputs(toolResult.RawOutput, toolResult.SummaryOutput), args)
+		}
+		return failedResult, false, fmt.Errorf("execute builtin tool %s: %w", intentName, err)
 	}
 	bubbleText := toolBubbleText(intentName, toolResult)
 	return Result{
@@ -235,6 +318,7 @@ func (s *Service) executeDirectBuiltinTool(ctx context.Context, request Request)
 		DeliveryResult: s.delivery.BuildDeliveryResultWithTargetPath(request.TaskID, "bubble", request.ResultTitle, bubbleText, ""),
 		Artifacts:      toolArtifactsFromResult(request.TaskID, toolResult),
 		BubbleText:     bubbleText,
+		RecoveryPoint:  cloneMap(recoveryPoint),
 		ToolCalls:      []tools.ToolCallRecord{normalizeFilesystemToolCall(toolResult.ToolCall, map[string]any{"path": stringValue(args, "path", "")})},
 		ToolName:       intentName,
 		ToolInput: mergeToolInputs(args, map[string]any{
@@ -254,22 +338,27 @@ func (s *Service) executeThroughToolExecutor(ctx context.Context, request Reques
 	}
 
 	workspacePath := workspacePathFromDeliveryResult(deliveryResult)
-	toolResult, err := s.executor.ExecuteToolWithContext(ctx, &tools.ToolExecuteContext{
-		TaskID:        request.TaskID,
-		RunID:         request.RunID,
-		WorkspacePath: workspacePath,
-		Platform:      s.fileSystem,
-		Execution:     s.execution,
-		Playwright:    s.playwright,
-	}, toolName, toolInput)
+	toolResult, recoveryPoint, err := s.executeTool(ctx, request, workspacePath, toolName, toolInput)
 	if err != nil {
-		return Result{}, false, fmt.Errorf("execute tool %s: %w", toolName, err)
+		failedResult := Result{
+			Content:        outputText,
+			DeliveryResult: deliveryResult,
+			RecoveryPoint:  cloneMap(recoveryPoint),
+			ToolName:       toolName,
+			ToolInput:      toolInput,
+		}
+		if toolResult != nil {
+			failedResult.ToolCalls = []tools.ToolCallRecord{normalizeFilesystemToolCall(toolResult.ToolCall, toolInput)}
+			failedResult.ToolOutput = normalizeFilesystemToolOutput(toolName, mergeToolOutputs(toolResult.RawOutput, toolResult.SummaryOutput), toolInput)
+		}
+		return failedResult, false, fmt.Errorf("execute tool %s: %w", toolName, err)
 	}
 
 	result := Result{
 		Content:        outputText,
 		DeliveryResult: deliveryResult,
 		Artifacts:      toolArtifactsFromResult(request.TaskID, toolResult),
+		RecoveryPoint:  cloneMap(recoveryPoint),
 		ToolCalls:      []tools.ToolCallRecord{normalizeFilesystemToolCall(toolResult.ToolCall, toolInput)},
 		ToolName:       toolName,
 		ToolInput:      toolInput,
@@ -458,21 +547,17 @@ func (s *Service) consumeWriteFileCandidates(ctx context.Context, taskID string,
 	}
 
 	if checkpointCandidate, ok := rawOutput["checkpoint_candidate"].(map[string]any); ok && s.checkpoint != nil {
-		createInput, shouldCreate, err := checkpoint.BuildCreateInputFromCandidate(taskID, checkpointCandidate)
-		if err != nil {
-			return nil, nil, fmt.Errorf("build checkpoint input from candidate: %w", err)
-		}
-		if shouldCreate {
-			point, err := s.checkpoint.Create(ctx, createInput)
+		if _, hasRecoveryPoint := merged["recovery_point"].(map[string]any); !hasRecoveryPoint {
+			createInput, shouldCreate, err := checkpoint.BuildCreateInputFromCandidate(taskID, checkpointCandidate)
 			if err != nil {
-				return nil, nil, fmt.Errorf("create recovery point from candidate: %w", err)
+				return nil, nil, fmt.Errorf("build checkpoint input from candidate: %w", err)
 			}
-			merged["recovery_point"] = map[string]any{
-				"recovery_point_id": point.RecoveryPointID,
-				"task_id":           point.TaskID,
-				"summary":           point.Summary,
-				"created_at":        point.CreatedAt,
-				"objects":           point.Objects,
+			if shouldCreate {
+				point, err := s.checkpoint.Create(ctx, createInput)
+				if err != nil {
+					return nil, nil, fmt.Errorf("create recovery point from candidate: %w", err)
+				}
+				merged["recovery_point"] = recoveryPointMap(point)
 			}
 		}
 	}
@@ -583,7 +668,7 @@ func (s *Service) fileSection(filePath string) string {
 
 func (s *Service) generateOutput(ctx context.Context, request Request, inputText string) (generationTrace, error) {
 	prompt := buildPrompt(request, inputText)
-	toolResult, err := s.executeTool(ctx, request, "generate_text", map[string]any{
+	toolResult, _, err := s.executeTool(ctx, request, s.workspace, "generate_text", map[string]any{
 		"prompt":        prompt,
 		"fallback_text": fallbackOutput(request, inputText),
 		"intent_name":   effectiveIntentName(request.Intent),
@@ -753,6 +838,13 @@ func previewTextForOutput(outputText, deliveryType string) string {
 		return "已生成正式文档：" + preview
 	}
 	return preview
+}
+
+func previewTextForDeliveryType(deliveryType string) string {
+	if deliveryType == "workspace_document" {
+		return "已为你写入文档并打开"
+	}
+	return "结果已通过气泡返回"
 }
 
 func truncateBubbleText(outputText string) string {
@@ -949,18 +1041,192 @@ func (s *Service) availableWorkers() []string {
 	return s.plugin.Workers()
 }
 
-func (s *Service) executeTool(ctx context.Context, request Request, toolName string, input map[string]any) (*tools.ToolExecutionResult, error) {
+func (s *Service) executeTool(ctx context.Context, request Request, workspacePath, toolName string, input map[string]any) (*tools.ToolExecutionResult, map[string]any, error) {
 	if s.executor == nil {
-		return nil, fmt.Errorf("tool executor is required")
+		return nil, nil, fmt.Errorf("tool executor is required")
 	}
+	execCtx := s.toolExecutionContext(workspacePath, request)
+	recoveryPoint, err := s.prepareGovernanceRecoveryPoint(ctx, request, workspacePath, toolName, input)
+	if err != nil {
+		return nil, cloneMap(recoveryPoint), err
+	}
+	toolResult, err := s.executor.ExecuteToolWithContext(ctx, execCtx, toolName, input)
+	if toolResult != nil && len(recoveryPoint) > 0 {
+		if toolResult.RawOutput == nil {
+			toolResult.RawOutput = map[string]any{}
+		}
+		toolResult.RawOutput["recovery_point"] = cloneMap(recoveryPoint)
+	}
+	return toolResult, cloneMap(recoveryPoint), err
+}
 
-	return s.executor.ExecuteToolWithContext(ctx, &tools.ToolExecuteContext{
-		TaskID:        request.TaskID,
-		RunID:         request.RunID,
-		WorkspacePath: s.workspace,
-		Platform:      s.fileSystem,
-		Model:         s.model,
-	}, toolName, input)
+func (s *Service) resolveGovernanceToolExecution(request Request) (string, map[string]any, *tools.ToolExecuteContext, bool, error) {
+	intentName := stringValue(request.Intent, "name", "")
+	args := mapValue(request.Intent, "arguments")
+	deliveryType := firstNonEmpty(strings.TrimSpace(request.DeliveryType), "workspace_document")
+	previewText := previewTextForDeliveryType(deliveryType)
+	deliveryResult := s.delivery.BuildDeliveryResultWithTargetPath(
+		request.TaskID,
+		deliveryType,
+		firstNonEmpty(strings.TrimSpace(request.ResultTitle), "处理结果"),
+		previewText,
+		targetPathFromIntent(request.Intent),
+	)
+	if s.tools != nil && intentName != "" && intentName != "write_file" {
+		if _, err := s.tools.Get(intentName); err == nil {
+			switch intentName {
+			case "read_file":
+				pathValue := stringValue(args, "path", stringValue(args, "target_path", ""))
+				if pathValue != "" {
+					return intentName, map[string]any{"path": pathValue}, s.toolExecutionContext(s.workspace, request), true, nil
+				}
+			case "list_dir":
+				pathValue := stringValue(args, "path", stringValue(args, "target_path", ""))
+				if pathValue != "" {
+					input := map[string]any{"path": pathValue}
+					if limit, ok := args["limit"]; ok {
+						input["limit"] = limit
+					}
+					return intentName, input, s.toolExecutionContext(s.workspace, request), true, nil
+				}
+			case "exec_command":
+				input := map[string]any{}
+				for _, key := range []string{"command", "args", "working_dir"} {
+					if value, ok := args[key]; ok {
+						input[key] = value
+					}
+				}
+				if len(input) > 0 {
+					return intentName, input, s.toolExecutionContext(s.workspace, request), true, nil
+				}
+			}
+		}
+	}
+	rawTargetPath := firstNonEmpty(targetPathFromIntent(request.Intent), deliveryPayloadPath(deliveryResult))
+	writePath := workspaceFSPath(rawTargetPath)
+	if writePath == "" {
+		writePath = strings.TrimSpace(strings.ReplaceAll(rawTargetPath, "\\", "/"))
+	}
+	if writePath == "" {
+		return "", nil, nil, false, nil
+	}
+	toolName, toolInput := "write_file", map[string]any{"path": writePath, "content": ""}
+	workspacePath := s.workspace
+	if toolName == "write_file" {
+		workspacePath = workspacePathFromDeliveryResult(deliveryResult)
+	}
+	return toolName, toolInput, s.toolExecutionContext(workspacePath, request), true, nil
+}
+
+func (s *Service) toolExecutionContext(workspacePath string, request Request) *tools.ToolExecuteContext {
+	workspacePath = firstNonEmpty(strings.TrimSpace(workspacePath), s.workspace)
+	return &tools.ToolExecuteContext{
+		TaskID:               request.TaskID,
+		RunID:                request.RunID,
+		WorkspacePath:        workspacePath,
+		ApprovalGranted:      request.ApprovalGranted,
+		ApprovedOperation:    stringValue(request.Intent, "name", ""),
+		ApprovedTargetObject: approvedTargetObject(request.Intent, workspacePath),
+		Platform:             s.fileSystem,
+		Execution:            s.execution,
+		Playwright:           s.playwright,
+		Model:                s.model,
+	}
+}
+
+func (s *Service) prepareGovernanceRecoveryPoint(ctx context.Context, request Request, workspacePath, toolName string, input map[string]any) (map[string]any, error) {
+	if s.checkpoint == nil {
+		return nil, nil
+	}
+	switch toolName {
+	case "write_file":
+		targetPath := stringValue(input, "path", "")
+		if targetPath == "" {
+			return nil, nil
+		}
+		if _, err := s.fileSystem.Stat(targetPath); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("%w: inspect target path %s: %v", ErrRecoveryPointPrepareFailed, targetPath, err)
+		}
+		point, err := s.checkpoint.Create(ctx, checkpoint.CreateInput{
+			TaskID:  request.TaskID,
+			Summary: "write_file_before_change",
+			Objects: []string{targetPath},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrRecoveryPointPrepareFailed, err)
+		}
+		return recoveryPointMap(point), nil
+	case "exec_command":
+		targetObject := stringValue(input, "working_dir", "")
+		if strings.TrimSpace(targetObject) == "" {
+			targetObject = firstNonEmpty(strings.TrimSpace(workspacePath), s.workspace)
+		}
+		if strings.TrimSpace(targetObject) == "" {
+			return nil, nil
+		}
+		point, err := s.checkpoint.Create(ctx, checkpoint.CreateInput{
+			TaskID:  request.TaskID,
+			Summary: "exec_command_before_change",
+			Objects: []string{targetObject},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrRecoveryPointPrepareFailed, err)
+		}
+		return recoveryPointMap(point), nil
+	default:
+		return nil, nil
+	}
+}
+
+func recoveryPointMap(point checkpoint.RecoveryPoint) map[string]any {
+	return map[string]any{
+		"recovery_point_id": point.RecoveryPointID,
+		"task_id":           point.TaskID,
+		"summary":           point.Summary,
+		"created_at":        point.CreatedAt,
+		"objects":           append([]string(nil), point.Objects...),
+	}
+}
+
+func governanceTargetObject(toolName string, toolInput map[string]any, execCtx *tools.ToolExecuteContext) string {
+	switch toolName {
+	case "write_file":
+		return stringValue(toolInput, "path", "")
+	case "exec_command":
+		return firstNonEmpty(stringValue(toolInput, "working_dir", ""), execCtx.WorkspacePath)
+	default:
+		return stringValue(toolInput, "path", "")
+	}
+}
+
+func approvedTargetObject(intent map[string]any, workspacePath string) string {
+	arguments := mapValue(intent, "arguments")
+	for _, key := range []string{"target_path", "path", "working_dir"} {
+		if value := strings.TrimSpace(stringValue(arguments, key, "")); value != "" {
+			normalized := strings.ReplaceAll(value, "\\", "/")
+			if key != "working_dir" {
+				if candidate := workspaceFSPath(normalized); candidate != "" {
+					normalized = candidate
+				}
+			}
+			workspaceRoot := strings.ReplaceAll(strings.TrimSpace(workspacePath), "\\", "/")
+			if workspaceRoot != "" && !path.IsAbs(normalized) && !isWindowsAbsolutePath(normalized) {
+				return path.Join(workspaceRoot, normalized)
+			}
+			return normalized
+		}
+	}
+	if stringValue(intent, "name", "") == "exec_command" {
+		return workspacePath
+	}
+	return ""
+}
+
+func requireAuthorizationFlag(intent map[string]any) bool {
+	return boolValue(mapValue(intent, "arguments"), "require_authorization")
 }
 
 func resolveWorkspaceRoot(fileSystem platform.FileSystemAdapter) string {

--- a/services/local-service/internal/execution/service_test.go
+++ b/services/local-service/internal/execution/service_test.go
@@ -457,6 +457,73 @@ func TestFallbackOutputRequestsClarificationWhenIntentMissing(t *testing.T) {
 	}
 }
 
+func TestAssessGovernanceRequiresAuthorizationForRestoreWrite(t *testing.T) {
+	service, workspaceRoot := newTestExecutionService(t, "unused")
+
+	assessment, handled, err := service.AssessGovernance(context.Background(), Request{
+		TaskID:       "task_auth_write",
+		RunID:        "run_auth_write",
+		Intent:       map[string]any{"name": "write_file", "arguments": map[string]any{"target_path": "notes/result.md", "require_authorization": true}},
+		DeliveryType: "workspace_document",
+		ResultTitle:  "授权写入",
+	})
+	if err != nil {
+		t.Fatalf("AssessGovernance returned error: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected write_file governance path to be handled")
+	}
+	if !assessment.ApprovalRequired {
+		t.Fatalf("expected approval to be required, got %+v", assessment)
+	}
+	if assessment.OperationName != "write_file" {
+		t.Fatalf("expected write_file operation, got %+v", assessment)
+	}
+	expectedTarget := "notes/result.md"
+	if assessment.TargetObject != expectedTarget {
+		t.Fatalf("expected target object %q, got %q", expectedTarget, assessment.TargetObject)
+	}
+	files, _ := assessment.ImpactScope["files"].([]string)
+	expectedImpactFile := filepath.Join(workspaceRoot, "notes", "result.md")
+	if len(files) != 1 || files[0] != expectedImpactFile {
+		t.Fatalf("expected impact scope files to include %q, got %+v", expectedImpactFile, assessment.ImpactScope)
+	}
+}
+
+func TestAssessGovernanceExecCommandUsesWorkspaceTargetWithoutRecoveryPoint(t *testing.T) {
+	service, workspaceRoot := newTestExecutionService(t, "unused")
+
+	assessment, handled, err := service.AssessGovernance(context.Background(), Request{
+		TaskID: "task_exec_auth",
+		RunID:  "run_exec_auth",
+		Intent: map[string]any{"name": "exec_command", "arguments": map[string]any{
+			"command":               "git status",
+			"working_dir":           workspaceRoot,
+			"require_authorization": true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("AssessGovernance returned error: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected exec_command governance path to be handled")
+	}
+	if assessment.OperationName != "exec_command" || assessment.TargetObject != workspaceRoot {
+		t.Fatalf("unexpected exec_command assessment: %+v", assessment)
+	}
+	if !assessment.ApprovalRequired {
+		t.Fatalf("expected exec_command to require approval when flagged, got %+v", assessment)
+	}
+
+	recoveryPoint, err := service.prepareGovernanceRecoveryPoint(context.Background(), Request{TaskID: "task_exec_auth"}, workspaceRoot, "exec_command", map[string]any{"working_dir": workspaceRoot})
+	if err != nil {
+		t.Fatalf("prepareGovernanceRecoveryPoint returned error: %v", err)
+	}
+	if recoveryPoint != nil {
+		t.Fatalf("expected exec_command not to create recovery point, got %+v", recoveryPoint)
+	}
+}
+
 type stubExecutionCapability struct {
 	result tools.CommandExecutionResult
 	err    error

--- a/services/local-service/internal/execution/service_test.go
+++ b/services/local-service/internal/execution/service_test.go
@@ -148,8 +148,12 @@ func TestExecuteWorkspaceDocumentWritesFile(t *testing.T) {
 	if result.ToolOutput["audit_record"] == nil {
 		t.Fatalf("expected write_file tool output to include consumed audit record, got %+v", result.ToolOutput)
 	}
-	if result.ToolOutput["recovery_point"] != nil {
-		t.Fatalf("expected no recovery point for create flow, got %+v", result.ToolOutput)
+	recoveryPoint, ok := result.ToolOutput["recovery_point"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected create flow to emit recovery point metadata, got %+v", result.ToolOutput)
+	}
+	if objects := recoveryPoint["objects"].([]string); len(objects) != 1 || objects[0] != "workspace/notes/output.md" {
+		t.Fatalf("expected create flow recovery point to target workspace/notes/output.md, got %+v", recoveryPoint)
 	}
 	if len(result.ToolCalls) != 2 {
 		t.Fatalf("expected generate_text + write_file tool chain, got %d calls", len(result.ToolCalls))
@@ -204,8 +208,70 @@ func TestExecuteWriteFileBubbleConsumesArtifactCandidate(t *testing.T) {
 	if result.ToolOutput["audit_record"] == nil {
 		t.Fatalf("expected audit candidate to be consumed, got %+v", result.ToolOutput)
 	}
+	if result.ToolOutput["recovery_point"] == nil {
+		t.Fatalf("expected create flow to expose recovery point candidate, got %+v", result.ToolOutput)
+	}
 	if _, err := os.Stat(filepath.Join(workspaceRoot, "notes", "output.md")); err != nil {
 		t.Fatalf("expected write_file bubble path to still write file, got %v", err)
+	}
+}
+
+func TestExecuteWriteFileOverwriteCreatesAndAppliesRecoveryPoint(t *testing.T) {
+	service, workspaceRoot := newTestExecutionService(t, "新的内容")
+	originalPath := filepath.Join(workspaceRoot, "notes", "output.md")
+	if err := os.MkdirAll(filepath.Dir(originalPath), 0o755); err != nil {
+		t.Fatalf("mkdir notes: %v", err)
+	}
+	if err := os.WriteFile(originalPath, []byte("旧的内容"), 0o644); err != nil {
+		t.Fatalf("seed original file: %v", err)
+	}
+
+	result, err := service.Execute(context.Background(), Request{
+		TaskID:       "task_restore",
+		RunID:        "run_restore",
+		Title:        "覆盖文件",
+		Intent:       map[string]any{"name": "write_file", "arguments": map[string]any{"target_path": "notes/output.md"}},
+		Snapshot:     contextsvc.TaskContextSnapshot{InputType: "text", Text: "请覆盖该文件"},
+		DeliveryType: "workspace_document",
+		ResultTitle:  "文件写入结果",
+	})
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.RecoveryPoint == nil {
+		t.Fatalf("expected overwrite execution to emit recovery point, got %+v", result.ToolOutput)
+	}
+	if result.ToolOutput["recovery_point"] == nil {
+		t.Fatalf("expected tool output to expose recovery point, got %+v", result.ToolOutput)
+	}
+	overwrittenContent, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatalf("read overwritten file: %v", err)
+	}
+	if !strings.Contains(string(overwrittenContent), "新的内容") {
+		t.Fatalf("expected file to be overwritten, got %q", string(overwrittenContent))
+	}
+
+	recoveryPoint := checkpoint.RecoveryPoint{
+		RecoveryPointID: result.RecoveryPoint["recovery_point_id"].(string),
+		TaskID:          result.RecoveryPoint["task_id"].(string),
+		Summary:         result.RecoveryPoint["summary"].(string),
+		CreatedAt:       result.RecoveryPoint["created_at"].(string),
+		Objects:         result.RecoveryPoint["objects"].([]string),
+	}
+	applyResult, err := service.ApplyRecoveryPoint(context.Background(), recoveryPoint)
+	if err != nil {
+		t.Fatalf("apply recovery point failed: %v", err)
+	}
+	if applyResult.RecoveryPointID != recoveryPoint.RecoveryPointID {
+		t.Fatalf("expected recovery point id to round-trip, got %+v", applyResult)
+	}
+	restoredContent, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatalf("read restored file: %v", err)
+	}
+	if string(restoredContent) != "旧的内容" {
+		t.Fatalf("expected restore to recover original content, got %q", string(restoredContent))
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -842,15 +842,37 @@ func (s *Service) SecurityRestoreApply(params map[string]any) (map[string]any, e
 	}
 
 	recoveryPoint := recoveryPointMap(point)
+	assessment := restoreApplyAssessment(point)
+	pendingExecution := buildRestoreApplyPendingExecution(point, assessment)
+	approvalRequest := buildApprovalRequest(task.TaskID, task.Intent, assessment)
+	bubble := s.delivery.BuildBubbleMessage(task.TaskID, "status", "恢复点回滚属于高风险操作，请先确认授权。", time.Now().Format(dateTimeLayout))
+	updatedTask, ok := s.runEngine.MarkWaitingApprovalWithPlan(task.TaskID, approvalRequest, pendingExecution, bubble)
+	if !ok {
+		return nil, ErrTaskNotFound
+	}
+	return map[string]any{
+		"applied":        false,
+		"task":           taskMap(updatedTask),
+		"recovery_point": recoveryPoint,
+		"audit_record":   nil,
+		"bubble_message": bubble,
+	}, nil
+}
+
+func (s *Service) applyRestoreAfterApproval(task runengine.TaskRecord, point checkpoint.RecoveryPoint) (runengine.TaskRecord, map[string]any, map[string]any, error) {
+	recoveryPoint := recoveryPointMap(point)
 	applied := false
 	securityStatus := "recovered"
+	finalStatus := "completed"
 	bubbleText := fmt.Sprintf("已根据恢复点 %s 恢复 %d 个对象。", point.RecoveryPointID, len(point.Objects))
 	if s.executor == nil {
 		securityStatus = "execution_error"
+		finalStatus = "failed"
 		bubbleText = "恢复失败：执行后端不可用。"
 	} else if applyResult, err := s.executor.ApplyRecoveryPoint(context.Background(), point); err != nil {
 		securityStatus = "execution_error"
-		bubbleText = fmt.Sprintf("恢复失败：%s", err.Error())
+		finalStatus = "failed"
+		bubbleText = "恢复失败：恢复点内容不可用或恢复执行失败。"
 	} else {
 		applied = true
 		if len(applyResult.RestoredObjects) > 0 {
@@ -859,14 +881,13 @@ func (s *Service) SecurityRestoreApply(params map[string]any) (map[string]any, e
 	}
 
 	bubble := s.delivery.BuildBubbleMessage(task.TaskID, "status", bubbleText, time.Now().Format(dateTimeLayout))
-	updatedTask, ok := s.runEngine.ApplyRecoveryOutcome(task.TaskID, securityStatus, recoveryPoint, bubble)
+	updatedTask, ok := s.runEngine.ApplyRecoveryOutcome(task.TaskID, finalStatus, securityStatus, recoveryPoint, bubble)
 	if !ok {
-		return nil, ErrTaskNotFound
+		return runengine.TaskRecord{}, nil, nil, ErrTaskNotFound
 	}
 	auditRecord := s.writeRestoreAuditRecord(updatedTask.TaskID, point, applied, bubbleText)
 	updatedTask = s.appendAuditData(updatedTask, compactAuditRecords(auditRecord), nil)
-
-	return map[string]any{
+	return updatedTask, bubble, map[string]any{
 		"applied":        applied,
 		"task":           taskMap(updatedTask),
 		"recovery_point": recoveryPoint,
@@ -962,6 +983,7 @@ func (s *Service) SecurityRespond(params map[string]any) (map[string]any, error)
 	}
 	pendingExecution = s.applyResolvedDeliveryToPlan(task, pendingExecution, task.Intent)
 	impactScope := s.buildImpactScope(task, pendingExecution)
+	operationName := stringValue(pendingExecution, "operation_name", "")
 	if decision == "deny_once" {
 		bubble := s.delivery.BuildBubbleMessage(task.TaskID, "status", "已拒绝本次操作，任务已取消。", task.UpdatedAt.Format(dateTimeLayout))
 		updatedTask, ok := s.runEngine.DenyAfterApproval(task.TaskID, authorizationRecord, impactScope, bubble)
@@ -983,6 +1005,27 @@ func (s *Service) SecurityRespond(params map[string]any) (map[string]any, error)
 		return nil, ErrTaskNotFound
 	}
 	processingTask = s.appendAuditData(processingTask, compactAuditRecords(s.audit.BuildAuthorizationAudit(processingTask.TaskID, processingTask.RunID, decision, impactScope)), nil)
+	if operationName == "restore_apply" {
+		recoveryPointID := stringValue(pendingExecution, "recovery_point_id", "")
+		point, err := s.findRecoveryPointFromStorage(task.TaskID, recoveryPointID)
+		if err != nil {
+			return nil, err
+		}
+		updatedTask, _, response, err := s.applyRestoreAfterApproval(processingTask, point)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"authorization_record": authorizationRecord,
+			"task":                 taskMap(updatedTask),
+			"bubble_message":       response["bubble_message"],
+			"impact_scope":         impactScope,
+			"delivery_result":      nil,
+			"recovery_point":       response["recovery_point"],
+			"audit_record":         response["audit_record"],
+			"applied":              response["applied"],
+		}, nil
+	}
 
 	resultTitle := stringValue(pendingExecution, "result_title", "处理结果")
 	resultPreview := stringValue(pendingExecution, "preview_text", "已为你写入文档并打开")
@@ -1716,6 +1759,64 @@ func recoveryPointMap(point checkpoint.RecoveryPoint) map[string]any {
 		"created_at":        point.CreatedAt,
 		"objects":           append([]string(nil), point.Objects...),
 	}
+}
+
+func restoreApplyAssessment(point checkpoint.RecoveryPoint) execution.GovernanceAssessment {
+	impactScope := restoreImpactScope(point)
+	return execution.GovernanceAssessment{
+		OperationName:      "restore_apply",
+		TargetObject:       firstNonEmptyString(firstImpactFile(impactScope), firstNonEmptyString(strings.Join(point.Objects, ", "), "workspace")),
+		RiskLevel:          "red",
+		ApprovalRequired:   true,
+		CheckpointRequired: false,
+		Reason:             "policy_requires_authorization",
+		ImpactScope:        impactScope,
+	}
+}
+
+func buildRestoreApplyPendingExecution(point checkpoint.RecoveryPoint, assessment execution.GovernanceAssessment) map[string]any {
+	return map[string]any{
+		"operation_name":      assessment.OperationName,
+		"target_object":       assessment.TargetObject,
+		"risk_level":          assessment.RiskLevel,
+		"risk_reason":         assessment.Reason,
+		"impact_scope":        cloneMap(assessment.ImpactScope),
+		"recovery_point_id":   point.RecoveryPointID,
+		"checkpoint_required": assessment.CheckpointRequired,
+	}
+}
+
+func restoreImpactScope(point checkpoint.RecoveryPoint) map[string]any {
+	files := append([]string(nil), point.Objects...)
+	outOfWorkspace := false
+	for _, filePath := range files {
+		normalized := strings.TrimSpace(strings.ReplaceAll(filePath, "\\", "/"))
+		if normalized == "" {
+			continue
+		}
+		if !strings.HasPrefix(normalized, "workspace/") && normalized != "workspace" {
+			outOfWorkspace = true
+			break
+		}
+	}
+	return map[string]any{
+		"files":                    files,
+		"webpages":                 []string{},
+		"apps":                     []string{},
+		"out_of_workspace":         outOfWorkspace,
+		"overwrite_or_delete_risk": true,
+	}
+}
+
+func firstImpactFile(impactScope map[string]any) string {
+	if len(impactScope) == 0 {
+		return ""
+	}
+	files, ok := impactScope["files"].([]string)
+	if !ok || len(files) == 0 {
+		return ""
+	}
+	return files[0]
 }
 
 func (s *Service) writeRestoreAuditRecord(taskID string, point checkpoint.RecoveryPoint, applied bool, summary string) map[string]any {
@@ -2556,15 +2657,18 @@ func (s *Service) executeTask(task runengine.TaskRecord, snapshot contextsvc.Tas
 		return updatedTask, resultBubble, deliveryResult, artifacts, nil
 	}
 
+	approvedOperation, approvedTargetObject := approvedExecutionFromTask(processingTask)
 	executionResult, err := s.executor.Execute(context.Background(), execution.Request{
-		TaskID:          processingTask.TaskID,
-		RunID:           processingTask.RunID,
-		Title:           processingTask.Title,
-		Intent:          taskIntent,
-		Snapshot:        snapshot,
-		DeliveryType:    deliveryType,
-		ResultTitle:     resultTitle,
-		ApprovalGranted: processingTask.Authorization != nil,
+		TaskID:               processingTask.TaskID,
+		RunID:                processingTask.RunID,
+		Title:                processingTask.Title,
+		Intent:               taskIntent,
+		Snapshot:             snapshot,
+		DeliveryType:         deliveryType,
+		ResultTitle:          resultTitle,
+		ApprovalGranted:      processingTask.Authorization != nil,
+		ApprovedOperation:    approvedOperation,
+		ApprovedTargetObject: approvedTargetObject,
 	})
 	processingTask = s.recordExecutionToolCalls(processingTask, executionResult.ToolCalls)
 	auditDeliveryResult := executionResult.DeliveryResult
@@ -2610,6 +2714,13 @@ func (s *Service) recordExecutionToolCalls(task runengine.TaskRecord, toolCalls 
 		}
 	}
 	return task
+}
+
+func approvedExecutionFromTask(task runengine.TaskRecord) (string, string) {
+	if len(task.PendingExecution) == 0 {
+		return "", ""
+	}
+	return stringValue(task.PendingExecution, "operation_name", ""), stringValue(task.PendingExecution, "target_object", "")
 }
 
 func toolCallErrorCode(toolCall tools.ToolCallRecord) any {

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -189,22 +189,18 @@ func (s *Service) SubmitInput(params map[string]any) (map[string]any, error) {
 	bubble := s.delivery.BuildBubbleMessage(task.TaskID, bubbleTypeForSuggestion(suggestion.RequiresConfirm), bubbleTextForInput(suggestion), task.StartedAt.Format(dateTimeLayout))
 	deliveryResult := map[string]any(nil)
 	if !suggestion.RequiresConfirm {
-		if requiresAuthorization(suggestion.Intent) {
-			pendingExecution := s.buildPendingExecution(task, suggestion.Intent)
-			approvalRequest := buildApprovalRequest(task.TaskID, suggestion.Intent, "red")
-			bubble = s.delivery.BuildBubbleMessage(task.TaskID, "status", "检测到待授权操作，请先确认。", task.StartedAt.Format(dateTimeLayout))
-			if _, ok := s.runEngine.MarkWaitingApprovalWithPlan(task.TaskID, approvalRequest, pendingExecution, bubble); ok {
-				task, _ = s.runEngine.GetTask(task.TaskID)
-			}
-			return map[string]any{
-				"task":           taskMap(task),
-				"bubble_message": bubble,
-			}, nil
+		governedTask, governedResponse, handled, governanceErr := s.handleTaskGovernanceDecision(task, suggestion.Intent)
+		if governanceErr != nil {
+			return nil, governanceErr
 		}
-		var err error
-		task, bubble, deliveryResult, _, err = s.executeTask(task, snapshot, suggestion.Intent)
-		if err != nil {
-			return nil, err
+		if handled {
+			return governedResponse, nil
+		}
+		task = governedTask
+		var execErr error
+		task, bubble, deliveryResult, _, execErr = s.executeTask(task, snapshot, suggestion.Intent)
+		if execErr != nil {
+			return nil, execErr
 		}
 	} else {
 		if _, ok := s.runEngine.SetPresentation(task.TaskID, bubble, nil, nil); ok {
@@ -262,22 +258,20 @@ func (s *Service) StartTask(params map[string]any) (map[string]any, error) {
 		return response, nil
 	}
 
-	if requiresAuthorization(suggestion.Intent) {
-		pendingExecution := s.buildPendingExecution(task, suggestion.Intent)
-		approvalRequest := buildApprovalRequest(task.TaskID, suggestion.Intent, "red")
-		bubble = s.delivery.BuildBubbleMessage(task.TaskID, "status", "检测到待授权操作，请先确认。", task.StartedAt.Format(dateTimeLayout))
-		if _, ok := s.runEngine.MarkWaitingApprovalWithPlan(task.TaskID, approvalRequest, pendingExecution, bubble); ok {
-			task, _ = s.runEngine.GetTask(task.TaskID)
-			response["task"] = taskMap(task)
-			response["bubble_message"] = bubble
-		}
-		return response, nil
+	governedTask, governedResponse, handled, governanceErr := s.handleTaskGovernanceDecision(task, suggestion.Intent)
+	if governanceErr != nil {
+		return nil, governanceErr
 	}
+	if handled {
+		return governedResponse, nil
+	}
+	task = governedTask
 
-	var err error
-	task, bubble, deliveryResult, _, err := s.executeTask(task, snapshot, suggestion.Intent)
-	if err != nil {
-		return nil, err
+	deliveryResult := map[string]any(nil)
+	var execErr error
+	task, bubble, deliveryResult, _, execErr = s.executeTask(task, snapshot, suggestion.Intent)
+	if execErr != nil {
+		return nil, execErr
 	}
 	response["task"] = taskMap(task)
 	response["bubble_message"] = bubble
@@ -335,28 +329,21 @@ func (s *Service) ConfirmTask(params map[string]any) (map[string]any, error) {
 	updatedTitle := s.intent.Suggest(snapshotFromTask(task), intentValue, false).TaskTitle
 
 	bubble := s.delivery.BuildBubbleMessage(task.TaskID, "status", "已按新的要求开始处理", task.UpdatedAt.Format(dateTimeLayout))
-	if requiresAuthorization(intentValue) {
-		updatedTask, ok := s.runEngine.UpdateIntent(task.TaskID, updatedTitle, intentValue)
-		if !ok {
-			return nil, ErrTaskNotFound
-		}
-		s.attachMemoryReadPlans(updatedTask.TaskID, updatedTask.RunID, snapshotFromTask(updatedTask), intentValue)
-
-		pendingExecution := s.buildPendingExecution(updatedTask, intentValue)
-		approvalRequest := buildApprovalRequest(task.TaskID, intentValue, "red")
-		bubble = s.delivery.BuildBubbleMessage(task.TaskID, "status", "检测到待授权操作，请先确认。", updatedTask.UpdatedAt.Format(dateTimeLayout))
-		updatedTask, ok = s.runEngine.MarkWaitingApprovalWithPlan(task.TaskID, approvalRequest, pendingExecution, bubble)
-		if !ok {
-			return nil, ErrTaskNotFound
-		}
-		return map[string]any{
-			"task":            taskMap(updatedTask),
-			"bubble_message":  bubble,
-			"delivery_result": nil,
-		}, nil
+	updatedTask, ok := s.runEngine.UpdateIntent(task.TaskID, updatedTitle, intentValue)
+	if !ok {
+		return nil, ErrTaskNotFound
 	}
+	s.attachMemoryReadPlans(updatedTask.TaskID, updatedTask.RunID, snapshotFromTask(updatedTask), intentValue)
+	governedTask, governedResponse, handled, governanceErr := s.handleTaskGovernanceDecision(updatedTask, intentValue)
+	if governanceErr != nil {
+		return nil, governanceErr
+	}
+	if handled {
+		return governedResponse, nil
+	}
+	updatedTask = governedTask
 
-	updatedTask, ok := s.runEngine.ConfirmTask(task.TaskID, updatedTitle, intentValue, bubble)
+	updatedTask, ok = s.runEngine.ConfirmTask(task.TaskID, updatedTitle, intentValue, bubble)
 	if !ok {
 		return nil, ErrTaskNotFound
 	}
@@ -916,15 +903,25 @@ func (s *Service) SecurityRespond(params map[string]any) (map[string]any, error)
 	if err != nil {
 		return nil, err
 	}
-	updatedTask, _ = s.runEngine.ResolveAuthorization(task.TaskID, authorizationRecord, impactScope)
+	if updatedTask.Status == "completed" {
+		updatedTask, _ = s.runEngine.ResolveAuthorization(task.TaskID, authorizationRecord, impactScope)
+	}
+	if updatedTask.Status == "failed" {
+		deliveryResult = nil
+	}
 
-	return map[string]any{
+	response := map[string]any{
 		"authorization_record": authorizationRecord,
 		"task":                 taskMap(updatedTask),
 		"bubble_message":       resultBubble,
-		"delivery_result":      deliveryResult,
 		"impact_scope":         impactScope,
-	}, nil
+	}
+	if len(deliveryResult) > 0 {
+		response["delivery_result"] = deliveryResult
+	} else {
+		response["delivery_result"] = nil
+	}
+	return response, nil
 }
 
 // SettingsGet 设置tingsGet。
@@ -1772,28 +1769,12 @@ func (s *Service) attachPostDeliveryHandoffs(taskID, runID string, snapshot cont
 	_, _ = s.runEngine.SetDeliveryPlans(taskID, storageWritePlan, artifactPlans)
 }
 
-// requiresAuthorization 处理当前模块的相关逻辑。
-
-// requiresAuthorization 判断当前意图是否必须进入等待授权链路。
-func requiresAuthorization(taskIntent map[string]any) bool {
-	if stringValue(taskIntent, "name", "") == "write_file" {
-		return true
-	}
-
-	arguments := mapValue(taskIntent, "arguments")
-	if requireAuthorization, ok := arguments["require_authorization"].(bool); ok {
-		return requireAuthorization
-	}
-
-	return false
-}
-
 // buildApprovalRequest 处理当前模块的相关逻辑。
 
 // buildApprovalRequest 构造统一的 approval_request 结构。
-func buildApprovalRequest(taskID string, taskIntent map[string]any, riskLevel string) map[string]any {
+func buildApprovalRequest(taskID string, taskIntent map[string]any, assessment execution.GovernanceAssessment) map[string]any {
 	arguments := mapValue(taskIntent, "arguments")
-	targetObject := stringValue(arguments, "target_path", "workspace_document")
+	targetObject := firstNonEmptyString(assessment.TargetObject, stringValue(arguments, "target_path", "workspace_document"))
 	if targetObject == "" {
 		targetObject = "workspace_document"
 	}
@@ -1801,10 +1782,10 @@ func buildApprovalRequest(taskID string, taskIntent map[string]any, riskLevel st
 	return map[string]any{
 		"approval_id":    fmt.Sprintf("appr_%s", taskID),
 		"task_id":        taskID,
-		"operation_name": firstNonEmptyString(stringValue(taskIntent, "name", ""), "write_file"),
-		"risk_level":     firstNonEmptyString(riskLevel, "red"),
+		"operation_name": firstNonEmptyString(assessment.OperationName, firstNonEmptyString(stringValue(taskIntent, "name", ""), "write_file")),
+		"risk_level":     firstNonEmptyString(assessment.RiskLevel, "red"),
 		"target_object":  targetObject,
-		"reason":         "policy_requires_authorization",
+		"reason":         firstNonEmptyString(assessment.Reason, "policy_requires_authorization"),
 		"status":         "pending",
 		"created_at":     time.Now().Format(dateTimeLayout),
 	}
@@ -1814,6 +1795,9 @@ func buildApprovalRequest(taskID string, taskIntent map[string]any, riskLevel st
 
 // buildImpactScope 构造最小影响范围摘要，用于授权结果回传和安全面板展示。
 func (s *Service) buildImpactScope(task runengine.TaskRecord, pendingExecution map[string]any) map[string]any {
+	if impactScope, ok := pendingExecution["impact_scope"].(map[string]any); ok && len(impactScope) > 0 {
+		return cloneMap(impactScope)
+	}
 	files := deriveImpactScopeFiles(task, pendingExecution, s.delivery)
 	workspacePath := workspacePathFromSettings(s.runEngine.Settings())
 	outOfWorkspace := false
@@ -1925,6 +1909,158 @@ func deliveryPreferenceFromStart(params map[string]any) (string, string) {
 func (s *Service) buildPendingExecution(task runengine.TaskRecord, taskIntent map[string]any) map[string]any {
 	plan := s.delivery.BuildApprovalExecutionPlan(task.TaskID, taskIntent)
 	return s.applyResolvedDeliveryToPlan(task, plan, taskIntent)
+}
+
+func (s *Service) applyGovernanceAssessment(plan map[string]any, assessment execution.GovernanceAssessment) map[string]any {
+	updatedPlan := cloneMap(plan)
+	if updatedPlan == nil {
+		updatedPlan = map[string]any{}
+	}
+	if len(assessment.ImpactScope) > 0 {
+		updatedPlan["impact_scope"] = cloneMap(assessment.ImpactScope)
+	}
+	if assessment.OperationName != "" {
+		updatedPlan["operation_name"] = assessment.OperationName
+	}
+	if assessment.TargetObject != "" {
+		updatedPlan["target_object"] = assessment.TargetObject
+	}
+	if assessment.RiskLevel != "" {
+		updatedPlan["risk_level"] = assessment.RiskLevel
+	}
+	if assessment.Reason != "" {
+		updatedPlan["risk_reason"] = assessment.Reason
+	}
+	updatedPlan["checkpoint_required"] = assessment.CheckpointRequired
+	return updatedPlan
+}
+
+func (s *Service) assessTaskGovernance(task runengine.TaskRecord, taskIntent map[string]any) (execution.GovernanceAssessment, bool, error) {
+	if s.executor == nil {
+		return execution.GovernanceAssessment{}, false, nil
+	}
+	resultTitle, _, _ := resultSpecFromIntent(taskIntent)
+	return s.executor.AssessGovernance(context.Background(), execution.Request{
+		TaskID:       task.TaskID,
+		RunID:        task.RunID,
+		Title:        task.Title,
+		Intent:       taskIntent,
+		Snapshot:     snapshotFromTask(task),
+		DeliveryType: resolveTaskDeliveryType(task, taskIntent),
+		ResultTitle:  resultTitle,
+	})
+}
+
+func (s *Service) handleTaskGovernanceDecision(task runengine.TaskRecord, taskIntent map[string]any) (runengine.TaskRecord, map[string]any, bool, error) {
+	assessment, ok, err := s.assessTaskGovernance(task, taskIntent)
+	if err != nil {
+		return task, nil, false, err
+	}
+	if !ok {
+		assessment, ok = s.fallbackGovernanceAssessment(task, taskIntent)
+		if !ok {
+			return task, nil, false, nil
+		}
+	}
+	if assessment.Deny {
+		response, blockedTask, blockErr := s.blockTaskByAssessment(task, assessment)
+		return blockedTask, response, true, blockErr
+	}
+	if !assessment.ApprovalRequired {
+		return task, nil, false, nil
+	}
+	pendingExecution := s.applyGovernanceAssessment(s.buildPendingExecution(task, taskIntent), assessment)
+	approvalRequest := buildApprovalRequest(task.TaskID, taskIntent, assessment)
+	bubble := s.delivery.BuildBubbleMessage(task.TaskID, "status", "检测到待授权操作，请先确认。", task.UpdatedAt.Format(dateTimeLayout))
+	updatedTask, changed := s.runEngine.MarkWaitingApprovalWithPlan(task.TaskID, approvalRequest, pendingExecution, bubble)
+	if !changed {
+		return task, nil, false, ErrTaskNotFound
+	}
+	return updatedTask, map[string]any{
+		"task":            taskMap(updatedTask),
+		"bubble_message":  bubble,
+		"delivery_result": nil,
+	}, true, nil
+}
+
+func (s *Service) fallbackGovernanceAssessment(task runengine.TaskRecord, taskIntent map[string]any) (execution.GovernanceAssessment, bool) {
+	if stringValue(taskIntent, "name", "") != "write_file" && !boolValue(mapValue(taskIntent, "arguments"), "require_authorization", false) {
+		return execution.GovernanceAssessment{}, false
+	}
+	plan := s.buildPendingExecution(task, taskIntent)
+	impactScope := s.buildImpactScope(task, plan)
+	return execution.GovernanceAssessment{
+		OperationName:    firstNonEmptyString(stringValue(taskIntent, "name", ""), "write_file"),
+		TargetObject:     impactScopeTarget(impactScope, targetPathFromIntent(taskIntent)),
+		RiskLevel:        "red",
+		ApprovalRequired: true,
+		Reason:           "policy_requires_authorization",
+		ImpactScope:      impactScope,
+	}, true
+}
+
+func (s *Service) blockTaskByAssessment(task runengine.TaskRecord, assessment execution.GovernanceAssessment) (map[string]any, runengine.TaskRecord, error) {
+	bubbleText := governanceInterceptionBubble(assessment)
+	bubble := s.delivery.BuildBubbleMessage(task.TaskID, "status", bubbleText, task.UpdatedAt.Format(dateTimeLayout))
+	updatedTask, ok := s.runEngine.BlockTaskByPolicy(task.TaskID, assessment.RiskLevel, bubbleText, assessment.ImpactScope, bubble)
+	if !ok {
+		return nil, task, ErrTaskNotFound
+	}
+	auditRecord := s.writeGovernanceAuditRecord(updatedTask.TaskID, updatedTask.RunID, "risk", "intercept_operation", bubbleText, impactScopeTarget(assessment.ImpactScope, assessment.TargetObject), "denied")
+	updatedTask = s.appendAuditData(updatedTask, compactAuditRecords(auditRecord), nil)
+	return map[string]any{
+		"task":            taskMap(updatedTask),
+		"bubble_message":  bubble,
+		"delivery_result": nil,
+		"impact_scope":    cloneMap(assessment.ImpactScope),
+	}, updatedTask, nil
+}
+
+func (s *Service) writeGovernanceAuditRecord(taskID, runID, auditType, action, summary, target, result string) map[string]any {
+	if s.audit == nil {
+		return nil
+	}
+	if record, err := s.audit.Write(context.Background(), audit.RecordInput{
+		TaskID:  taskID,
+		Type:    auditType,
+		Action:  action,
+		Summary: summary,
+		Target:  target,
+		Result:  result,
+	}); err == nil {
+		return record.Map()
+	}
+	if record, err := s.audit.BuildRecord(audit.RecordInput{
+		TaskID:  taskID,
+		Type:    auditType,
+		Action:  action,
+		Summary: summary,
+		Target:  target,
+		Result:  result,
+	}); err == nil {
+		return record.Map()
+	}
+	return nil
+}
+
+func governanceInterceptionBubble(assessment execution.GovernanceAssessment) string {
+	switch assessment.Reason {
+	case risk.ReasonOutOfWorkspace:
+		return "目标超出工作区边界，已阻止本次操作。"
+	case risk.ReasonCommandNotAllowed:
+		return "命令存在高危风险，已被策略拦截。"
+	case risk.ReasonCapabilityDenied:
+		return "当前平台能力不可用，已阻止本次操作。"
+	default:
+		return "高风险操作已被策略拦截，未进入执行。"
+	}
+}
+
+func impactScopeTarget(impactScope map[string]any, fallback string) string {
+	if files := stringSliceValue(impactScope["files"]); len(files) > 0 {
+		return files[0]
+	}
+	return firstNonEmptyString(strings.TrimSpace(fallback), "main_flow")
 }
 
 // applyResolvedDeliveryToPlan 把任务级交付偏好解析结果回填到恢复执行计划中。
@@ -2195,34 +2331,26 @@ func (s *Service) executeTask(task runengine.TaskRecord, snapshot contextsvc.Tas
 	}
 
 	executionResult, err := s.executor.Execute(context.Background(), execution.Request{
-		TaskID:       processingTask.TaskID,
-		RunID:        processingTask.RunID,
-		Title:        processingTask.Title,
-		Intent:       taskIntent,
-		Snapshot:     snapshot,
-		DeliveryType: deliveryType,
-		ResultTitle:  resultTitle,
+		TaskID:          processingTask.TaskID,
+		RunID:           processingTask.RunID,
+		Title:           processingTask.Title,
+		Intent:          taskIntent,
+		Snapshot:        snapshot,
+		DeliveryType:    deliveryType,
+		ResultTitle:     resultTitle,
+		ApprovalGranted: processingTask.Authorization != nil,
 	})
+	processingTask = s.recordExecutionToolCalls(processingTask, executionResult.ToolCalls)
+	auditDeliveryResult := executionResult.DeliveryResult
 	if err != nil {
-		return runengine.TaskRecord{}, nil, nil, nil, fmt.Errorf("execute task %s: %w", processingTask.TaskID, err)
+		auditDeliveryResult = nil
 	}
-
-	for _, toolCall := range executionResult.ToolCalls {
-		if toolCall.ToolName == "" {
-			continue
-		}
-		if recordedTask, ok := s.runEngine.RecordToolCall(
-			processingTask.TaskID,
-			toolCall.ToolName,
-			toolCall.Input,
-			toolCall.Output,
-			toolCall.DurationMS,
-		); ok {
-			processingTask = recordedTask
-		}
-	}
-	executionAuditRecords, executionTokenUsage := s.buildExecutionAudit(processingTask, executionResult.ToolCalls, executionResult.DeliveryResult)
+	executionAuditRecords, executionTokenUsage := s.buildExecutionAudit(processingTask, executionResult.ToolCalls, auditDeliveryResult)
 	processingTask = s.appendAuditData(processingTask, executionAuditRecords, executionTokenUsage)
+	if err != nil {
+		failedTask, failureBubble := s.failExecutionTask(processingTask, taskIntent, executionResult, err)
+		return failedTask, failureBubble, nil, nil, nil
+	}
 
 	resultBubble := s.delivery.BuildBubbleMessage(
 		processingTask.TaskID,
@@ -2230,12 +2358,82 @@ func (s *Service) executeTask(task runengine.TaskRecord, snapshot contextsvc.Tas
 		firstNonEmptyString(executionResult.BubbleText, resultBubbleText),
 		processingTask.UpdatedAt.Format(dateTimeLayout),
 	)
-	updatedTask, ok := s.runEngine.CompleteTask(processingTask.TaskID, executionResult.DeliveryResult, resultBubble, executionResult.Artifacts)
+	updatedTask, ok := s.runEngine.CompleteTask(processingTask.TaskID, executionResult.DeliveryResult, resultBubble, executionResult.Artifacts, executionResult.RecoveryPoint)
 	if !ok {
 		return runengine.TaskRecord{}, nil, nil, nil, ErrTaskNotFound
 	}
 	s.attachPostDeliveryHandoffs(updatedTask.TaskID, updatedTask.RunID, snapshot, taskIntent, executionResult.DeliveryResult, executionResult.Artifacts)
 	return updatedTask, resultBubble, executionResult.DeliveryResult, executionResult.Artifacts, nil
+}
+
+func (s *Service) recordExecutionToolCalls(task runengine.TaskRecord, toolCalls []tools.ToolCallRecord) runengine.TaskRecord {
+	for _, toolCall := range toolCalls {
+		if toolCall.ToolName == "" {
+			continue
+		}
+		if recordedTask, ok := s.runEngine.RecordToolCallLifecycle(
+			task.TaskID,
+			toolCall.ToolName,
+			string(toolCall.Status),
+			toolCall.Input,
+			toolCall.Output,
+			toolCall.DurationMS,
+			toolCallErrorCode(toolCall),
+		); ok {
+			task = recordedTask
+		}
+	}
+	return task
+}
+
+func toolCallErrorCode(toolCall tools.ToolCallRecord) any {
+	if toolCall.ErrorCode == nil {
+		return nil
+	}
+	return *toolCall.ErrorCode
+}
+
+func (s *Service) failExecutionTask(task runengine.TaskRecord, taskIntent map[string]any, executionResult execution.Result, err error) (runengine.TaskRecord, map[string]any) {
+	impactScope := s.buildImpactScope(task, task.PendingExecution)
+	bubbleText := executionFailureBubble(err)
+	securityStatus := "execution_error"
+	stepName := "execution_failed"
+	auditType := "execution"
+	auditAction := "execute_task"
+	auditTarget := impactScopeTarget(impactScope, targetPathFromIntent(taskIntent))
+	auditResult := "failed"
+	if errors.Is(err, execution.ErrRecoveryPointPrepareFailed) {
+		securityStatus = "execution_error"
+		stepName = "recovery_prepare_failed"
+		auditType = "recovery"
+		auditAction = "create_recovery_point"
+		auditTarget = impactScopeTarget(impactScope, stringValue(executionResult.RecoveryPoint, "summary", "workspace"))
+	}
+	bubble := s.delivery.BuildBubbleMessage(task.TaskID, "status", bubbleText, task.UpdatedAt.Format(dateTimeLayout))
+	updatedTask, ok := s.runEngine.FailTaskExecution(task.TaskID, stepName, securityStatus, bubbleText, impactScope, bubble, executionResult.RecoveryPoint)
+	if !ok {
+		return task, bubble
+	}
+	auditRecord := s.writeGovernanceAuditRecord(updatedTask.TaskID, updatedTask.RunID, auditType, auditAction, bubbleText, auditTarget, auditResult)
+	updatedTask = s.appendAuditData(updatedTask, compactAuditRecords(auditRecord), nil)
+	return updatedTask, bubble
+}
+
+func executionFailureBubble(err error) string {
+	switch {
+	case errors.Is(err, execution.ErrRecoveryPointPrepareFailed):
+		return "执行失败：执行前恢复点创建失败，请稍后重试。"
+	case errors.Is(err, tools.ErrWorkspaceBoundaryDenied):
+		return "执行失败：目标超出工作区边界，已阻止本次操作。"
+	case errors.Is(err, tools.ErrCommandNotAllowed):
+		return "执行失败：命令存在高危风险，已被策略拦截。"
+	case errors.Is(err, tools.ErrCapabilityDenied):
+		return "执行失败：当前平台能力不可用，请检查环境后重试。"
+	case errors.Is(err, tools.ErrToolExecutionFailed):
+		return "执行失败：工具运行失败，请检查环境后重试。"
+	default:
+		return "执行失败：请稍后重试。"
+	}
 }
 
 func (s *Service) buildExecutionAudit(task runengine.TaskRecord, toolCalls []tools.ToolCallRecord, deliveryResult map[string]any) ([]map[string]any, map[string]any) {

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -707,6 +707,34 @@ func (s *Service) SecurityAuditList(params map[string]any) (map[string]any, erro
 	}, nil
 }
 
+// SecurityRestorePointsList 处理 agent.security.restore_points.list。
+func (s *Service) SecurityRestorePointsList(params map[string]any) (map[string]any, error) {
+	limit := clampListLimit(intValue(params, "limit", 20))
+	offset := clampListOffset(intValue(params, "offset", 0))
+	taskID := stringValue(params, "task_id", "")
+	if s.storage == nil {
+		return map[string]any{"items": []map[string]any{}, "page": pageMap(limit, offset, 0)}, nil
+	}
+	points, total, err := s.storage.RecoveryPointStore().ListRecoveryPoints(context.Background(), taskID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrStorageQueryFailed, err)
+	}
+	items := make([]map[string]any, 0, len(points))
+	for _, point := range points {
+		items = append(items, map[string]any{
+			"recovery_point_id": point.RecoveryPointID,
+			"task_id":           point.TaskID,
+			"summary":           point.Summary,
+			"created_at":        point.CreatedAt,
+			"objects":           append([]string(nil), point.Objects...),
+		})
+	}
+	return map[string]any{
+		"items": items,
+		"page":  pageMap(limit, offset, total),
+	}, nil
+}
+
 func clampListLimit(limit int) int {
 	if limit <= 0 {
 		return 20

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/audit"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/checkpoint"
 	contextsvc "github.com/cialloclaw/cialloclaw/services/local-service/internal/context"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/delivery"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/execution"
@@ -29,10 +30,11 @@ import (
 
 // ErrTaskNotFound 表示调用方给出的 task_id 在当前运行态中不存在。
 var (
-	ErrTaskNotFound        = errors.New("task not found")
-	ErrTaskStatusInvalid   = errors.New("task status invalid")
-	ErrTaskAlreadyFinished = errors.New("task already finished")
-	ErrStorageQueryFailed  = errors.New("storage query failed")
+	ErrTaskNotFound          = errors.New("task not found")
+	ErrTaskStatusInvalid     = errors.New("task status invalid")
+	ErrTaskAlreadyFinished   = errors.New("task already finished")
+	ErrStorageQueryFailed    = errors.New("storage query failed")
+	ErrRecoveryPointNotFound = errors.New("recovery point not found")
 )
 
 // Service 提供当前模块的服务能力。
@@ -732,6 +734,68 @@ func (s *Service) SecurityRestorePointsList(params map[string]any) (map[string]a
 	return map[string]any{
 		"items": items,
 		"page":  pageMap(limit, offset, total),
+	}, nil
+}
+
+// SecurityRestoreApply 处理 agent.security.restore.apply。
+func (s *Service) SecurityRestoreApply(params map[string]any) (map[string]any, error) {
+	recoveryPointID := stringValue(params, "recovery_point_id", "")
+	if strings.TrimSpace(recoveryPointID) == "" {
+		return nil, errors.New("recovery_point_id is required")
+	}
+	taskID := stringValue(params, "task_id", "")
+	point, err := s.findRecoveryPointFromStorage(taskID, recoveryPointID)
+	if err != nil {
+		return nil, err
+	}
+	resolvedTaskID := firstNonEmptyString(strings.TrimSpace(taskID), point.TaskID)
+	task, ok := s.runEngine.GetTask(resolvedTaskID)
+	if !ok {
+		if s.storage == nil {
+			return nil, ErrTaskNotFound
+		}
+		persisted, loadErr := s.storage.TaskRunStore().LoadTaskRuns(context.Background())
+		if loadErr != nil {
+			return nil, fmt.Errorf("%w: %v", ErrStorageQueryFailed, loadErr)
+		}
+		loadedTask, found := findTaskRecordFromStorage(persisted, resolvedTaskID)
+		if !found {
+			return nil, ErrTaskNotFound
+		}
+		task = s.runEngine.HydrateTaskFromStorage(loadedTask)
+	}
+
+	recoveryPoint := recoveryPointMap(point)
+	applied := false
+	securityStatus := "recovered"
+	bubbleText := fmt.Sprintf("已根据恢复点 %s 恢复 %d 个对象。", point.RecoveryPointID, len(point.Objects))
+	if s.executor == nil {
+		securityStatus = "execution_error"
+		bubbleText = "恢复失败：执行后端不可用。"
+	} else if applyResult, err := s.executor.ApplyRecoveryPoint(context.Background(), point); err != nil {
+		securityStatus = "execution_error"
+		bubbleText = fmt.Sprintf("恢复失败：%s", err.Error())
+	} else {
+		applied = true
+		if len(applyResult.RestoredObjects) > 0 {
+			bubbleText = fmt.Sprintf("已根据恢复点 %s 恢复 %d 个对象。", point.RecoveryPointID, len(applyResult.RestoredObjects))
+		}
+	}
+
+	bubble := s.delivery.BuildBubbleMessage(task.TaskID, "status", bubbleText, time.Now().Format(dateTimeLayout))
+	updatedTask, ok := s.runEngine.ApplyRecoveryOutcome(task.TaskID, securityStatus, recoveryPoint, bubble)
+	if !ok {
+		return nil, ErrTaskNotFound
+	}
+	auditRecord := s.writeRestoreAuditRecord(updatedTask.TaskID, point, applied, bubbleText)
+	updatedTask = s.appendAuditData(updatedTask, compactAuditRecords(auditRecord), nil)
+
+	return map[string]any{
+		"applied":        applied,
+		"task":           taskMap(updatedTask),
+		"recovery_point": recoveryPoint,
+		"audit_record":   auditRecord,
+		"bubble_message": bubble,
 	}, nil
 }
 
@@ -1489,6 +1553,140 @@ func (s *Service) latestRestorePointFromStorage(taskID string) map[string]any {
 	}
 }
 
+func (s *Service) findRecoveryPointFromStorage(taskID, recoveryPointID string) (checkpoint.RecoveryPoint, error) {
+	if s.storage == nil {
+		return checkpoint.RecoveryPoint{}, fmt.Errorf("%w: recovery point store unavailable", ErrStorageQueryFailed)
+	}
+	item, err := s.storage.RecoveryPointStore().GetRecoveryPoint(context.Background(), recoveryPointID)
+	if err != nil {
+		if errors.Is(err, storage.ErrRecoveryPointNotFound) {
+			return checkpoint.RecoveryPoint{}, ErrRecoveryPointNotFound
+		}
+		return checkpoint.RecoveryPoint{}, fmt.Errorf("%w: %v", ErrStorageQueryFailed, err)
+	}
+	if taskID != "" && item.TaskID != taskID {
+		return checkpoint.RecoveryPoint{}, ErrRecoveryPointNotFound
+	}
+	return item, nil
+}
+
+func recoveryPointMap(point checkpoint.RecoveryPoint) map[string]any {
+	return map[string]any{
+		"recovery_point_id": point.RecoveryPointID,
+		"task_id":           point.TaskID,
+		"summary":           point.Summary,
+		"created_at":        point.CreatedAt,
+		"objects":           append([]string(nil), point.Objects...),
+	}
+}
+
+func (s *Service) writeRestoreAuditRecord(taskID string, point checkpoint.RecoveryPoint, applied bool, summary string) map[string]any {
+	if s.audit == nil {
+		return nil
+	}
+	input := audit.RecordInput{
+		TaskID:  taskID,
+		Type:    "recovery",
+		Action:  "restore_apply",
+		Summary: firstNonEmptyString(strings.TrimSpace(summary), "restore apply completed"),
+		Target:  firstNonEmptyString(strings.Join(point.Objects, ", "), "recovery_scope"),
+		Result:  map[bool]string{true: "success", false: "failed"}[applied],
+	}
+	if record, err := s.audit.Write(context.Background(), input); err == nil {
+		return record.Map()
+	}
+	if record, err := s.audit.BuildRecord(input); err == nil {
+		return record.Map()
+	}
+	return nil
+}
+
+func findTaskRecordFromStorage(records []storage.TaskRunRecord, taskID string) (runengine.TaskRecord, bool) {
+	for _, record := range records {
+		if record.TaskID == taskID {
+			return runengine.TaskRecord{
+				TaskID:            record.TaskID,
+				SessionID:         record.SessionID,
+				RunID:             record.RunID,
+				Title:             record.Title,
+				SourceType:        record.SourceType,
+				Status:            record.Status,
+				Intent:            cloneMap(record.Intent),
+				PreferredDelivery: record.PreferredDelivery,
+				FallbackDelivery:  record.FallbackDelivery,
+				CurrentStep:       record.CurrentStep,
+				RiskLevel:         record.RiskLevel,
+				StartedAt:         record.StartedAt,
+				UpdatedAt:         record.UpdatedAt,
+				FinishedAt:        cloneStorageTimePointer(record.FinishedAt),
+				Timeline:          taskTimelineFromStorage(record.Timeline),
+				BubbleMessage:     cloneMap(record.BubbleMessage),
+				DeliveryResult:    cloneMap(record.DeliveryResult),
+				Artifacts:         cloneMapSlice(record.Artifacts),
+				AuditRecords:      cloneMapSlice(record.AuditRecords),
+				MirrorReferences:  cloneMapSlice(record.MirrorReferences),
+				SecuritySummary:   cloneMap(record.SecuritySummary),
+				ApprovalRequest:   cloneMap(record.ApprovalRequest),
+				PendingExecution:  cloneMap(record.PendingExecution),
+				Authorization:     cloneMap(record.Authorization),
+				ImpactScope:       cloneMap(record.ImpactScope),
+				TokenUsage:        cloneMap(record.TokenUsage),
+				MemoryReadPlans:   cloneMapSlice(record.MemoryReadPlans),
+				MemoryWritePlans:  cloneMapSlice(record.MemoryWritePlans),
+				StorageWritePlan:  cloneMap(record.StorageWritePlan),
+				ArtifactPlans:     cloneMapSlice(record.ArtifactPlans),
+				Notifications:     taskNotificationsFromStorage(record.Notifications),
+				LatestEvent:       cloneMap(record.LatestEvent),
+				LatestToolCall:    cloneMap(record.LatestToolCall),
+				CurrentStepStatus: record.CurrentStepStatus,
+			}, true
+		}
+	}
+	return runengine.TaskRecord{}, false
+}
+
+func taskTimelineFromStorage(timeline []storage.TaskStepSnapshot) []runengine.TaskStepRecord {
+	if len(timeline) == 0 {
+		return nil
+	}
+	result := make([]runengine.TaskStepRecord, len(timeline))
+	for index, step := range timeline {
+		result[index] = runengine.TaskStepRecord{
+			StepID:        step.StepID,
+			TaskID:        step.TaskID,
+			Name:          step.Name,
+			Status:        step.Status,
+			OrderIndex:    step.OrderIndex,
+			InputSummary:  step.InputSummary,
+			OutputSummary: step.OutputSummary,
+		}
+	}
+	return result
+}
+
+func taskNotificationsFromStorage(values []storage.NotificationSnapshot) []runengine.NotificationRecord {
+	if len(values) == 0 {
+		return nil
+	}
+	result := make([]runengine.NotificationRecord, len(values))
+	for index, value := range values {
+		result[index] = runengine.NotificationRecord{
+			Method:    value.Method,
+			Params:    cloneMap(value.Params),
+			CreatedAt: value.CreatedAt,
+		}
+	}
+	return result
+}
+
+func cloneStorageTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
 func latestOutputPathFromTasks(tasks []runengine.TaskRecord) string {
 	for _, task := range tasks {
 		if outputPath := pathFromDeliveryResult(task.DeliveryResult); outputPath != "" {
@@ -2107,7 +2305,7 @@ func (s *Service) executeTask(task runengine.TaskRecord, snapshot contextsvc.Tas
 		firstNonEmptyString(executionResult.BubbleText, resultBubbleText),
 		processingTask.UpdatedAt.Format(dateTimeLayout),
 	)
-	updatedTask, ok := s.runEngine.CompleteTask(processingTask.TaskID, executionResult.DeliveryResult, resultBubble, executionResult.Artifacts)
+	updatedTask, ok := s.runEngine.CompleteTask(processingTask.TaskID, executionResult.DeliveryResult, resultBubble, executionResult.Artifacts, executionResult.RecoveryPoint)
 	if !ok {
 		return runengine.TaskRecord{}, nil, nil, nil, ErrTaskNotFound
 	}

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -43,6 +43,17 @@ func (b failingExecutionBackend) RunCommand(_ context.Context, _ string, _ []str
 	return tools.CommandExecutionResult{}, b.err
 }
 
+type successfulExecutionBackend struct {
+	result tools.CommandExecutionResult
+}
+
+func (b successfulExecutionBackend) RunCommand(_ context.Context, _ string, _ []string, _ string) (tools.CommandExecutionResult, error) {
+	if b.result.ExitCode == 0 && b.result.Stdout == "" && b.result.Stderr == "" {
+		return tools.CommandExecutionResult{Stdout: "ok", ExitCode: 0}, nil
+	}
+	return b.result, nil
+}
+
 type failingCheckpointWriter struct {
 	err error
 }
@@ -1492,7 +1503,7 @@ func TestServiceSecurityRespondAllowOnceReturnsStructuredExecutionFailure(t *tes
 }
 
 func TestServiceSecurityRespondAllowOnceExecCommandCompletesAfterApproval(t *testing.T) {
-	service, workspaceRoot := newTestServiceWithExecution(t, "unused")
+	service, workspaceRoot := newTestServiceWithExecutionOptions(t, "unused", successfulExecutionBackend{result: tools.CommandExecutionResult{Stdout: "ok", ExitCode: 0}}, nil)
 	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
 		t.Fatalf("mkdir workspace root: %v", err)
 	}

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -35,6 +35,22 @@ type stubModelClient struct {
 	output string
 }
 
+type failingExecutionBackend struct {
+	err error
+}
+
+func (b failingExecutionBackend) RunCommand(_ context.Context, _ string, _ []string, _ string) (tools.CommandExecutionResult, error) {
+	return tools.CommandExecutionResult{}, b.err
+}
+
+type failingCheckpointWriter struct {
+	err error
+}
+
+func (w failingCheckpointWriter) WriteRecoveryPoint(_ context.Context, _ checkpoint.RecoveryPoint) error {
+	return w.err
+}
+
 func (s stubModelClient) GenerateText(_ context.Context, request model.GenerateTextRequest) (model.GenerateTextResponse, error) {
 	return model.GenerateTextResponse{
 		TaskID:     request.TaskID,
@@ -53,6 +69,10 @@ func (s stubModelClient) GenerateText(_ context.Context, request model.GenerateT
 }
 
 func newTestServiceWithExecution(t *testing.T, modelOutput string) (*Service, string) {
+	return newTestServiceWithExecutionOptions(t, modelOutput, platform.LocalExecutionBackend{}, nil)
+}
+
+func newTestServiceWithExecutionOptions(t *testing.T, modelOutput string, executionBackend tools.ExecutionCapability, checkpointWriter checkpoint.Writer) (*Service, string) {
 	t.Helper()
 
 	workspaceRoot := filepath.Join(t.TempDir(), "workspace")
@@ -61,8 +81,13 @@ func newTestServiceWithExecution(t *testing.T, modelOutput string) (*Service, st
 		t.Fatalf("new local path policy: %v", err)
 	}
 
+	storageService := storage.NewService(platform.NewLocalStorageAdapter(filepath.Join(t.TempDir(), "service.db")))
+	t.Cleanup(func() { _ = storageService.Close() })
+	if checkpointWriter == nil {
+		checkpointWriter = storageService.RecoveryPointWriter()
+	}
 	modelService := model.NewService(modelConfig(), stubModelClient{output: modelOutput})
-	auditService := audit.NewService()
+	auditService := audit.NewService(storageService.AuditWriter())
 	deliveryService := delivery.NewService()
 	toolRegistry := tools.NewRegistry()
 	if err := builtin.RegisterBuiltinTools(toolRegistry); err != nil {
@@ -71,9 +96,7 @@ func newTestServiceWithExecution(t *testing.T, modelOutput string) (*Service, st
 	toolExecutor := tools.NewToolExecutor(toolRegistry)
 	pluginService := plugin.NewService()
 	fileSystem := platform.NewLocalFileSystemAdapter(pathPolicy)
-	executor := execution.NewService(fileSystem, platform.LocalExecutionBackend{}, sidecarclient.NewNoopPlaywrightSidecarClient(), modelService, auditService, checkpoint.NewService(), deliveryService, toolRegistry, toolExecutor, pluginService)
-	storageService := storage.NewService(platform.NewLocalStorageAdapter(filepath.Join(t.TempDir(), "service.db")))
-	t.Cleanup(func() { _ = storageService.Close() })
+	executor := execution.NewService(fileSystem, executionBackend, sidecarclient.NewNoopPlaywrightSidecarClient(), modelService, auditService, checkpoint.NewService(checkpointWriter), deliveryService, toolRegistry, toolExecutor, pluginService)
 
 	service := NewService(
 		contextsvc.NewService(),
@@ -1278,6 +1301,288 @@ func TestServiceSecurityRespondDenyOnceCancelsTask(t *testing.T) {
 	}
 	if record.PendingExecution != nil {
 		t.Fatal("expected pending execution plan to be cleared after denial")
+	}
+}
+
+func TestServiceStartTaskWriteFileOverwriteWaitsForApproval(t *testing.T) {
+	service, workspaceRoot := newTestServiceWithExecution(t, "unused")
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, "notes"), 0o755); err != nil {
+		t.Fatalf("mkdir notes: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "notes", "output.md"), []byte("旧内容"), 0o644); err != nil {
+		t.Fatalf("seed output file: %v", err)
+	}
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_overwrite",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "请覆盖该文件",
+		},
+		"intent": map[string]any{
+			"name": "write_file",
+			"arguments": map[string]any{
+				"target_path": "notes/output.md",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+	task := startResult["task"].(map[string]any)
+	if task["status"] != "waiting_auth" {
+		t.Fatalf("expected waiting_auth for overwrite risk, got %+v", task)
+	}
+	if task["risk_level"] != "yellow" {
+		t.Fatalf("expected yellow overwrite risk, got %+v", task)
+	}
+	pendingPlan, ok := service.runEngine.PendingExecutionPlan(task["task_id"].(string))
+	if !ok {
+		t.Fatal("expected pending execution plan for overwrite task")
+	}
+	impactScope := pendingPlan["impact_scope"].(map[string]any)
+	if impactScope["overwrite_or_delete_risk"] != true {
+		t.Fatalf("expected overwrite_or_delete_risk=true, got %+v", impactScope)
+	}
+}
+
+func TestServiceStartTaskExecCommandWaitsForApproval(t *testing.T) {
+	service, workspaceRoot := newTestServiceWithExecution(t, "unused")
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_exec_cmd",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "执行命令",
+		},
+		"intent": map[string]any{
+			"name": "exec_command",
+			"arguments": map[string]any{
+				"command": "cmd",
+				"args":    []any{"/c", "echo", "ok"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+	task := startResult["task"].(map[string]any)
+	if task["status"] != "waiting_auth" {
+		t.Fatalf("expected waiting_auth for exec_command, got %+v", task)
+	}
+	if task["risk_level"] != "yellow" {
+		t.Fatalf("expected yellow risk for safe exec_command, got %+v", task)
+	}
+	pendingPlan, ok := service.runEngine.PendingExecutionPlan(task["task_id"].(string))
+	if !ok {
+		t.Fatal("expected pending execution plan for exec_command")
+	}
+	files := pendingPlan["impact_scope"].(map[string]any)["files"].([]string)
+	if len(files) != 1 || !strings.Contains(files[0], filepath.Base(workspaceRoot)) {
+		t.Fatalf("expected impact scope to include workspace root, got %+v", pendingPlan)
+	}
+}
+
+func TestServiceStartTaskOutOfWorkspaceWriteIsBlocked(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "unused")
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_outside",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "越界写入",
+		},
+		"intent": map[string]any{
+			"name": "write_file",
+			"arguments": map[string]any{
+				"target_path": "../secret.txt",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+	task := startResult["task"].(map[string]any)
+	if task["status"] != "cancelled" {
+		t.Fatalf("expected cancelled task after out-of-workspace deny, got %+v", task)
+	}
+	record, ok := service.runEngine.GetTask(task["task_id"].(string))
+	if !ok {
+		t.Fatal("expected blocked task to remain in runtime")
+	}
+	if stringValue(record.SecuritySummary, "security_status", "") != "intercepted" {
+		t.Fatalf("expected intercepted security status, got %+v", record.SecuritySummary)
+	}
+	if len(record.AuditRecords) == 0 {
+		t.Fatal("expected blocked task to record audit trail")
+	}
+}
+
+func TestServiceSecurityRespondAllowOnceReturnsStructuredExecutionFailure(t *testing.T) {
+	service, _ := newTestServiceWithExecutionOptions(t, "unused", failingExecutionBackend{err: errors.New("runner unavailable")}, nil)
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_exec_fail",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "执行命令",
+		},
+		"intent": map[string]any{
+			"name": "exec_command",
+			"arguments": map[string]any{
+				"command": "cmd",
+				"args":    []any{"/c", "echo", "ok"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	respondResult, err := service.SecurityRespond(map[string]any{
+		"task_id":       taskID,
+		"approval_id":   "appr_exec_fail",
+		"decision":      "allow_once",
+		"remember_rule": false,
+	})
+	if err != nil {
+		t.Fatalf("security respond failed: %v", err)
+	}
+	if respondResult["task"].(map[string]any)["status"] != "failed" {
+		t.Fatalf("expected failed task after execution error, got %+v", respondResult)
+	}
+	if respondResult["delivery_result"] != nil {
+		t.Fatalf("expected no delivery result on execution failure, got %+v", respondResult)
+	}
+	bubble := respondResult["bubble_message"].(map[string]any)
+	if !strings.Contains(stringValue(bubble, "text", ""), "执行失败") {
+		t.Fatalf("expected failure bubble, got %+v", bubble)
+	}
+	record, ok := service.runEngine.GetTask(taskID)
+	if !ok {
+		t.Fatal("expected failed task to remain in runtime")
+	}
+	if stringValue(record.SecuritySummary, "security_status", "") != "execution_error" {
+		t.Fatalf("expected execution_error security status, got %+v", record.SecuritySummary)
+	}
+	if len(record.AuditRecords) == 0 {
+		t.Fatal("expected failed execution to append audit records")
+	}
+	for _, auditRecord := range record.AuditRecords {
+		if auditRecord["action"] == "publish_result" {
+			t.Fatalf("expected failed execution not to publish delivery audit, got %+v", record.AuditRecords)
+		}
+	}
+}
+
+func TestServiceSecurityRespondAllowOnceExecCommandCompletesAfterApproval(t *testing.T) {
+	service, workspaceRoot := newTestServiceWithExecution(t, "unused")
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		t.Fatalf("mkdir workspace root: %v", err)
+	}
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_exec_allow",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "执行命令",
+		},
+		"intent": map[string]any{
+			"name": "exec_command",
+			"arguments": map[string]any{
+				"command": "cmd",
+				"args":    []any{"/c", "echo", "ok"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	respondResult, err := service.SecurityRespond(map[string]any{
+		"task_id":       taskID,
+		"approval_id":   "appr_exec_allow",
+		"decision":      "allow_once",
+		"remember_rule": false,
+	})
+	if err != nil {
+		t.Fatalf("security respond failed: %v", err)
+	}
+	if respondResult["task"].(map[string]any)["status"] != "completed" {
+		t.Fatalf("expected completed task after approved exec_command, got %+v", respondResult)
+	}
+	record, ok := service.runEngine.GetTask(taskID)
+	if !ok {
+		t.Fatal("expected task to remain in runtime after approved exec_command")
+	}
+	if record.LatestToolCall["tool_name"] != "exec_command" {
+		t.Fatalf("expected exec_command tool trace, got %+v", record.LatestToolCall)
+	}
+}
+
+func TestServiceSecurityRespondAllowOnceReturnsStructuredRecoveryFailure(t *testing.T) {
+	service, workspaceRoot := newTestServiceWithExecutionOptions(t, "unused", platform.LocalExecutionBackend{}, failingCheckpointWriter{err: errors.New("checkpoint unavailable")})
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, "notes"), 0o755); err != nil {
+		t.Fatalf("mkdir notes: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "notes", "output.md"), []byte("旧内容"), 0o644); err != nil {
+		t.Fatalf("seed output file: %v", err)
+	}
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_recovery_fail",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "请覆盖该文件",
+		},
+		"intent": map[string]any{
+			"name": "write_file",
+			"arguments": map[string]any{
+				"target_path": "notes/output.md",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	respondResult, err := service.SecurityRespond(map[string]any{
+		"task_id":       taskID,
+		"approval_id":   "appr_recovery_fail",
+		"decision":      "allow_once",
+		"remember_rule": false,
+	})
+	if err != nil {
+		t.Fatalf("security respond failed: %v", err)
+	}
+	if respondResult["task"].(map[string]any)["status"] != "failed" {
+		t.Fatalf("expected failed task after recovery preparation error, got %+v", respondResult)
+	}
+	record, ok := service.runEngine.GetTask(taskID)
+	if !ok {
+		t.Fatal("expected recovery-failed task to remain in runtime")
+	}
+	if stringValue(record.SecuritySummary, "security_status", "") != "execution_error" {
+		t.Fatalf("expected execution_error security status for recovery failure, got %+v", record.SecuritySummary)
+	}
+	if len(record.AuditRecords) == 0 {
+		t.Fatal("expected recovery failure to append audit records")
+	}
+	lastAudit := record.AuditRecords[len(record.AuditRecords)-1]
+	if lastAudit["action"] != "create_recovery_point" {
+		t.Fatalf("expected recovery failure audit action, got %+v", lastAudit)
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -60,9 +60,11 @@ func newTestServiceWithExecution(t *testing.T, modelOutput string) (*Service, st
 	if err != nil {
 		t.Fatalf("new local path policy: %v", err)
 	}
+	storageService := storage.NewService(platform.NewLocalStorageAdapter(filepath.Join(t.TempDir(), "service.db")))
+	t.Cleanup(func() { _ = storageService.Close() })
 
 	modelService := model.NewService(modelConfig(), stubModelClient{output: modelOutput})
-	auditService := audit.NewService()
+	auditService := audit.NewService(storageService.AuditWriter())
 	deliveryService := delivery.NewService()
 	toolRegistry := tools.NewRegistry()
 	if err := builtin.RegisterBuiltinTools(toolRegistry); err != nil {
@@ -71,14 +73,12 @@ func newTestServiceWithExecution(t *testing.T, modelOutput string) (*Service, st
 	toolExecutor := tools.NewToolExecutor(toolRegistry)
 	pluginService := plugin.NewService()
 	fileSystem := platform.NewLocalFileSystemAdapter(pathPolicy)
-	executor := execution.NewService(fileSystem, platform.LocalExecutionBackend{}, sidecarclient.NewNoopPlaywrightSidecarClient(), modelService, auditService, checkpoint.NewService(), deliveryService, toolRegistry, toolExecutor, pluginService)
-	storageService := storage.NewService(platform.NewLocalStorageAdapter(filepath.Join(t.TempDir(), "service.db")))
-	t.Cleanup(func() { _ = storageService.Close() })
+	executor := execution.NewService(fileSystem, platform.LocalExecutionBackend{}, sidecarclient.NewNoopPlaywrightSidecarClient(), modelService, auditService, checkpoint.NewService(storageService.RecoveryPointWriter()), deliveryService, toolRegistry, toolExecutor, pluginService)
 
 	service := NewService(
 		contextsvc.NewService(),
 		intent.NewService(),
-		runengine.NewEngine(),
+		mustNewStoredEngine(t, storageService.TaskRunStore()),
 		deliveryService,
 		memory.NewService(),
 		risk.NewService(),
@@ -88,6 +88,15 @@ func newTestServiceWithExecution(t *testing.T, modelOutput string) (*Service, st
 	).WithAudit(auditService).WithStorage(storageService).WithExecutor(executor).WithTaskInspector(taskinspector.NewService(fileSystem))
 
 	return service, workspaceRoot
+}
+
+func mustNewStoredEngine(t *testing.T, taskStore storage.TaskRunStore) *runengine.Engine {
+	t.Helper()
+	engine, err := runengine.NewEngineWithStore(taskStore)
+	if err != nil {
+		t.Fatalf("new stored engine: %v", err)
+	}
+	return engine
 }
 
 func newTestService() *Service {
@@ -1589,6 +1598,273 @@ func TestServiceSecurityRestorePointsListWithoutStorageReturnsEmptyPage(t *testi
 	page := result["page"].(map[string]any)
 	if page["total"] != 0 {
 		t.Fatalf("expected empty page metadata, got %+v", page)
+	}
+}
+
+func TestServiceTaskDetailGetFallsBackToStoredRecoveryPointForTask(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "executor-backed summary")
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_exec",
+		"source":     "floating_ball",
+		"trigger":    "text_selected_click",
+		"input": map[string]any{
+			"type": "text_selection",
+			"text": "task detail restore point fallback",
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	err = service.storage.RecoveryPointWriter().WriteRecoveryPoint(context.Background(), checkpoint.RecoveryPoint{
+		RecoveryPointID: "rp_task_detail",
+		TaskID:          taskID,
+		Summary:         "stored recovery point for task detail",
+		CreatedAt:       "2026-04-08T10:02:00Z",
+		Objects:         []string{"workspace/result.md"},
+	})
+	if err != nil {
+		t.Fatalf("write recovery point failed: %v", err)
+	}
+
+	result, err := service.TaskDetailGet(map[string]any{"task_id": taskID})
+	if err != nil {
+		t.Fatalf("task detail get failed: %v", err)
+	}
+	securitySummary := result["security_summary"].(map[string]any)
+	latestRestorePoint := securitySummary["latest_restore_point"].(map[string]any)
+	if latestRestorePoint["recovery_point_id"] != "rp_task_detail" {
+		t.Fatalf("expected storage-backed restore point in task detail, got %+v", latestRestorePoint)
+	}
+}
+
+func TestServiceSecurityRestoreApplyRestoresWorkspaceAndReturnsFormalResult(t *testing.T) {
+	service, workspaceRoot := newTestServiceWithExecution(t, "新的内容")
+	originalPath := filepath.Join(workspaceRoot, "notes", "output.md")
+	if err := os.MkdirAll(filepath.Dir(originalPath), 0o755); err != nil {
+		t.Fatalf("mkdir notes: %v", err)
+	}
+	if err := os.WriteFile(originalPath, []byte("旧的内容"), 0o644); err != nil {
+		t.Fatalf("seed original file: %v", err)
+	}
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_exec",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "请覆盖该文件",
+		},
+		"intent": map[string]any{
+			"name": "write_file",
+			"arguments": map[string]any{
+				"target_path": "notes/output.md",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	approvalID := startResult["task"].(map[string]any)["task_id"].(string)
+	respondResult, err := service.SecurityRespond(map[string]any{
+		"task_id":     taskID,
+		"approval_id": approvalID,
+		"decision":    "allow_once",
+	})
+	if err != nil {
+		t.Fatalf("security respond failed: %v", err)
+	}
+	if respondResult["task"].(map[string]any)["status"] != "completed" {
+		t.Fatalf("expected write_file task to complete after authorization, got %+v", respondResult)
+	}
+
+	pointsResult, err := service.SecurityRestorePointsList(map[string]any{"task_id": taskID, "limit": 20, "offset": 0})
+	if err != nil {
+		t.Fatalf("security restore points list failed: %v", err)
+	}
+	points := pointsResult["items"].([]map[string]any)
+	if len(points) == 0 {
+		t.Fatal("expected completed write_file task to persist recovery point")
+	}
+
+	applyResult, err := service.SecurityRestoreApply(map[string]any{
+		"task_id":           taskID,
+		"recovery_point_id": points[0]["recovery_point_id"],
+	})
+	if err != nil {
+		t.Fatalf("security restore apply failed: %v", err)
+	}
+	if applyResult["applied"] != true {
+		t.Fatalf("expected restore apply success, got %+v", applyResult)
+	}
+	auditRecord := applyResult["audit_record"].(map[string]any)
+	if auditRecord["action"] != "restore_apply" || auditRecord["result"] != "success" {
+		t.Fatalf("expected restore audit success, got %+v", auditRecord)
+	}
+	bubble := applyResult["bubble_message"].(map[string]any)
+	if !strings.Contains(stringValue(bubble, "text", ""), "恢复点") {
+		t.Fatalf("expected bubble message to mention recovery point, got %+v", bubble)
+	}
+	restoredContent, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatalf("read restored file: %v", err)
+	}
+	if string(restoredContent) != "旧的内容" {
+		t.Fatalf("expected restore apply to recover original content, got %q", string(restoredContent))
+	}
+	updatedTask, ok := service.runEngine.GetTask(taskID)
+	if !ok {
+		t.Fatal("expected task to remain available after restore")
+	}
+	if stringValue(updatedTask.SecuritySummary, "security_status", "") != "recovered" {
+		t.Fatalf("expected recovered security status, got %+v", updatedTask.SecuritySummary)
+	}
+}
+
+func TestServiceSecurityRestoreApplyReturnsStructuredFailure(t *testing.T) {
+	service, workspaceRoot := newTestServiceWithExecution(t, "新的内容")
+	originalPath := filepath.Join(workspaceRoot, "notes", "output.md")
+	if err := os.MkdirAll(filepath.Dir(originalPath), 0o755); err != nil {
+		t.Fatalf("mkdir notes: %v", err)
+	}
+	if err := os.WriteFile(originalPath, []byte("旧的内容"), 0o644); err != nil {
+		t.Fatalf("seed original file: %v", err)
+	}
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_exec",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "请覆盖该文件",
+		},
+		"intent": map[string]any{
+			"name": "write_file",
+			"arguments": map[string]any{
+				"target_path": "notes/output.md",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	approvalID := startResult["task"].(map[string]any)["task_id"].(string)
+	respondResult, err := service.SecurityRespond(map[string]any{
+		"task_id":     taskID,
+		"approval_id": approvalID,
+		"decision":    "allow_once",
+	})
+	if err != nil {
+		t.Fatalf("security respond failed: %v", err)
+	}
+	if respondResult["task"].(map[string]any)["status"] != "completed" {
+		t.Fatalf("expected write_file task to complete after authorization, got %+v", respondResult)
+	}
+	pointsResult, err := service.SecurityRestorePointsList(map[string]any{"task_id": taskID, "limit": 20, "offset": 0})
+	if err != nil {
+		t.Fatalf("security restore points list failed: %v", err)
+	}
+	points := pointsResult["items"].([]map[string]any)
+	if len(points) == 0 {
+		t.Fatal("expected completed write_file task to persist recovery point")
+	}
+	backupPath := filepath.Join(workspaceRoot, ".recovery_points", points[0]["recovery_point_id"].(string), "notes", "output.md")
+	if err := os.Remove(backupPath); err != nil {
+		t.Fatalf("remove backup snapshot: %v", err)
+	}
+
+	applyResult, err := service.SecurityRestoreApply(map[string]any{
+		"task_id":           taskID,
+		"recovery_point_id": points[0]["recovery_point_id"],
+	})
+	if err != nil {
+		t.Fatalf("security restore apply returned rpc error unexpectedly: %v", err)
+	}
+	if applyResult["applied"] != false {
+		t.Fatalf("expected restore apply failure result, got %+v", applyResult)
+	}
+	auditRecord := applyResult["audit_record"].(map[string]any)
+	if auditRecord["result"] != "failed" {
+		t.Fatalf("expected failed restore audit record, got %+v", auditRecord)
+	}
+	bubble := applyResult["bubble_message"].(map[string]any)
+	if !strings.Contains(stringValue(bubble, "text", ""), "恢复失败") {
+		t.Fatalf("expected failure bubble message, got %+v", bubble)
+	}
+	updatedTask, ok := service.runEngine.GetTask(taskID)
+	if !ok {
+		t.Fatal("expected task to remain available after failed restore")
+	}
+	if stringValue(updatedTask.SecuritySummary, "security_status", "") != "execution_error" {
+		t.Fatalf("expected execution_error security status, got %+v", updatedTask.SecuritySummary)
+	}
+}
+
+func TestServiceSecurityRestoreApplySupportsPersistedTaskFallback(t *testing.T) {
+	service, workspaceRoot := newTestServiceWithExecution(t, "新的内容")
+	originalPath := filepath.Join(workspaceRoot, "notes", "output.md")
+	if err := os.MkdirAll(filepath.Dir(originalPath), 0o755); err != nil {
+		t.Fatalf("mkdir notes: %v", err)
+	}
+	if err := os.WriteFile(originalPath, []byte("旧的内容"), 0o644); err != nil {
+		t.Fatalf("seed original file: %v", err)
+	}
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_exec",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "请覆盖该文件",
+		},
+		"intent": map[string]any{
+			"name": "write_file",
+			"arguments": map[string]any{
+				"target_path": "notes/output.md",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	approvalID := startResult["task"].(map[string]any)["task_id"].(string)
+	respondResult, err := service.SecurityRespond(map[string]any{"task_id": taskID, "approval_id": approvalID, "decision": "allow_once"})
+	if err != nil {
+		t.Fatalf("security respond failed: %v", err)
+	}
+	if respondResult["task"].(map[string]any)["status"] != "completed" {
+		t.Fatalf("expected task to complete before persisted fallback, got %+v", respondResult)
+	}
+	if _, err := service.TaskDetailGet(map[string]any{"task_id": taskID}); err != nil {
+		t.Fatalf("task detail get before persisted fallback failed: %v", err)
+	}
+	pointsResult, err := service.SecurityRestorePointsList(map[string]any{"task_id": taskID, "limit": 20, "offset": 0})
+	if err != nil {
+		t.Fatalf("security restore points list failed: %v", err)
+	}
+	points := pointsResult["items"].([]map[string]any)
+	if len(points) == 0 {
+		t.Fatal("expected recovery point to exist")
+	}
+	persistedEngine := runengine.NewEngine()
+	service.runEngine = persistedEngine
+
+	applyResult, err := service.SecurityRestoreApply(map[string]any{"task_id": taskID, "recovery_point_id": points[0]["recovery_point_id"]})
+	if err != nil {
+		t.Fatalf("security restore apply failed with persisted task fallback: %v", err)
+	}
+	if applyResult["applied"] != true {
+		t.Fatalf("expected restore apply success with persisted task fallback, got %+v", applyResult)
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -1549,6 +1549,47 @@ func TestServiceSecurityRespondAllowOnceExecCommandCompletesAfterApproval(t *tes
 	}
 }
 
+func TestServiceSecurityRespondAllowOnceCompletesDerivedWriteFileAfterApproval(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "新的文档内容")
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_derived_write",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "请总结成文档",
+		},
+		"intent": map[string]any{
+			"name": "summarize",
+			"arguments": map[string]any{
+				"style":                 "key_points",
+				"require_authorization": true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	if startResult["task"].(map[string]any)["status"] != "waiting_auth" {
+		t.Fatalf("expected derived write flow to wait for auth, got %+v", startResult)
+	}
+
+	respondResult, err := service.SecurityRespond(map[string]any{
+		"task_id":       taskID,
+		"approval_id":   "appr_derived_write",
+		"decision":      "allow_once",
+		"remember_rule": false,
+	})
+	if err != nil {
+		t.Fatalf("security respond failed: %v", err)
+	}
+	if respondResult["task"].(map[string]any)["status"] != "completed" {
+		t.Fatalf("expected completed task after approved derived write_file, got %+v", respondResult)
+	}
+}
+
 func TestServiceSecurityRespondAllowOnceReturnsStructuredRecoveryFailure(t *testing.T) {
 	service, workspaceRoot := newTestServiceWithExecutionOptions(t, "unused", platform.LocalExecutionBackend{}, failingCheckpointWriter{err: errors.New("checkpoint unavailable")})
 	if err := os.MkdirAll(filepath.Join(workspaceRoot, "notes"), 0o755); err != nil {
@@ -2276,14 +2317,33 @@ func TestServiceSecurityRestoreApplyRestoresWorkspaceAndReturnsFormalResult(t *t
 	if err != nil {
 		t.Fatalf("security restore apply failed: %v", err)
 	}
-	if applyResult["applied"] != true {
-		t.Fatalf("expected restore apply success, got %+v", applyResult)
+	if applyResult["task"].(map[string]any)["status"] != "waiting_auth" || applyResult["applied"] != false {
+		t.Fatalf("expected restore apply to require authorization first, got %+v", applyResult)
 	}
-	auditRecord := applyResult["audit_record"].(map[string]any)
+	contentBeforeApproval, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatalf("read file before restore approval: %v", err)
+	}
+	if !strings.Contains(string(contentBeforeApproval), "新的内容") {
+		t.Fatalf("expected restore request not to mutate workspace before approval, got %q", string(contentBeforeApproval))
+	}
+	respondApplyResult, err := service.SecurityRespond(map[string]any{
+		"task_id":       taskID,
+		"approval_id":   "appr_restore_apply",
+		"decision":      "allow_once",
+		"remember_rule": false,
+	})
+	if err != nil {
+		t.Fatalf("security respond for restore apply failed: %v", err)
+	}
+	if respondApplyResult["applied"] != true {
+		t.Fatalf("expected approved restore apply success, got %+v", respondApplyResult)
+	}
+	auditRecord := respondApplyResult["audit_record"].(map[string]any)
 	if auditRecord["action"] != "restore_apply" || auditRecord["result"] != "success" {
 		t.Fatalf("expected restore audit success, got %+v", auditRecord)
 	}
-	bubble := applyResult["bubble_message"].(map[string]any)
+	bubble := respondApplyResult["bubble_message"].(map[string]any)
 	if !strings.Contains(stringValue(bubble, "text", ""), "恢复点") {
 		t.Fatalf("expected bubble message to mention recovery point, got %+v", bubble)
 	}
@@ -2363,6 +2423,18 @@ func TestServiceSecurityRestoreApplyReturnsStructuredFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("security restore apply returned rpc error unexpectedly: %v", err)
 	}
+	if applyResult["task"].(map[string]any)["status"] != "waiting_auth" {
+		t.Fatalf("expected restore apply to wait for auth before execution, got %+v", applyResult)
+	}
+	applyResult, err = service.SecurityRespond(map[string]any{
+		"task_id":       taskID,
+		"approval_id":   "appr_restore_apply_failure",
+		"decision":      "allow_once",
+		"remember_rule": false,
+	})
+	if err != nil {
+		t.Fatalf("security respond for restore apply failure failed: %v", err)
+	}
 	if applyResult["applied"] != false {
 		t.Fatalf("expected restore apply failure result, got %+v", applyResult)
 	}
@@ -2435,6 +2507,13 @@ func TestServiceSecurityRestoreApplySupportsPersistedTaskFallback(t *testing.T) 
 	applyResult, err := service.SecurityRestoreApply(map[string]any{"task_id": taskID, "recovery_point_id": points[0]["recovery_point_id"]})
 	if err != nil {
 		t.Fatalf("security restore apply failed with persisted task fallback: %v", err)
+	}
+	if applyResult["task"].(map[string]any)["status"] != "waiting_auth" {
+		t.Fatalf("expected restore apply fallback to wait for auth, got %+v", applyResult)
+	}
+	applyResult, err = service.SecurityRespond(map[string]any{"task_id": taskID, "approval_id": "appr_restore_apply_persisted", "decision": "allow_once"})
+	if err != nil {
+		t.Fatalf("security respond failed with persisted fallback: %v", err)
 	}
 	if applyResult["applied"] != true {
 		t.Fatalf("expected restore apply success with persisted task fallback, got %+v", applyResult)

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -1536,6 +1536,62 @@ func TestServiceSecurityAuditListRequiresTaskID(t *testing.T) {
 	}
 }
 
+func TestServiceSecurityRestorePointsListFallsBackToStoredRecoveryPoints(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "executor-backed summary")
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+	err := service.storage.RecoveryPointWriter().WriteRecoveryPoint(context.Background(), checkpoint.RecoveryPoint{
+		RecoveryPointID: "rp_001",
+		TaskID:          "task_external",
+		Summary:         "stored recovery point",
+		CreatedAt:       "2026-04-08T10:00:00Z",
+		Objects:         []string{"workspace/result.md"},
+	})
+	if err != nil {
+		t.Fatalf("write recovery point failed: %v", err)
+	}
+
+	result, err := service.SecurityRestorePointsList(map[string]any{"task_id": "task_external", "limit": 20, "offset": 0})
+	if err != nil {
+		t.Fatalf("security restore points list failed: %v", err)
+	}
+
+	items := result["items"].([]map[string]any)
+	if len(items) != 1 || items[0]["recovery_point_id"] != "rp_001" {
+		t.Fatalf("expected storage-backed recovery point, got %+v", items)
+	}
+	if items[0]["task_id"] != "task_external" {
+		t.Fatalf("expected task_external recovery point, got %+v", items[0])
+	}
+	objects := items[0]["objects"].([]string)
+	if len(objects) != 1 || objects[0] != "workspace/result.md" {
+		t.Fatalf("expected recovery point objects to round-trip, got %+v", objects)
+	}
+	page := result["page"].(map[string]any)
+	if page["total"] != 1 {
+		t.Fatalf("expected total=1, got %+v", page)
+	}
+}
+
+func TestServiceSecurityRestorePointsListWithoutStorageReturnsEmptyPage(t *testing.T) {
+	service := newTestService()
+
+	result, err := service.SecurityRestorePointsList(map[string]any{"limit": 20, "offset": 0})
+	if err != nil {
+		t.Fatalf("security restore points list failed: %v", err)
+	}
+
+	items := result["items"].([]map[string]any)
+	if len(items) != 0 {
+		t.Fatalf("expected empty restore point list, got %+v", items)
+	}
+	page := result["page"].(map[string]any)
+	if page["total"] != 0 {
+		t.Fatalf("expected empty page metadata, got %+v", page)
+	}
+}
+
 func TestServiceTaskControlRejectsInvalidStatusTransition(t *testing.T) {
 	service := newTestService()
 

--- a/services/local-service/internal/platform/adapters.go
+++ b/services/local-service/internal/platform/adapters.go
@@ -30,6 +30,7 @@ type FileSystemAdapter interface {
 	Normalize(path string) string
 	EnsureWithinWorkspace(path string) (string, error)
 	WriteFile(path string, content []byte) error
+	Remove(path string) error
 	Move(src, dst string) error
 	MkdirAll(path string) error
 }
@@ -219,6 +220,15 @@ func (a *LocalFileSystemAdapter) WriteFile(path string, content []byte) error {
 	}
 
 	return os.WriteFile(safePath, content, 0o644)
+}
+
+// Remove 删除工作区内的目标文件。
+func (a *LocalFileSystemAdapter) Remove(path string) error {
+	safePath, err := a.policy.EnsureWithinWorkspace(path)
+	if err != nil {
+		return err
+	}
+	return os.Remove(safePath)
 }
 
 // Move 处理当前模块的相关逻辑。

--- a/services/local-service/internal/risk/service.go
+++ b/services/local-service/internal/risk/service.go
@@ -55,6 +55,7 @@ func (s *Service) Assess(input AssessmentInput) AssessmentResult {
 	if isApprovalCommand(input.CommandPreview) {
 		result.RiskLevel = RiskLevelRed
 		result.ApprovalRequired = true
+		result.CheckpointRequired = input.OperationName == "exec_command"
 		result.Reason = ReasonCommandApproval
 		return result
 	}
@@ -73,8 +74,17 @@ func (s *Service) Assess(input AssessmentInput) AssessmentResult {
 		return result
 	}
 
+	if input.OperationName == "exec_command" {
+		result.RiskLevel = RiskLevelYellow
+		result.ApprovalRequired = true
+		result.CheckpointRequired = len(input.ImpactScope.Files) > 0
+		result.Reason = ReasonCommandApproval
+		return result
+	}
+
 	if input.ImpactScope.OverwriteOrDeleteRisk {
 		result.RiskLevel = RiskLevelYellow
+		result.ApprovalRequired = true
 		result.CheckpointRequired = true
 		result.Reason = ReasonOverwriteOrDelete
 		return result

--- a/services/local-service/internal/risk/service_test.go
+++ b/services/local-service/internal/risk/service_test.go
@@ -68,9 +68,31 @@ func TestServiceAssess(t *testing.T) {
 				CommandPreview:      "powershell Get-Process",
 			},
 			want: AssessmentResult{
-				RiskLevel:        RiskLevelRed,
-				ApprovalRequired: true,
-				Reason:           ReasonCommandApproval,
+				RiskLevel:          RiskLevelRed,
+				ApprovalRequired:   true,
+				CheckpointRequired: true,
+				Reason:             ReasonCommandApproval,
+			},
+		},
+		{
+			name: "safe_command_still_requires_approval",
+			input: AssessmentInput{
+				OperationName:       "exec_command",
+				TargetObject:        "D:/workspace",
+				CapabilityAvailable: true,
+				WorkspaceKnown:      true,
+				ImpactScope: ImpactScope{
+					Files: []string{"D:/workspace"},
+				},
+			},
+			want: AssessmentResult{
+				RiskLevel:          RiskLevelYellow,
+				ApprovalRequired:   true,
+				CheckpointRequired: true,
+				Reason:             ReasonCommandApproval,
+				ImpactScope: ImpactScope{
+					Files: []string{"D:/workspace"},
+				},
 			},
 		},
 		{
@@ -123,6 +145,7 @@ func TestServiceAssess(t *testing.T) {
 			},
 			want: AssessmentResult{
 				RiskLevel:          RiskLevelYellow,
+				ApprovalRequired:   true,
 				CheckpointRequired: true,
 				Reason:             ReasonOverwriteOrDelete,
 				ImpactScope: ImpactScope{

--- a/services/local-service/internal/rpc/handlers.go
+++ b/services/local-service/internal/rpc/handlers.go
@@ -32,6 +32,7 @@ func (s *Server) registerHandlers() {
 		"agent.security.summary.get":           s.handleAgentSecuritySummaryGet,
 		"agent.security.audit.list":            s.handleAgentSecurityAuditList,
 		"agent.security.pending.list":          s.handleAgentSecurityPendingList,
+		"agent.security.restore_points.list":   s.handleAgentSecurityRestorePointsList,
 		"agent.security.respond":               s.handleAgentSecurityRespond,
 		"agent.settings.get":                   s.handleAgentSettingsGet,
 		"agent.settings.update":                s.handleAgentSettingsUpdate,
@@ -189,6 +190,14 @@ func (s *Server) handleAgentSecurityAuditList(params map[string]any) (any, *rpcE
 // handleAgentSecurityPendingList 处理 agent.security.pending.list。
 func (s *Server) handleAgentSecurityPendingList(params map[string]any) (any, *rpcError) {
 	data, err := s.orchestrator.SecurityPendingList(params)
+	return wrapOrchestratorResult(data, err)
+}
+
+// handleAgentSecurityRestorePointsList 处理当前模块的相关逻辑。
+
+// handleAgentSecurityRestorePointsList 处理 agent.security.restore_points.list。
+func (s *Server) handleAgentSecurityRestorePointsList(params map[string]any) (any, *rpcError) {
+	data, err := s.orchestrator.SecurityRestorePointsList(params)
 	return wrapOrchestratorResult(data, err)
 }
 

--- a/services/local-service/internal/rpc/handlers.go
+++ b/services/local-service/internal/rpc/handlers.go
@@ -33,6 +33,7 @@ func (s *Server) registerHandlers() {
 		"agent.security.audit.list":            s.handleAgentSecurityAuditList,
 		"agent.security.pending.list":          s.handleAgentSecurityPendingList,
 		"agent.security.restore_points.list":   s.handleAgentSecurityRestorePointsList,
+		"agent.security.restore.apply":         s.handleAgentSecurityRestoreApply,
 		"agent.security.respond":               s.handleAgentSecurityRespond,
 		"agent.settings.get":                   s.handleAgentSettingsGet,
 		"agent.settings.update":                s.handleAgentSettingsUpdate,
@@ -201,6 +202,14 @@ func (s *Server) handleAgentSecurityRestorePointsList(params map[string]any) (an
 	return wrapOrchestratorResult(data, err)
 }
 
+// handleAgentSecurityRestoreApply 处理当前模块的相关逻辑。
+
+// handleAgentSecurityRestoreApply 处理 agent.security.restore.apply。
+func (s *Server) handleAgentSecurityRestoreApply(params map[string]any) (any, *rpcError) {
+	data, err := s.orchestrator.SecurityRestoreApply(params)
+	return wrapOrchestratorResult(data, err)
+}
+
 // handleAgentSecurityRespond 处理当前模块的相关逻辑。
 
 // handleAgentSecurityRespond 处理 agent.security.respond。
@@ -264,6 +273,14 @@ func wrapOrchestratorResult(data any, err error) (any, *rpcError) {
 			Message: "SQLITE_WRITE_FAILED",
 			Detail:  err.Error(),
 			TraceID: "trace_storage_query_failed",
+		}
+	}
+	if errors.Is(err, orchestrator.ErrRecoveryPointNotFound) {
+		return nil, &rpcError{
+			Code:    1005002,
+			Message: "ARTIFACT_NOT_FOUND",
+			Detail:  err.Error(),
+			TraceID: "trace_recovery_point_not_found",
 		}
 	}
 

--- a/services/local-service/internal/rpc/server_test.go
+++ b/services/local-service/internal/rpc/server_test.go
@@ -298,6 +298,59 @@ func TestDispatchReturnsSecurityRestorePointsList(t *testing.T) {
 	}
 }
 
+func TestDispatchReturnsSecurityRestoreApplyResult(t *testing.T) {
+	server := newTestServer()
+	storageService := storage.NewService(platform.NewLocalStorageAdapter(filepath.Join(t.TempDir(), "restore-apply.db")))
+	defer func() { _ = storageService.Close() }()
+	server.orchestrator.WithStorage(storageService)
+	startResult, err := server.orchestrator.StartTask(map[string]any{
+		"session_id": "sess_restore",
+		"source":     "floating_ball",
+		"trigger":    "text_selected_click",
+		"input": map[string]any{
+			"type": "text_selection",
+			"text": "restore runtime task",
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task: %v", err)
+	}
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+
+	err = storageService.RecoveryPointWriter().WriteRecoveryPoint(context.Background(), checkpoint.RecoveryPoint{
+		RecoveryPointID: "rp_001",
+		TaskID:          taskID,
+		Summary:         "stored recovery point",
+		CreatedAt:       "2026-04-08T10:00:00Z",
+		Objects:         []string{"workspace/result.md"},
+	})
+	if err != nil {
+		t.Fatalf("write recovery point: %v", err)
+	}
+
+	response := server.dispatch(requestEnvelope{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`"req-security-restore-apply"`),
+		Method:  "agent.security.restore.apply",
+		Params: mustMarshal(t, map[string]any{
+			"task_id":           taskID,
+			"recovery_point_id": "rp_001",
+		}),
+	})
+
+	success, ok := response.(successEnvelope)
+	if !ok {
+		t.Fatalf("expected success response envelope, got %#v", response)
+	}
+	data := success.Result.Data.(map[string]any)
+	if _, ok := data["applied"].(bool); !ok {
+		t.Fatalf("expected applied flag in restore result, got %+v", data)
+	}
+	if data["recovery_point"].(map[string]any)["recovery_point_id"] != "rp_001" {
+		t.Fatalf("expected rp_001 restore result, got %+v", data)
+	}
+}
+
 func TestDispatchMapsSecurityAuditListStorageErrors(t *testing.T) {
 	_, rpcErr := wrapOrchestratorResult(nil, orchestrator.ErrStorageQueryFailed)
 	if rpcErr == nil {
@@ -305,6 +358,16 @@ func TestDispatchMapsSecurityAuditListStorageErrors(t *testing.T) {
 	}
 	if rpcErr.Code != 1005001 || rpcErr.Message != "SQLITE_WRITE_FAILED" {
 		t.Fatalf("expected SQLITE_WRITE_FAILED mapping, got code=%d message=%s", rpcErr.Code, rpcErr.Message)
+	}
+}
+
+func TestDispatchMapsRecoveryPointNotFoundErrors(t *testing.T) {
+	_, rpcErr := wrapOrchestratorResult(nil, orchestrator.ErrRecoveryPointNotFound)
+	if rpcErr == nil {
+		t.Fatal("expected rpc error")
+	}
+	if rpcErr.Code != 1005002 {
+		t.Fatalf("expected 1005002 mapping, got code=%d message=%s", rpcErr.Code, rpcErr.Message)
 	}
 }
 

--- a/services/local-service/internal/rpc/server_test.go
+++ b/services/local-service/internal/rpc/server_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/audit"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/checkpoint"
 	serviceconfig "github.com/cialloclaw/cialloclaw/services/local-service/internal/config"
 	contextsvc "github.com/cialloclaw/cialloclaw/services/local-service/internal/context"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/delivery"
@@ -254,6 +255,46 @@ func TestDispatchReturnsSecurityAuditList(t *testing.T) {
 	}
 	if items[0]["audit_id"] != "audit_001" {
 		t.Fatalf("expected stored audit_001, got %+v", items[0])
+	}
+}
+
+func TestDispatchReturnsSecurityRestorePointsList(t *testing.T) {
+	server := newTestServer()
+	storageService := storage.NewService(platform.NewLocalStorageAdapter(filepath.Join(t.TempDir(), "restore.db")))
+	defer func() { _ = storageService.Close() }()
+	server.orchestrator.WithStorage(storageService)
+	err := storageService.RecoveryPointWriter().WriteRecoveryPoint(context.Background(), checkpoint.RecoveryPoint{
+		RecoveryPointID: "rp_001",
+		TaskID:          "task_001",
+		Summary:         "stored recovery point",
+		CreatedAt:       "2026-04-08T10:00:00Z",
+		Objects:         []string{"workspace/result.md"},
+	})
+	if err != nil {
+		t.Fatalf("write recovery point: %v", err)
+	}
+
+	response := server.dispatch(requestEnvelope{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`"req-security-restore-points-list"`),
+		Method:  "agent.security.restore_points.list",
+		Params: mustMarshal(t, map[string]any{
+			"task_id": "task_001",
+			"limit":   20,
+			"offset":  0,
+		}),
+	})
+
+	success, ok := response.(successEnvelope)
+	if !ok {
+		t.Fatalf("expected success response envelope, got %#v", response)
+	}
+	items := success.Result.Data.(map[string]any)["items"].([]map[string]any)
+	if len(items) != 1 {
+		t.Fatalf("expected one recovery point item, got %d", len(items))
+	}
+	if items[0]["recovery_point_id"] != "rp_001" {
+		t.Fatalf("expected stored rp_001, got %+v", items[0])
 	}
 }
 

--- a/services/local-service/internal/rpc/server_test.go
+++ b/services/local-service/internal/rpc/server_test.go
@@ -346,6 +346,9 @@ func TestDispatchReturnsSecurityRestoreApplyResult(t *testing.T) {
 	if _, ok := data["applied"].(bool); !ok {
 		t.Fatalf("expected applied flag in restore result, got %+v", data)
 	}
+	if data["task"].(map[string]any)["status"] != "waiting_auth" {
+		t.Fatalf("expected restore apply rpc to enter waiting_auth, got %+v", data)
+	}
 	if data["recovery_point"].(map[string]any)["recovery_point_id"] != "rp_001" {
 		t.Fatalf("expected rp_001 restore result, got %+v", data)
 	}

--- a/services/local-service/internal/runengine/engine.go
+++ b/services/local-service/internal/runengine/engine.go
@@ -432,6 +432,11 @@ func (e *Engine) SetPresentation(taskID string, bubbleMessage map[string]any, de
 
 // RecordToolCall 记录主链路最近一次完成的 tool_call 兼容层快照。
 func (e *Engine) RecordToolCall(taskID, toolName string, input, output map[string]any, durationMS int64) (TaskRecord, bool) {
+	return e.RecordToolCallLifecycle(taskID, toolName, "succeeded", input, output, durationMS, nil)
+}
+
+// RecordToolCallLifecycle 根据工具执行状态记录最近一次 tool_call 快照。
+func (e *Engine) RecordToolCallLifecycle(taskID, toolName, status string, input, output map[string]any, durationMS int64, errorCode any) (TaskRecord, bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -441,11 +446,92 @@ func (e *Engine) RecordToolCall(taskID, toolName string, input, output map[strin
 	}
 
 	record.UpdatedAt = e.now()
-	record.LatestToolCall = e.buildToolCallRecord(record, toolName, input, output, durationMS, nil)
+	record.LatestToolCall = e.buildToolCallRecord(record, toolName, status, input, output, durationMS, errorCode)
 	record.LatestEvent = e.buildEventWithPayload(record, "tool_call.completed", map[string]any{
-		"status":    record.Status,
-		"tool_name": toolName,
+		"status":      record.Status,
+		"tool_name":   toolName,
+		"tool_status": firstNonEmpty(status, "succeeded"),
 	})
+	record.queueNotification("task.updated", map[string]any{
+		"task_id": record.TaskID,
+		"status":  record.Status,
+	})
+	e.persistTaskLocked(record)
+
+	return record.clone(), true
+}
+
+// FailTaskExecution 将任务收敛到 failed，用于执行失败或恢复点准备失败场景。
+func (e *Engine) FailTaskExecution(taskID, stepName, securityStatus, outputSummary string, impactScope map[string]any, bubbleMessage map[string]any, latestRestorePoint ...map[string]any) (TaskRecord, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	record, ok := e.tasks[taskID]
+	if !ok {
+		return TaskRecord{}, false
+	}
+
+	now := e.now()
+	record.Status = "failed"
+	record.CurrentStep = firstNonEmpty(stepName, "execution_failed")
+	record.UpdatedAt = now
+	record.FinishedAt = &now
+	record.PendingExecution = nil
+	record.BubbleMessage = cloneMap(bubbleMessage)
+	record.ImpactScope = cloneMap(impactScope)
+	restorePoint := latestRestorePointFromSummary(record.SecuritySummary)
+	if len(latestRestorePoint) > 0 && len(latestRestorePoint[0]) > 0 {
+		restorePoint = cloneMap(latestRestorePoint[0])
+	}
+	record.SecuritySummary = map[string]any{
+		"security_status":        firstNonEmpty(securityStatus, "execution_error"),
+		"risk_level":             record.RiskLevel,
+		"pending_authorizations": 0,
+		"latest_restore_point":   restorePoint,
+	}
+	record.Timeline = advanceTimeline(record.Timeline, record.CurrentStep, "failed", firstNonEmpty(outputSummary, "执行失败"))
+	record.CurrentStepStatus = currentTimelineStatus(record.Timeline)
+	record.LatestEvent = e.buildEvent(record, "task.updated")
+	record.queueNotification("task.updated", map[string]any{
+		"task_id": record.TaskID,
+		"status":  record.Status,
+	})
+	e.persistTaskLocked(record)
+
+	return record.clone(), true
+}
+
+// BlockTaskByPolicy 将被治理策略拦截的任务收敛到 cancelled。
+func (e *Engine) BlockTaskByPolicy(taskID, riskLevel, outputSummary string, impactScope map[string]any, bubbleMessage map[string]any) (TaskRecord, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	record, ok := e.tasks[taskID]
+	if !ok {
+		return TaskRecord{}, false
+	}
+
+	now := e.now()
+	record.Status = "cancelled"
+	record.CurrentStep = "risk_blocked"
+	record.UpdatedAt = now
+	record.FinishedAt = &now
+	record.PendingExecution = nil
+	record.ApprovalRequest = nil
+	record.BubbleMessage = cloneMap(bubbleMessage)
+	record.ImpactScope = cloneMap(impactScope)
+	if riskLevel != "" {
+		record.RiskLevel = riskLevel
+	}
+	record.SecuritySummary = map[string]any{
+		"security_status":        "intercepted",
+		"risk_level":             record.RiskLevel,
+		"pending_authorizations": 0,
+		"latest_restore_point":   latestRestorePointFromSummary(record.SecuritySummary),
+	}
+	record.Timeline = advanceTimeline(record.Timeline, "risk_blocked", "cancelled", firstNonEmpty(outputSummary, "高风险操作已被策略拦截"))
+	record.CurrentStepStatus = currentTimelineStatus(record.Timeline)
+	record.LatestEvent = e.buildEvent(record, "task.updated")
 	record.queueNotification("task.updated", map[string]any{
 		"task_id": record.TaskID,
 		"status":  record.Status,
@@ -458,7 +544,7 @@ func (e *Engine) RecordToolCall(taskID, toolName string, input, output map[strin
 // CompleteTask 完成Task。
 
 // CompleteTask 把任务收敛到 completed，并写入正式交付结果、artifact 和恢复点摘要。
-func (e *Engine) CompleteTask(taskID string, deliveryResult map[string]any, bubbleMessage map[string]any, artifacts []map[string]any) (TaskRecord, bool) {
+func (e *Engine) CompleteTask(taskID string, deliveryResult map[string]any, bubbleMessage map[string]any, artifacts []map[string]any, latestRestorePoint ...map[string]any) (TaskRecord, bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -477,7 +563,11 @@ func (e *Engine) CompleteTask(taskID string, deliveryResult map[string]any, bubb
 	record.Artifacts = cloneMapSlice(artifacts)
 	record.Timeline = advanceTimeline(record.Timeline, "return_result", "completed", "结果已正式交付")
 	record.CurrentStepStatus = currentTimelineStatus(record.Timeline)
-	record.SecuritySummary = buildSecuritySummary(record.RiskLevel, buildRecoveryPoint(record.TaskID, now))
+	restorePoint := buildRecoveryPoint(record.TaskID, now)
+	if len(latestRestorePoint) > 0 && len(latestRestorePoint[0]) > 0 {
+		restorePoint = cloneMap(latestRestorePoint[0])
+	}
+	record.SecuritySummary = buildSecuritySummary(record.RiskLevel, restorePoint)
 	record.LatestEvent = e.buildEvent(record, "delivery.ready")
 	record.queueNotification("task.updated", map[string]any{
 		"task_id": record.TaskID,
@@ -1075,10 +1165,10 @@ func (e *Engine) buildEventWithPayload(record *TaskRecord, eventType string, pay
 
 // buildToolCall 为当前任务生成一条兼容层 ToolCall 记录。
 func (e *Engine) buildToolCall(record *TaskRecord, toolName string) map[string]any {
-	return e.buildToolCallRecord(record, toolName, map[string]any{}, map[string]any{}, 120, nil)
+	return e.buildToolCallRecord(record, toolName, "succeeded", map[string]any{}, map[string]any{}, 120, nil)
 }
 
-func (e *Engine) buildToolCallRecord(record *TaskRecord, toolName string, input, output map[string]any, durationMS int64, errorCode any) map[string]any {
+func (e *Engine) buildToolCallRecord(record *TaskRecord, toolName, status string, input, output map[string]any, durationMS int64, errorCode any) map[string]any {
 	if durationMS <= 0 {
 		durationMS = 1
 	}
@@ -1089,7 +1179,7 @@ func (e *Engine) buildToolCallRecord(record *TaskRecord, toolName string, input,
 		"task_id":      record.TaskID,
 		"step_id":      timelineCurrentStepID(record.Timeline),
 		"tool_name":    toolName,
-		"status":       "succeeded",
+		"status":       firstNonEmpty(status, "succeeded"),
 		"input":        cloneMap(input),
 		"output":       cloneMap(output),
 		"error_code":   errorCode,

--- a/services/local-service/internal/runengine/engine.go
+++ b/services/local-service/internal/runengine/engine.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -611,8 +612,8 @@ func (e *Engine) CompleteTask(taskID string, deliveryResult map[string]any, bubb
 	return record.clone(), true
 }
 
-// ApplyRecoveryOutcome 在恢复点应用后刷新任务的安全摘要与通知回写。
-func (e *Engine) ApplyRecoveryOutcome(taskID, securityStatus string, recoveryPoint map[string]any, bubbleMessage map[string]any) (TaskRecord, bool) {
+// ApplyRecoveryOutcome 在恢复点应用后刷新任务的状态、安全摘要与通知回写。
+func (e *Engine) ApplyRecoveryOutcome(taskID, taskStatus, securityStatus string, recoveryPoint map[string]any, bubbleMessage map[string]any) (TaskRecord, bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -622,7 +623,18 @@ func (e *Engine) ApplyRecoveryOutcome(taskID, securityStatus string, recoveryPoi
 	}
 
 	record.UpdatedAt = e.now()
+	if strings.TrimSpace(taskStatus) != "" {
+		record.Status = taskStatus
+		if taskStatus == "completed" || taskStatus == "failed" || taskStatus == "cancelled" {
+			now := e.now()
+			record.FinishedAt = &now
+		} else {
+			record.FinishedAt = nil
+		}
+	}
 	record.BubbleMessage = cloneMap(bubbleMessage)
+	record.PendingExecution = nil
+	record.ApprovalRequest = nil
 	record.SecuritySummary = map[string]any{
 		"security_status":        firstNonEmpty(securityStatus, "recovered"),
 		"risk_level":             record.RiskLevel,
@@ -755,11 +767,12 @@ func (e *Engine) MarkWaitingApprovalWithPlan(taskID string, approvalRequest map[
 		record.RiskLevel = riskLevel
 	}
 	record.BubbleMessage = cloneMap(bubbleMessage)
+	latestRestorePoint := latestRestorePointFromSummary(record.SecuritySummary)
 	record.SecuritySummary = map[string]any{
 		"security_status":        "pending_confirmation",
 		"risk_level":             record.RiskLevel,
 		"pending_authorizations": 1,
-		"latest_restore_point":   nil,
+		"latest_restore_point":   latestRestorePoint,
 	}
 	record.Timeline = advanceTimeline(record.Timeline, "waiting_authorization", "running", "等待用户授权")
 	record.CurrentStepStatus = currentTimelineStatus(record.Timeline)

--- a/services/local-service/internal/runengine/engine.go
+++ b/services/local-service/internal/runengine/engine.go
@@ -276,6 +276,35 @@ func (e *Engine) GetTask(taskID string) (TaskRecord, bool) {
 	return record.clone(), true
 }
 
+// HydrateTaskFromStorage 将持久化快照重新装载回运行时内存，用于恢复重启后的治理动作。
+func (e *Engine) HydrateTaskFromStorage(record TaskRecord) TaskRecord {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	cloned := record.clone()
+	if existing, ok := e.tasks[cloned.TaskID]; ok {
+		*existing = cloned
+		e.persistTaskLocked(existing)
+		return existing.clone()
+	}
+	stored := cloned
+	e.tasks[stored.TaskID] = &stored
+	e.taskOrder = append([]string{stored.TaskID}, e.taskOrder...)
+	if stored.SessionID != "" {
+		seen := false
+		for _, sessionID := range e.sessionOrder {
+			if sessionID == stored.SessionID {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			e.sessionOrder = append(e.sessionOrder, stored.SessionID)
+		}
+	}
+	e.persistTaskLocked(&stored)
+	return stored.clone()
+}
+
 // ListTasks 列出Tasks。
 
 // ListTasks 按未完成/已完成分组列出任务，并在分页前应用统一排序规则。
@@ -456,7 +485,7 @@ func (e *Engine) RecordToolCall(taskID, toolName string, input, output map[strin
 // CompleteTask 完成Task。
 
 // CompleteTask 把任务收敛到 completed，并写入正式交付结果、artifact 和恢复点摘要。
-func (e *Engine) CompleteTask(taskID string, deliveryResult map[string]any, bubbleMessage map[string]any, artifacts []map[string]any) (TaskRecord, bool) {
+func (e *Engine) CompleteTask(taskID string, deliveryResult map[string]any, bubbleMessage map[string]any, artifacts []map[string]any, latestRestorePoint ...map[string]any) (TaskRecord, bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -475,7 +504,11 @@ func (e *Engine) CompleteTask(taskID string, deliveryResult map[string]any, bubb
 	record.Artifacts = cloneMapSlice(artifacts)
 	record.Timeline = advanceTimeline(record.Timeline, "return_result", "completed", "结果已正式交付")
 	record.CurrentStepStatus = currentTimelineStatus(record.Timeline)
-	record.SecuritySummary = buildSecuritySummary(record.RiskLevel, buildRecoveryPoint(record.TaskID, now))
+	restorePoint := buildRecoveryPoint(record.TaskID, now)
+	if len(latestRestorePoint) > 0 && len(latestRestorePoint[0]) > 0 {
+		restorePoint = cloneMap(latestRestorePoint[0])
+	}
+	record.SecuritySummary = buildSecuritySummary(record.RiskLevel, restorePoint)
 	record.LatestEvent = e.buildEvent(record, "delivery.ready")
 	record.queueNotification("task.updated", map[string]any{
 		"task_id": record.TaskID,
@@ -484,6 +517,42 @@ func (e *Engine) CompleteTask(taskID string, deliveryResult map[string]any, bubb
 	record.queueNotification("delivery.ready", map[string]any{
 		"task_id":         record.TaskID,
 		"delivery_result": cloneMap(record.DeliveryResult),
+	})
+	e.persistTaskLocked(record)
+
+	return record.clone(), true
+}
+
+// ApplyRecoveryOutcome 在恢复点应用后刷新任务的安全摘要与通知回写。
+func (e *Engine) ApplyRecoveryOutcome(taskID, securityStatus string, recoveryPoint map[string]any, bubbleMessage map[string]any) (TaskRecord, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	record, ok := e.tasks[taskID]
+	if !ok {
+		return TaskRecord{}, false
+	}
+
+	record.UpdatedAt = e.now()
+	record.BubbleMessage = cloneMap(bubbleMessage)
+	record.SecuritySummary = map[string]any{
+		"security_status":        firstNonEmpty(securityStatus, "recovered"),
+		"risk_level":             record.RiskLevel,
+		"pending_authorizations": 0,
+		"latest_restore_point":   cloneMap(recoveryPoint),
+	}
+	eventType := "recovery.failed"
+	if securityStatus == "recovered" {
+		eventType = "recovery.applied"
+	}
+	record.LatestEvent = e.buildEventWithPayload(record, eventType, map[string]any{
+		"status":            record.Status,
+		"security_status":   firstNonEmpty(securityStatus, "recovered"),
+		"recovery_point_id": stringValue(cloneMap(recoveryPoint), "recovery_point_id", ""),
+	})
+	record.queueNotification("task.updated", map[string]any{
+		"task_id": record.TaskID,
+		"status":  record.Status,
 	})
 	e.persistTaskLocked(record)
 

--- a/services/local-service/internal/runengine/engine_test.go
+++ b/services/local-service/internal/runengine/engine_test.go
@@ -326,6 +326,116 @@ func TestEngineAuthorizationAndHandoffState(t *testing.T) {
 	}
 }
 
+func TestEngineResolveAuthorizationClearsPendingPlanAndKeepsRestorePoint(t *testing.T) {
+	engine := NewEngine()
+	now := time.Date(2026, 4, 11, 9, 0, 0, 0, time.UTC)
+	engine.now = func() time.Time { return now }
+
+	task := engine.CreateTask(CreateTaskInput{
+		SessionID:   "sess_resolve",
+		Title:       "待授权任务",
+		SourceType:  "hover_input",
+		Status:      "processing",
+		Intent:      map[string]any{"name": "write_file"},
+		CurrentStep: "generate_output",
+		RiskLevel:   "yellow",
+	})
+	approvalRequest := map[string]any{"approval_id": "appr_resolve", "task_id": task.TaskID, "status": "pending"}
+	pendingExecution := map[string]any{"operation_name": "write_file", "target_object": "workspace/notes/a.md"}
+	bubble := map[string]any{"task_id": task.TaskID, "type": "status", "text": "等待授权"}
+	if _, ok := engine.MarkWaitingApprovalWithPlan(task.TaskID, approvalRequest, pendingExecution, bubble); !ok {
+		t.Fatal("expected waiting approval transition to succeed")
+	}
+
+	record, ok := engine.GetTask(task.TaskID)
+	if !ok {
+		t.Fatal("expected task record")
+	}
+	record.SecuritySummary = map[string]any{
+		"security_status":        "pending_authorization",
+		"risk_level":             "yellow",
+		"pending_authorizations": 1,
+		"latest_restore_point": map[string]any{
+			"recovery_point_id": "rp_keep",
+		},
+	}
+	engine.tasks[task.TaskID] = &record
+
+	resolved, ok := engine.ResolveAuthorization(task.TaskID, map[string]any{"decision": "allow_once"}, map[string]any{"files": []string{"workspace/notes/a.md"}})
+	if !ok {
+		t.Fatal("expected resolve authorization to succeed")
+	}
+	if resolved.PendingExecution != nil || resolved.ApprovalRequest != nil {
+		t.Fatalf("expected pending authorization data cleared, got %+v", resolved)
+	}
+	if resolved.Authorization["decision"] != "allow_once" {
+		t.Fatalf("expected authorization stored, got %+v", resolved.Authorization)
+	}
+	latestRestore, _ := resolved.SecuritySummary["latest_restore_point"].(map[string]any)
+	if latestRestore["recovery_point_id"] != "rp_keep" {
+		t.Fatalf("expected latest restore point to be preserved, got %+v", resolved.SecuritySummary)
+	}
+
+	plan, ok := engine.PendingExecutionPlan(task.TaskID)
+	if ok || plan != nil {
+		t.Fatalf("expected no pending execution plan after resolve, got %+v", plan)
+	}
+}
+
+func TestEngineApplyRecoveryOutcomeSetsTerminalAndNonTerminalStatus(t *testing.T) {
+	engine := NewEngine()
+	now := time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC)
+	engine.now = func() time.Time { return now }
+
+	task := engine.CreateTask(CreateTaskInput{
+		SessionID:   "sess_restore",
+		Title:       "恢复任务",
+		SourceType:  "hover_input",
+		Status:      "waiting_auth",
+		Intent:      map[string]any{"name": "restore_apply"},
+		CurrentStep: "restore_apply",
+		RiskLevel:   "red",
+	})
+	if _, ok := engine.MarkWaitingApprovalWithPlan(task.TaskID, map[string]any{"approval_id": "appr_restore"}, map[string]any{"operation_name": "restore_apply"}, map[string]any{"text": "等待授权"}); !ok {
+		t.Fatal("expected waiting approval state")
+	}
+
+	recoveryPoint := map[string]any{"recovery_point_id": "rp_done"}
+	completed, ok := engine.ApplyRecoveryOutcome(task.TaskID, "completed", "recovered", recoveryPoint, map[string]any{"text": "恢复完成"})
+	if !ok {
+		t.Fatal("expected apply recovery outcome to succeed")
+	}
+	if completed.Status != "completed" || completed.FinishedAt == nil {
+		t.Fatalf("expected completed terminal state with finished_at, got %+v", completed)
+	}
+	if completed.PendingExecution != nil || completed.ApprovalRequest != nil {
+		t.Fatalf("expected approval artifacts cleared, got %+v", completed)
+	}
+	if completed.LatestEvent["type"] != "recovery.applied" {
+		t.Fatalf("expected recovery.applied event, got %+v", completed.LatestEvent)
+	}
+
+	processingTask := engine.CreateTask(CreateTaskInput{
+		SessionID:   "sess_restore_retry",
+		Title:       "恢复重试",
+		SourceType:  "hover_input",
+		Status:      "waiting_auth",
+		Intent:      map[string]any{"name": "restore_apply"},
+		CurrentStep: "restore_apply",
+		RiskLevel:   "red",
+	})
+	processing, ok := engine.ApplyRecoveryOutcome(processingTask.TaskID, "processing", "recovery_failed", recoveryPoint, map[string]any{"text": "恢复失败"})
+	if !ok {
+		t.Fatal("expected non-terminal recovery outcome to succeed")
+	}
+	if processing.Status != "processing" || processing.FinishedAt != nil {
+		t.Fatalf("expected non-terminal state without finished_at, got %+v", processing)
+	}
+	if processing.LatestEvent["type"] != "recovery.failed" {
+		t.Fatalf("expected recovery.failed event, got %+v", processing.LatestEvent)
+	}
+}
+
 // TestEngineDefaultsUseWorkspaceRelativePaths 验证默认配置不会写入平台盘符路径。
 func TestEngineDefaultsUseWorkspaceRelativePaths(t *testing.T) {
 	engine := NewEngine()

--- a/services/local-service/internal/storage/governance_store.go
+++ b/services/local-service/internal/storage/governance_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -51,6 +52,8 @@ type inMemoryRecoveryPointStore struct {
 	points []checkpoint.RecoveryPoint
 }
 
+var ErrRecoveryPointNotFound = errors.New("recovery point not found")
+
 func newInMemoryRecoveryPointStore() *inMemoryRecoveryPointStore {
 	return &inMemoryRecoveryPointStore{points: make([]checkpoint.RecoveryPoint, 0)}
 }
@@ -75,6 +78,17 @@ func (s *inMemoryRecoveryPointStore) ListRecoveryPoints(_ context.Context, taskI
 		return parseGovernanceTime(items[i].CreatedAt).After(parseGovernanceTime(items[j].CreatedAt))
 	})
 	return pageRecoveryPoints(items, limit, offset), len(items), nil
+}
+
+func (s *inMemoryRecoveryPointStore) GetRecoveryPoint(_ context.Context, recoveryPointID string) (checkpoint.RecoveryPoint, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, point := range s.points {
+		if point.RecoveryPointID == recoveryPointID {
+			return point, nil
+		}
+	}
+	return checkpoint.RecoveryPoint{}, ErrRecoveryPointNotFound
 }
 
 type SQLiteAuditStore struct {
@@ -261,6 +275,22 @@ func (s *SQLiteRecoveryPointStore) ListRecoveryPoints(ctx context.Context, taskI
 		return nil, 0, fmt.Errorf("iterate recovery points: %w", err)
 	}
 	return items, total, nil
+}
+
+func (s *SQLiteRecoveryPointStore) GetRecoveryPoint(ctx context.Context, recoveryPointID string) (checkpoint.RecoveryPoint, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT recovery_point_id, task_id, summary, created_at, objects_json FROM recovery_points WHERE recovery_point_id = ?`, recoveryPointID)
+	var point checkpoint.RecoveryPoint
+	var objectsJSON string
+	if err := row.Scan(&point.RecoveryPointID, &point.TaskID, &point.Summary, &point.CreatedAt, &objectsJSON); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return checkpoint.RecoveryPoint{}, ErrRecoveryPointNotFound
+		}
+		return checkpoint.RecoveryPoint{}, fmt.Errorf("get recovery point: %w", err)
+	}
+	if err := json.Unmarshal([]byte(objectsJSON), &point.Objects); err != nil {
+		return checkpoint.RecoveryPoint{}, fmt.Errorf("unmarshal recovery point objects: %w", err)
+	}
+	return point, nil
 }
 
 func (s *SQLiteRecoveryPointStore) Close() error {

--- a/services/local-service/internal/storage/types.go
+++ b/services/local-service/internal/storage/types.go
@@ -135,4 +135,5 @@ type AuditStore interface {
 type RecoveryPointStore interface {
 	WriteRecoveryPoint(ctx context.Context, point checkpoint.RecoveryPoint) error
 	ListRecoveryPoints(ctx context.Context, taskID string, limit, offset int) ([]checkpoint.RecoveryPoint, int, error)
+	GetRecoveryPoint(ctx context.Context, recoveryPointID string) (checkpoint.RecoveryPoint, error)
 }

--- a/services/local-service/internal/tools/builtin/exec_command.go
+++ b/services/local-service/internal/tools/builtin/exec_command.go
@@ -73,6 +73,13 @@ func (t *ExecCommandTool) Execute(ctx context.Context, execCtx *tools.ToolExecut
 		"stdout_truncated": stdoutTruncated,
 		"stderr_truncated": stderrTruncated,
 		"exit_code":        result.ExitCode,
+		"audit_candidate": map[string]any{
+			"type":    "command",
+			"action":  "exec_command",
+			"summary": buildExecCommandAuditSummary(command, result.ExitCode),
+			"target":  workingDir,
+			"result":  commandAuditResult(result.ExitCode),
+		},
 	}
 
 	return &tools.ToolResult{
@@ -140,6 +147,20 @@ func buildExecCommandSummary(command string, args []string, workingDir string, r
 		"stdout_preview": previewText(result.Stdout, commandOutputPreviewLimit),
 		"stderr_preview": previewText(result.Stderr, commandOutputPreviewLimit),
 	}
+}
+
+func buildExecCommandAuditSummary(command string, exitCode int) string {
+	if exitCode == 0 {
+		return fmt.Sprintf("execute command: %s", command)
+	}
+	return fmt.Sprintf("command exited with code %d: %s", exitCode, command)
+}
+
+func commandAuditResult(exitCode int) string {
+	if exitCode == 0 {
+		return "success"
+	}
+	return "failed"
 }
 
 func resolveExecCommandWorkingDir(execCtx *tools.ToolExecuteContext, workingDir string) (string, error) {

--- a/services/local-service/internal/tools/executor.go
+++ b/services/local-service/internal/tools/executor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 )
@@ -335,11 +336,28 @@ func approvalBypassAllowed(execCtx *ToolExecuteContext, toolName string, prechec
 	if target == "" {
 		return false
 	}
-	return normalizeApprovalTarget(execCtx.ApprovedTargetObject) == normalizeApprovalTarget(target)
+	workspaceRoot := strings.TrimSpace(precheckInput.Workspace.WorkspacePath)
+	return normalizeApprovalTarget(execCtx.ApprovedTargetObject, workspaceRoot) == normalizeApprovalTarget(target, workspaceRoot)
 }
 
-func normalizeApprovalTarget(target string) string {
-	return strings.Trim(strings.ReplaceAll(strings.TrimSpace(target), "\\", "/"), "/")
+func normalizeApprovalTarget(target, workspaceRoot string) string {
+	normalized := strings.ReplaceAll(strings.TrimSpace(target), "\\", "/")
+	workspaceRoot = strings.Trim(strings.ReplaceAll(strings.TrimSpace(workspaceRoot), "\\", "/"), "/")
+	normalized = strings.Trim(normalized, "/")
+	if workspaceRoot != "" {
+		if normalized == workspaceRoot {
+			return "."
+		}
+		if strings.HasPrefix(normalized, workspaceRoot+"/") {
+			normalized = strings.TrimPrefix(normalized, workspaceRoot+"/")
+		}
+	}
+	normalized = strings.TrimPrefix(normalized, "workspace/")
+	normalized = strings.TrimPrefix(normalized, "./")
+	if normalized == "" {
+		return "."
+	}
+	return strings.Trim(path.Clean(normalized), "/")
 }
 
 func normalizeDuration(duration time.Duration) time.Duration {

--- a/services/local-service/internal/tools/executor.go
+++ b/services/local-service/internal/tools/executor.go
@@ -83,6 +83,29 @@ func (e *ToolExecutor) ExecuteTool(ctx context.Context, name string, input map[s
 	return e.ExecuteToolWithContext(ctx, nil, name, input)
 }
 
+// PrecheckToolWithContext runs validation and risk precheck without executing the tool.
+func (e *ToolExecutor) PrecheckToolWithContext(ctx context.Context, execCtx *ToolExecuteContext, name string, input map[string]any) (ToolMetadata, *RiskPrecheckResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if execCtx == nil {
+		execCtx = &ToolExecuteContext{}
+	}
+	tool, err := e.ResolveTool(name)
+	if err != nil {
+		return ToolMetadata{}, nil, err
+	}
+	metadata := tool.Metadata()
+	if err := tool.Validate(input); err != nil {
+		return metadata, nil, fmt.Errorf("%w: %v", ErrToolValidationFailed, err)
+	}
+	precheckResult, err := e.precheck(ctx, BuildRiskPrecheckInput(metadata, name, execCtx, input))
+	if err != nil {
+		return metadata, nil, err
+	}
+	return metadata, precheckResult, nil
+}
+
 // ExecuteToolWithContext executes a tool with a ToolExecuteContext.
 func (e *ToolExecutor) ExecuteToolWithContext(ctx context.Context, execCtx *ToolExecuteContext, name string, input map[string]any) (*ToolExecutionResult, error) {
 	if ctx == nil {
@@ -113,7 +136,8 @@ func (e *ToolExecutor) ExecuteToolWithContext(ctx context.Context, execCtx *Tool
 		record = e.recorder.Finish(ctx, record, ToolCallStatusFailed, nil, 0, mapToolErrorCode(e.errorMapper, err))
 		return &ToolExecutionResult{Metadata: metadata, ToolCall: record}, err
 	}
-	if precheckResult != nil && (precheckResult.Deny || precheckResult.ApprovalRequired) {
+	approvalGranted := approvalBypassAllowed(execCtx, name, precheckInput)
+	if precheckResult != nil && (precheckResult.Deny || (precheckResult.ApprovalRequired && !approvalGranted)) {
 		blockedErr := e.precheckBlockedError(*precheckResult)
 		result := e.buildPrecheckBlockedResult(ctx, metadata, record, *precheckResult, blockedErr)
 		return result, blockedErr
@@ -270,8 +294,14 @@ func (e *ToolExecutor) buildPrecheckBlockedResult(ctx context.Context, metadata 
 		"checkpoint_required": precheck.CheckpointRequired,
 		"deny":                precheck.Deny,
 	}
+	if precheck.Reason != "" {
+		output["reason"] = precheck.Reason
+	}
 	if precheck.DenyReason != "" {
 		output["deny_reason"] = precheck.DenyReason
+	}
+	if len(precheck.ImpactScope) > 0 {
+		output["impact_scope"] = precheck.ImpactScope
 	}
 
 	record = e.recorder.Finish(ctx, record, ToolCallStatusFailed, output, time.Nanosecond, mapToolErrorCode(e.errorMapper, err))
@@ -286,6 +316,30 @@ func (e *ToolExecutor) buildPrecheckBlockedResult(ctx context.Context, metadata 
 		Duration: time.Nanosecond,
 		ToolCall: record,
 	}
+}
+
+func approvalBypassAllowed(execCtx *ToolExecuteContext, toolName string, precheckInput RiskPrecheckInput) bool {
+	if execCtx == nil || !execCtx.ApprovalGranted {
+		return false
+	}
+	if strings.TrimSpace(execCtx.ApprovedOperation) != "" && execCtx.ApprovedOperation != toolName {
+		return false
+	}
+	if strings.TrimSpace(execCtx.ApprovedTargetObject) == "" {
+		return true
+	}
+	target := strings.TrimSpace(precheckInput.Workspace.TargetPath)
+	if target == "" {
+		target = strings.TrimSpace(precheckInput.Workspace.WorkspacePath)
+	}
+	if target == "" {
+		return false
+	}
+	return normalizeApprovalTarget(execCtx.ApprovedTargetObject) == normalizeApprovalTarget(target)
+}
+
+func normalizeApprovalTarget(target string) string {
+	return strings.Trim(strings.ReplaceAll(strings.TrimSpace(target), "\\", "/"), "/")
 }
 
 func normalizeDuration(duration time.Duration) time.Duration {

--- a/services/local-service/internal/tools/executor_test.go
+++ b/services/local-service/internal/tools/executor_test.go
@@ -208,3 +208,69 @@ func TestToolExecuteContextFields(t *testing.T) {
 		t.Fatalf("unexpected context fields: %+v", ctx)
 	}
 }
+
+func TestToolExecutorPrecheckToolWithContextReturnsAssessment(t *testing.T) {
+	exec := newExecutorForTest(&stubTool{
+		meta: ToolMetadata{Name: "write_file", DisplayName: "Write File", Source: ToolSourceBuiltin},
+	}, nil)
+
+	resultMeta, precheck, err := exec.PrecheckToolWithContext(context.Background(), &ToolExecuteContext{
+		WorkspacePath: "D:/workspace",
+	}, "write_file", map[string]any{"path": "notes/a.md"})
+	if err != nil {
+		t.Fatalf("PrecheckToolWithContext returned error: %v", err)
+	}
+	if resultMeta.Name != "write_file" {
+		t.Fatalf("expected metadata for write_file, got %+v", resultMeta)
+	}
+	if precheck == nil {
+		t.Fatal("expected precheck result")
+	}
+	if precheck.RiskLevel == "" {
+		t.Fatalf("expected risk level to be populated, got %+v", precheck)
+	}
+}
+
+func TestApprovalBypassAllowedUsesStoredOperationAndTarget(t *testing.T) {
+	execCtx := &ToolExecuteContext{
+		ApprovalGranted:      true,
+		ApprovedOperation:    "write_file",
+		ApprovedTargetObject: "workspace/notes/a.md",
+	}
+	precheckInput := RiskPrecheckInput{
+		Workspace: WorkspaceBoundaryInfo{
+			WorkspacePath: "D:/repo/workspace",
+			TargetPath:    "D:/repo/workspace/notes/a.md",
+		},
+	}
+	if !approvalBypassAllowed(execCtx, "write_file", precheckInput) {
+		t.Fatal("expected approval bypass to allow normalized stored target")
+	}
+	if approvalBypassAllowed(execCtx, "exec_command", precheckInput) {
+		t.Fatal("expected approval bypass to reject mismatched operation")
+	}
+
+	execCtx.ApprovedOperation = ""
+	execCtx.ApprovedTargetObject = ""
+	if !approvalBypassAllowed(execCtx, "write_file", precheckInput) {
+		t.Fatal("expected blank approved target to allow granted approval")
+	}
+}
+
+func TestNormalizeApprovalTargetHandlesWorkspaceForms(t *testing.T) {
+	workspaceRoot := "D:/repo/workspace"
+	inputs := []string{
+		"workspace/notes/a.md",
+		"./notes/a.md",
+		"D:/repo/workspace/notes/a.md",
+		"notes/a.md",
+	}
+	for _, input := range inputs {
+		if got := normalizeApprovalTarget(input, workspaceRoot); got != "notes/a.md" {
+			t.Fatalf("expected normalized path notes/a.md for %q, got %q", input, got)
+		}
+	}
+	if got := normalizeApprovalTarget(workspaceRoot, workspaceRoot); got != "." {
+		t.Fatalf("expected workspace root to normalize to '.', got %q", got)
+	}
+}

--- a/services/local-service/internal/tools/risk_precheck.go
+++ b/services/local-service/internal/tools/risk_precheck.go
@@ -2,6 +2,8 @@ package tools
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"path/filepath"
 	"strings"
 
@@ -19,6 +21,7 @@ type WorkspaceBoundaryInfo struct {
 	WorkspacePath string `json:"workspace_path,omitempty"`
 	TargetPath    string `json:"target_path,omitempty"`
 	Within        *bool  `json:"within_workspace,omitempty"`
+	Exists        *bool  `json:"exists,omitempty"`
 }
 
 // PlatformCapabilityInfo 预留平台能力信息，后续可继续扩展审批/检查点能力接线。
@@ -38,11 +41,13 @@ type RiskPrecheckInput struct {
 
 // RiskPrecheckResult 是风险预检查的最小输出。
 type RiskPrecheckResult struct {
-	RiskLevel          string `json:"risk_level"`
-	ApprovalRequired   bool   `json:"approval_required"`
-	CheckpointRequired bool   `json:"checkpoint_required"`
-	Deny               bool   `json:"deny"`
-	DenyReason         string `json:"deny_reason,omitempty"`
+	RiskLevel          string         `json:"risk_level"`
+	ApprovalRequired   bool           `json:"approval_required"`
+	CheckpointRequired bool           `json:"checkpoint_required"`
+	Deny               bool           `json:"deny"`
+	Reason             string         `json:"reason,omitempty"`
+	DenyReason         string         `json:"deny_reason,omitempty"`
+	ImpactScope        map[string]any `json:"impact_scope,omitempty"`
 }
 
 // RiskPrechecker 在执行前完成本地风险判定，不直接触发工具执行。
@@ -74,7 +79,9 @@ func (p DefaultRiskPrechecker) Precheck(_ context.Context, input RiskPrecheckInp
 		ApprovalRequired:   assessment.ApprovalRequired,
 		CheckpointRequired: assessment.CheckpointRequired,
 		Deny:               assessment.Deny,
+		Reason:             assessment.Reason,
 		DenyReason:         assessment.Reason,
+		ImpactScope:        impactScopeMap(assessment.ImpactScope),
 	}, nil
 }
 
@@ -96,7 +103,7 @@ func BuildRiskPrecheckInput(metadata ToolMetadata, toolName string, execCtx *Too
 		SupportsWorkspaceBoundary: execCtx.Platform != nil,
 	}
 
-	targetPath, ok := extractTargetPath(input)
+	targetPath, ok := extractTargetPath(precheckInput.ToolName, precheckInput.Input)
 	if !ok {
 		return precheckInput
 	}
@@ -114,6 +121,11 @@ func BuildRiskPrecheckInput(metadata ToolMetadata, toolName string, execCtx *Too
 		precheckInput.Workspace.TargetPath = safePath
 		if absPath, err := execCtx.Platform.Abs(safePath); err == nil {
 			precheckInput.Workspace.TargetPath = absPath
+		}
+		if _, statErr := execCtx.Platform.Stat(safePath); statErr == nil {
+			precheckInput.Workspace.Exists = boolPtr(true)
+		} else if errors.Is(statErr, fs.ErrNotExist) {
+			precheckInput.Workspace.Exists = boolPtr(false)
 		}
 	}
 	return precheckInput
@@ -134,19 +146,25 @@ func buildAssessmentInput(input RiskPrecheckInput) risksvc.AssessmentInput {
 		WorkspaceKnown:      workspaceKnown,
 		CommandPreview:      normalizeCommandString(input.Input),
 		ImpactScope: risksvc.ImpactScope{
-			Files:          filesFromTarget(input.Workspace.TargetPath),
+			Files:          filesFromTarget(firstNonEmptyTarget(input.Workspace.TargetPath, input.Workspace.WorkspacePath)),
 			OutOfWorkspace: outOfWorkspace,
 		},
 	}
 
 	if input.ToolName == "write_file" {
-		assessment.ImpactScope.OverwriteOrDeleteRisk = workspaceKnown && !outOfWorkspace
+		exists := input.Workspace.Exists != nil && *input.Workspace.Exists
+		assessment.ImpactScope.OverwriteOrDeleteRisk = workspaceKnown && !outOfWorkspace && exists
 	}
 
 	return assessment
 }
 
-func extractTargetPath(input map[string]any) (string, bool) {
+func extractTargetPath(toolName string, input map[string]any) (string, bool) {
+	if toolName == "exec_command" {
+		if value, ok := input["working_dir"].(string); ok && strings.TrimSpace(value) != "" {
+			return value, true
+		}
+	}
 	for _, key := range []string{"path", "target_path", "file_path"} {
 		value, ok := input[key].(string)
 		if ok && strings.TrimSpace(value) != "" {
@@ -154,6 +172,23 @@ func extractTargetPath(input map[string]any) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func firstNonEmptyTarget(primary, fallback string) string {
+	if strings.TrimSpace(primary) != "" {
+		return primary
+	}
+	return fallback
+}
+
+func impactScopeMap(scope risksvc.ImpactScope) map[string]any {
+	return map[string]any{
+		"files":                    append([]string(nil), scope.Files...),
+		"webpages":                 append([]string(nil), scope.Webpages...),
+		"apps":                     append([]string(nil), scope.Apps...),
+		"out_of_workspace":         scope.OutOfWorkspace,
+		"overwrite_or_delete_risk": scope.OverwriteOrDeleteRisk,
+	}
 }
 
 func normalizeCommandString(input map[string]any) string {

--- a/services/local-service/internal/tools/risk_precheck_test.go
+++ b/services/local-service/internal/tools/risk_precheck_test.go
@@ -59,9 +59,12 @@ func TestDefaultRiskPrecheckerReadFileLowRisk(t *testing.T) {
 	if result.RiskLevel != RiskLevelGreen || result.Deny || result.ApprovalRequired || result.CheckpointRequired {
 		t.Fatalf("unexpected precheck result: %+v", result)
 	}
+	if result.Reason != "normal" {
+		t.Fatalf("expected normal reason, got %+v", result)
+	}
 }
 
-func TestDefaultRiskPrecheckerWriteFileInsideWorkspace(t *testing.T) {
+func TestDefaultRiskPrecheckerWriteFileInsideWorkspaceCreateFlow(t *testing.T) {
 	prechecker := DefaultRiskPrechecker{}
 	within := true
 	result, err := prechecker.Precheck(context.Background(), RiskPrecheckInput{
@@ -77,7 +80,33 @@ func TestDefaultRiskPrecheckerWriteFileInsideWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.RiskLevel != RiskLevelYellow || result.Deny || result.ApprovalRequired || !result.CheckpointRequired {
+	if result.RiskLevel != RiskLevelGreen || result.Deny || result.ApprovalRequired || result.CheckpointRequired {
+		t.Fatalf("unexpected precheck result: %+v", result)
+	}
+	if files := result.ImpactScope["files"].([]string); len(files) != 1 || files[0] != "/workspace/report.txt" {
+		t.Fatalf("expected write_file impact scope to include target file, got %+v", result.ImpactScope)
+	}
+}
+
+func TestDefaultRiskPrecheckerWriteFileOverwriteRequiresApproval(t *testing.T) {
+	prechecker := DefaultRiskPrechecker{}
+	within := true
+	exists := true
+	result, err := prechecker.Precheck(context.Background(), RiskPrecheckInput{
+		Metadata: ToolMetadata{Name: "write_file", DisplayName: "Write", Source: ToolSourceBuiltin},
+		ToolName: "write_file",
+		Input:    map[string]any{"path": "report.txt"},
+		Workspace: WorkspaceBoundaryInfo{
+			WorkspacePath: "/workspace",
+			TargetPath:    "/workspace/report.txt",
+			Within:        &within,
+			Exists:        &exists,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RiskLevel != RiskLevelYellow || result.Deny || !result.ApprovalRequired || !result.CheckpointRequired {
 		t.Fatalf("unexpected precheck result: %+v", result)
 	}
 }
@@ -108,13 +137,42 @@ func TestDefaultRiskPrecheckerExecCommandHighRisk(t *testing.T) {
 	result, err := prechecker.Precheck(context.Background(), RiskPrecheckInput{
 		Metadata: ToolMetadata{Name: "exec_command", DisplayName: "Exec", Source: ToolSourceBuiltin},
 		ToolName: "exec_command",
-		Input:    map[string]any{"command": "rm -rf /tmp/demo"},
+		Input:    map[string]any{"command": "rm -rf /tmp/demo", "working_dir": "/workspace"},
+		Workspace: WorkspaceBoundaryInfo{
+			WorkspacePath: "/workspace",
+			TargetPath:    "/workspace",
+		},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result.RiskLevel != RiskLevelRed || !result.Deny {
 		t.Fatalf("unexpected precheck result: %+v", result)
+	}
+}
+
+func TestDefaultRiskPrecheckerExecCommandRequiresApprovalAndImpactScope(t *testing.T) {
+	prechecker := DefaultRiskPrechecker{}
+	within := true
+	result, err := prechecker.Precheck(context.Background(), RiskPrecheckInput{
+		Metadata: ToolMetadata{Name: "exec_command", DisplayName: "Exec", Source: ToolSourceBuiltin},
+		ToolName: "exec_command",
+		Input:    map[string]any{"command": "git status", "working_dir": "notes"},
+		Workspace: WorkspaceBoundaryInfo{
+			WorkspacePath: "/workspace",
+			TargetPath:    "/workspace/notes",
+			Within:        &within,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RiskLevel != RiskLevelYellow || !result.ApprovalRequired || !result.CheckpointRequired {
+		t.Fatalf("unexpected precheck result: %+v", result)
+	}
+	files := result.ImpactScope["files"].([]string)
+	if len(files) != 1 || files[0] != "/workspace/notes" {
+		t.Fatalf("expected exec_command impact scope to include working dir, got %+v", result.ImpactScope)
 	}
 }
 

--- a/services/local-service/internal/tools/types.go
+++ b/services/local-service/internal/tools/types.go
@@ -296,14 +296,17 @@ type ModelCapability interface {
 // storage / platform / risk / audit / checkpoint 均为可选注入，
 // 工具实现使用前需做 nil 检查，不得假设一定可用。
 type ToolExecuteContext struct {
-	TaskID        string
-	RunID         string
-	StepID        string
-	TraceID       string
-	WorkspacePath string
-	Logger        any
-	Timeout       time.Duration
-	Cancel        context.CancelFunc
+	TaskID               string
+	RunID                string
+	StepID               string
+	TraceID              string
+	WorkspacePath        string
+	Logger               any
+	Timeout              time.Duration
+	Cancel               context.CancelFunc
+	ApprovalGranted      bool
+	ApprovedOperation    string
+	ApprovedTargetObject string
 
 	Storage    StorageCapability
 	Platform   PlatformCapability


### PR DESCRIPTION
## 概要

- 将 `feat/security-restore-apply` 合并到 `feat/security-governance-control`，并保持该分支与最新的 `origin/main` 同步
- 加强后端治理链，使高风险操作始终遵循 `风险 -> 审批 -> 审计 -> 恢复点 -> 执行` 的流程
- 将基于快照的恢复应用支持合并到同一后端分支，包括恢复点查询/应用流程和结构化任务结果

## 变更内容

- 风险 / 工具层
  - 统一 `write_file`、`exec_command` 和工作区外写入的治理预检查行为
  - 区分文件写入的创建与覆盖操作
  - 向上传递结构化的 `impact_scope`（影响范围）、风险原因和审批信号

- 执行 / 编排器 / 运行引擎
  - 在审批后添加受保护的执行行为
  - 返回允许 / 拒绝 / 执行失败 / 恢复失败的结构化任务结果
  - 将审计跟踪、工具生命周期状态和恢复元数据持久化到正式的任务状态中
  - 防止失败分支发出虚假的交付成功信号

- 恢复应用流程
  - 将恢复点列表/应用支持合并到治理分支
  - 保留基于快照的恢复行为和持久化任务回退机制
  - 在通过声明字段暴露恢复状态的同时，保持协议安全的任务详细信息行为

- 测试
  - 添加并保持对允许 / 拒绝 / 失败 / 恢复路径的覆盖
  - 验证恢复应用成功 / 失败 / 持久化回退
  - 验证高风险操作命中预期的治理路径和正式状态变更

## 验证

- `go test ./services/local-service/internal/checkpoint ./services/local-service/internal/storage ./services/local-service/internal/platform ./services/local-service/internal/execution ./services/local-service/internal/orchestrator ./services/local-service/internal/runengine ./services/local-service/internal/rpc ./services/local-service/internal/tools ./services/local-service/internal/tools/builtin ./services/local-service/internal/risk ./services/local-service/internal/audit`

## 备注

- 推送前已获取并检查最新的 `origin/main`；冲突解决后无需合并额外的上游更改
- 执行/编排器代码和测试中的合并冲突已解决，然后重新运行了受影响的测试套件
