### PR TITLE
Backfill owner-4 task-centric queries from stored task runs

### DIFF
--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -710,6 +710,16 @@ func (s *Service) DashboardModuleGet(params map[string]any) (map[string]any, err
 	tab := stringValue(params, "tab", "daily_summary")
 	finishedTasks, _ := s.runEngine.ListTasks("finished", "finished_at", "desc", 0, 0)
 	unfinishedTasks, _ := s.runEngine.ListTasks("unfinished", "updated_at", "desc", 0, 0)
+	if len(finishedTasks) == 0 {
+		if persistedTasks, ok := s.listTasksFromStorage("finished", "finished_at", "desc", 0, 0); ok {
+			finishedTasks = persistedTasks
+		}
+	}
+	if len(unfinishedTasks) == 0 {
+		if persistedTasks, ok := s.listTasksFromStorage("unfinished", "updated_at", "desc", 0, 0); ok {
+			unfinishedTasks = persistedTasks
+		}
+	}
 	_, pendingTotal := s.runEngine.PendingApprovalRequests(20, 0)
 	latestAudit := latestAuditRecordFromTasks(append(append([]runengine.TaskRecord{}, unfinishedTasks...), finishedTasks...))
 	if latestAudit == nil {

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -421,6 +422,14 @@ func (s *Service) TaskList(params map[string]any) (map[string]any, error) {
 	sortBy := stringValue(params, "sort_by", "updated_at")
 	sortOrder := stringValue(params, "sort_order", "desc")
 	tasks, total := s.runEngine.ListTasks(group, sortBy, sortOrder, limit, offset)
+	if len(tasks) == 0 {
+		if persistedTasks, ok := s.listTasksFromStorage(group, sortBy, sortOrder, limit, offset); ok {
+			tasks = persistedTasks
+			if allPersistedTasks, totalOK := s.listTasksFromStorage(group, sortBy, sortOrder, 0, 0); totalOK {
+				total = len(allPersistedTasks)
+			}
+		}
+	}
 
 	items := make([]map[string]any, 0, len(tasks))
 	for _, task := range tasks {
@@ -439,6 +448,9 @@ func (s *Service) TaskList(params map[string]any) (map[string]any, error) {
 func (s *Service) TaskDetailGet(params map[string]any) (map[string]any, error) {
 	taskID := stringValue(params, "task_id", "")
 	task, ok := s.runEngine.TaskDetail(taskID)
+	if !ok {
+		task, ok = s.taskDetailFromStorage(taskID)
+	}
 	if !ok {
 		return nil, ErrTaskNotFound
 	}
@@ -1009,6 +1021,174 @@ func pageMap(limit, offset, total int) map[string]any {
 		"total":    total,
 		"has_more": offset+limit < total,
 	}
+}
+
+func (s *Service) listTasksFromStorage(group, sortBy, sortOrder string, limit, offset int) ([]runengine.TaskRecord, bool) {
+	if s.storage == nil {
+		return nil, false
+	}
+	records, err := s.storage.TaskRunStore().LoadTaskRuns(context.Background())
+	if err != nil || len(records) == 0 {
+		return nil, false
+	}
+	tasks := make([]runengine.TaskRecord, 0, len(records))
+	for _, record := range records {
+		task := taskRecordFromStorage(record)
+		if !matchesTaskGroup(task, group) {
+			continue
+		}
+		tasks = append(tasks, task)
+	}
+	runengineSortTaskRecords(tasks, sortBy, sortOrder)
+	total := len(tasks)
+	if offset >= total {
+		return []runengine.TaskRecord{}, true
+	}
+	end := offset + limit
+	if limit <= 0 || end > total {
+		end = total
+	}
+	return tasks[offset:end], true
+}
+
+func (s *Service) taskDetailFromStorage(taskID string) (runengine.TaskRecord, bool) {
+	if s.storage == nil || strings.TrimSpace(taskID) == "" {
+		return runengine.TaskRecord{}, false
+	}
+	records, err := s.storage.TaskRunStore().LoadTaskRuns(context.Background())
+	if err != nil {
+		return runengine.TaskRecord{}, false
+	}
+	for _, record := range records {
+		if record.TaskID == taskID {
+			return taskRecordFromStorage(record), true
+		}
+	}
+	return runengine.TaskRecord{}, false
+}
+
+func matchesTaskGroup(task runengine.TaskRecord, group string) bool {
+	switch group {
+	case "finished":
+		return isFinishedTaskStatus(task.Status)
+	case "unfinished":
+		return !isFinishedTaskStatus(task.Status)
+	default:
+		return true
+	}
+}
+
+func isFinishedTaskStatus(status string) bool {
+	switch status {
+	case "completed", "cancelled", "ended_unfinished", "failed":
+		return true
+	default:
+		return false
+	}
+}
+
+func runengineSortTaskRecords(tasks []runengine.TaskRecord, sortBy, sortOrder string) {
+	switch sortBy {
+	case "started_at", "finished_at", "updated_at":
+	default:
+		sortBy = "updated_at"
+	}
+	if sortOrder != "asc" {
+		sortOrder = "desc"
+	}
+	sort.SliceStable(tasks, func(i, j int) bool {
+		left := taskSortTime(tasks[i], sortBy)
+		right := taskSortTime(tasks[j], sortBy)
+		if left.Equal(right) {
+			if sortOrder == "asc" {
+				return tasks[i].TaskID < tasks[j].TaskID
+			}
+			return tasks[i].TaskID > tasks[j].TaskID
+		}
+		if sortOrder == "asc" {
+			return left.Before(right)
+		}
+		return left.After(right)
+	})
+}
+
+func taskSortTime(task runengine.TaskRecord, sortBy string) time.Time {
+	switch sortBy {
+	case "started_at":
+		return task.StartedAt
+	case "finished_at":
+		if task.FinishedAt != nil {
+			return *task.FinishedAt
+		}
+		return time.Time{}
+	default:
+		return task.UpdatedAt
+	}
+}
+
+func taskRecordFromStorage(record storage.TaskRunRecord) runengine.TaskRecord {
+	return runengine.TaskRecord{
+		TaskID:            record.TaskID,
+		SessionID:         record.SessionID,
+		RunID:             record.RunID,
+		Title:             record.Title,
+		SourceType:        record.SourceType,
+		Status:            record.Status,
+		Intent:            cloneMap(record.Intent),
+		PreferredDelivery: record.PreferredDelivery,
+		FallbackDelivery:  record.FallbackDelivery,
+		CurrentStep:       record.CurrentStep,
+		RiskLevel:         record.RiskLevel,
+		StartedAt:         record.StartedAt,
+		UpdatedAt:         record.UpdatedAt,
+		FinishedAt:        cloneTimePointer(record.FinishedAt),
+		Timeline:          timelineFromStorage(record.Timeline),
+		BubbleMessage:     cloneMap(record.BubbleMessage),
+		DeliveryResult:    cloneMap(record.DeliveryResult),
+		Artifacts:         cloneMapSlice(record.Artifacts),
+		AuditRecords:      cloneMapSlice(record.AuditRecords),
+		MirrorReferences:  cloneMapSlice(record.MirrorReferences),
+		SecuritySummary:   cloneMap(record.SecuritySummary),
+		ApprovalRequest:   cloneMap(record.ApprovalRequest),
+		PendingExecution:  cloneMap(record.PendingExecution),
+		Authorization:     cloneMap(record.Authorization),
+		ImpactScope:       cloneMap(record.ImpactScope),
+		TokenUsage:        cloneMap(record.TokenUsage),
+		MemoryReadPlans:   cloneMapSlice(record.MemoryReadPlans),
+		MemoryWritePlans:  cloneMapSlice(record.MemoryWritePlans),
+		StorageWritePlan:  cloneMap(record.StorageWritePlan),
+		ArtifactPlans:     cloneMapSlice(record.ArtifactPlans),
+		LatestEvent:       cloneMap(record.LatestEvent),
+		LatestToolCall:    cloneMap(record.LatestToolCall),
+		CurrentStepStatus: record.CurrentStepStatus,
+	}
+}
+
+func timelineFromStorage(timeline []storage.TaskStepSnapshot) []runengine.TaskStepRecord {
+	if len(timeline) == 0 {
+		return nil
+	}
+	result := make([]runengine.TaskStepRecord, len(timeline))
+	for index, step := range timeline {
+		result[index] = runengine.TaskStepRecord{
+			StepID:        step.StepID,
+			TaskID:        step.TaskID,
+			Name:          step.Name,
+			Status:        step.Status,
+			OrderIndex:    step.OrderIndex,
+			InputSummary:  step.InputSummary,
+			OutputSummary: step.OutputSummary,
+		}
+	}
+	return result
+}
+
+func cloneTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 // taskStatusForSuggestion 处理当前模块的相关逻辑。

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -422,12 +422,10 @@ func (s *Service) TaskList(params map[string]any) (map[string]any, error) {
 	sortBy := stringValue(params, "sort_by", "updated_at")
 	sortOrder := stringValue(params, "sort_order", "desc")
 	tasks, total := s.runEngine.ListTasks(group, sortBy, sortOrder, limit, offset)
-	if len(tasks) == 0 {
-		if persistedTasks, ok := s.listTasksFromStorage(group, sortBy, sortOrder, limit, offset); ok {
+	if total == 0 {
+		if persistedTasks, persistedTotal, ok := s.listTasksFromStorage(group, sortBy, sortOrder, limit, offset); ok {
 			tasks = persistedTasks
-			if allPersistedTasks, totalOK := s.listTasksFromStorage(group, sortBy, sortOrder, 0, 0); totalOK {
-				total = len(allPersistedTasks)
-			}
+			total = persistedTotal
 		}
 	}
 
@@ -711,16 +709,19 @@ func (s *Service) DashboardModuleGet(params map[string]any) (map[string]any, err
 	finishedTasks, _ := s.runEngine.ListTasks("finished", "finished_at", "desc", 0, 0)
 	unfinishedTasks, _ := s.runEngine.ListTasks("unfinished", "updated_at", "desc", 0, 0)
 	if len(finishedTasks) == 0 {
-		if persistedTasks, ok := s.listTasksFromStorage("finished", "finished_at", "desc", 0, 0); ok {
+		if persistedTasks, _, ok := s.listTasksFromStorage("finished", "finished_at", "desc", 0, 0); ok {
 			finishedTasks = persistedTasks
 		}
 	}
 	if len(unfinishedTasks) == 0 {
-		if persistedTasks, ok := s.listTasksFromStorage("unfinished", "updated_at", "desc", 0, 0); ok {
+		if persistedTasks, _, ok := s.listTasksFromStorage("unfinished", "updated_at", "desc", 0, 0); ok {
 			unfinishedTasks = persistedTasks
 		}
 	}
 	_, pendingTotal := s.runEngine.PendingApprovalRequests(20, 0)
+	if pendingTotal == 0 {
+		pendingTotal = countPendingApprovalTasks(unfinishedTasks)
+	}
 	latestAudit := latestAuditRecordFromTasks(append(append([]runengine.TaskRecord{}, unfinishedTasks...), finishedTasks...))
 	if latestAudit == nil {
 		latestAudit = s.latestAuditRecordFromStorage("")
@@ -745,7 +746,7 @@ func (s *Service) MirrorOverviewGet(params map[string]any) (map[string]any, erro
 	_ = params
 	finishedTasks, _ := s.runEngine.ListTasks("finished", "finished_at", "desc", 0, 0)
 	if len(finishedTasks) == 0 {
-		if persistedTasks, ok := s.listTasksFromStorage("finished", "finished_at", "desc", 0, 0); ok {
+		if persistedTasks, _, ok := s.listTasksFromStorage("finished", "finished_at", "desc", 0, 0); ok {
 			finishedTasks = persistedTasks
 		}
 	}
@@ -770,14 +771,17 @@ func (s *Service) SecuritySummaryGet() (map[string]any, error) {
 	unfinishedTasks, _ := s.runEngine.ListTasks("unfinished", "updated_at", "desc", 0, 0)
 	finishedTasks, _ := s.runEngine.ListTasks("finished", "finished_at", "desc", 0, 0)
 	if len(unfinishedTasks) == 0 {
-		if persistedTasks, ok := s.listTasksFromStorage("unfinished", "updated_at", "desc", 0, 0); ok {
+		if persistedTasks, _, ok := s.listTasksFromStorage("unfinished", "updated_at", "desc", 0, 0); ok {
 			unfinishedTasks = persistedTasks
 		}
 	}
 	if len(finishedTasks) == 0 {
-		if persistedTasks, ok := s.listTasksFromStorage("finished", "finished_at", "desc", 0, 0); ok {
+		if persistedTasks, _, ok := s.listTasksFromStorage("finished", "finished_at", "desc", 0, 0); ok {
 			finishedTasks = persistedTasks
 		}
+	}
+	if pendingTotal == 0 {
+		pendingTotal = countPendingApprovalTasks(unfinishedTasks)
 	}
 	allTasks := append(append([]runengine.TaskRecord{}, unfinishedTasks...), finishedTasks...)
 	dataLogSettings := mapValue(s.runEngine.Settings(), "data_log")
@@ -1048,13 +1052,13 @@ func pageMap(limit, offset, total int) map[string]any {
 	}
 }
 
-func (s *Service) listTasksFromStorage(group, sortBy, sortOrder string, limit, offset int) ([]runengine.TaskRecord, bool) {
+func (s *Service) listTasksFromStorage(group, sortBy, sortOrder string, limit, offset int) ([]runengine.TaskRecord, int, bool) {
 	if s.storage == nil {
-		return nil, false
+		return nil, 0, false
 	}
 	records, err := s.storage.TaskRunStore().LoadTaskRuns(context.Background())
 	if err != nil || len(records) == 0 {
-		return nil, false
+		return nil, 0, false
 	}
 	tasks := make([]runengine.TaskRecord, 0, len(records))
 	for _, record := range records {
@@ -1067,13 +1071,13 @@ func (s *Service) listTasksFromStorage(group, sortBy, sortOrder string, limit, o
 	runengineSortTaskRecords(tasks, sortBy, sortOrder)
 	total := len(tasks)
 	if offset >= total {
-		return []runengine.TaskRecord{}, true
+		return []runengine.TaskRecord{}, total, true
 	}
 	end := offset + limit
 	if limit <= 0 || end > total {
 		end = total
 	}
-	return tasks[offset:end], true
+	return tasks[offset:end], total, true
 }
 
 func (s *Service) taskDetailFromStorage(taskID string) (runengine.TaskRecord, bool) {
@@ -1096,10 +1100,8 @@ func matchesTaskGroup(task runengine.TaskRecord, group string) bool {
 	switch group {
 	case "finished":
 		return isFinishedTaskStatus(task.Status)
-	case "unfinished":
-		return !isFinishedTaskStatus(task.Status)
 	default:
-		return true
+		return !isFinishedTaskStatus(task.Status)
 	}
 }
 
@@ -1125,16 +1127,34 @@ func runengineSortTaskRecords(tasks []runengine.TaskRecord, sortBy, sortOrder st
 		left := taskSortTime(tasks[i], sortBy)
 		right := taskSortTime(tasks[j], sortBy)
 		if left.Equal(right) {
-			if sortOrder == "asc" {
-				return tasks[i].TaskID < tasks[j].TaskID
+			leftUpdated := tasks[i].UpdatedAt
+			rightUpdated := tasks[j].UpdatedAt
+			if leftUpdated.Equal(rightUpdated) {
+				if sortOrder == "asc" {
+					return tasks[i].TaskID < tasks[j].TaskID
+				}
+				return tasks[i].TaskID > tasks[j].TaskID
 			}
-			return tasks[i].TaskID > tasks[j].TaskID
+			if sortOrder == "asc" {
+				return leftUpdated.Before(rightUpdated)
+			}
+			return leftUpdated.After(rightUpdated)
 		}
 		if sortOrder == "asc" {
 			return left.Before(right)
 		}
 		return left.After(right)
 	})
+}
+
+func countPendingApprovalTasks(tasks []runengine.TaskRecord) int {
+	count := 0
+	for _, task := range tasks {
+		if task.Status == "waiting_auth" && len(task.ApprovalRequest) != 0 {
+			count++
+		}
+	}
+	return count
 }
 
 func taskSortTime(task runengine.TaskRecord, sortBy string) time.Time {

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -769,6 +769,16 @@ func (s *Service) SecuritySummaryGet() (map[string]any, error) {
 	_, pendingTotal := s.runEngine.PendingApprovalRequests(20, 0)
 	unfinishedTasks, _ := s.runEngine.ListTasks("unfinished", "updated_at", "desc", 0, 0)
 	finishedTasks, _ := s.runEngine.ListTasks("finished", "finished_at", "desc", 0, 0)
+	if len(unfinishedTasks) == 0 {
+		if persistedTasks, ok := s.listTasksFromStorage("unfinished", "updated_at", "desc", 0, 0); ok {
+			unfinishedTasks = persistedTasks
+		}
+	}
+	if len(finishedTasks) == 0 {
+		if persistedTasks, ok := s.listTasksFromStorage("finished", "finished_at", "desc", 0, 0); ok {
+			finishedTasks = persistedTasks
+		}
+	}
 	allTasks := append(append([]runengine.TaskRecord{}, unfinishedTasks...), finishedTasks...)
 	dataLogSettings := mapValue(s.runEngine.Settings(), "data_log")
 	latestRestorePoint := latestRestorePointFromTasks(allTasks)

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -734,6 +734,11 @@ func (s *Service) DashboardModuleGet(params map[string]any) (map[string]any, err
 func (s *Service) MirrorOverviewGet(params map[string]any) (map[string]any, error) {
 	_ = params
 	finishedTasks, _ := s.runEngine.ListTasks("finished", "finished_at", "desc", 0, 0)
+	if len(finishedTasks) == 0 {
+		if persistedTasks, ok := s.listTasksFromStorage("finished", "finished_at", "desc", 0, 0); ok {
+			finishedTasks = persistedTasks
+		}
+	}
 	memoryReferences := collectMirrorReferences(finishedTasks)
 	return map[string]any{
 		"history_summary": buildMirrorHistorySummary(finishedTasks, memoryReferences),

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -1611,6 +1611,59 @@ func TestServiceMirrorOverviewUsesRuntimeMirrorReferences(t *testing.T) {
 	}
 }
 
+func TestServiceMirrorOverviewFallsBackToStoredFinishedTasks(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "stored mirror overview")
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+
+	err := service.storage.TaskRunStore().SaveTaskRun(context.Background(), storage.TaskRunRecord{
+		TaskID:      "task_mirror_stored",
+		SessionID:   "sess_stored",
+		RunID:       "run_mirror_stored",
+		Title:       "stored mirror task",
+		SourceType:  "hover_input",
+		Status:      "completed",
+		CurrentStep: "deliver_result",
+		RiskLevel:   "green",
+		StartedAt:   time.Date(2026, 4, 14, 11, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 4, 14, 11, 5, 0, 0, time.UTC),
+		FinishedAt:  timePointer(time.Date(2026, 4, 14, 11, 6, 0, 0, time.UTC)),
+		MirrorReferences: []map[string]any{{
+			"memory_id": "mem_stored_001",
+			"reason":    "stored memory hit",
+			"summary":   "stored mirror reference",
+		}},
+		DeliveryResult: map[string]any{
+			"type": "workspace_document",
+			"payload": map[string]any{
+				"path": "workspace/stored-result.md",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("save task run failed: %v", err)
+	}
+
+	result, err := service.MirrorOverviewGet(map[string]any{})
+	if err != nil {
+		t.Fatalf("mirror overview failed: %v", err)
+	}
+
+	memoryReferences := result["memory_references"].([]map[string]any)
+	if len(memoryReferences) != 1 || memoryReferences[0]["memory_id"] != "mem_stored_001" {
+		t.Fatalf("expected storage-backed mirror references, got %+v", memoryReferences)
+	}
+	historySummary := result["history_summary"].([]string)
+	if len(historySummary) == 0 {
+		t.Fatal("expected storage-backed mirror history summary")
+	}
+	profile := result["profile"].(map[string]any)
+	if profile["preferred_output"] != "workspace_document" {
+		t.Fatalf("expected storage-backed mirror profile to infer workspace_document, got %+v", profile)
+	}
+}
+
 func TestServiceSecuritySummaryUsesRuntimeTaskState(t *testing.T) {
 	service := newTestService()
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -1857,6 +1857,65 @@ func TestServiceDashboardModuleHighlightsIncludeAuditTrail(t *testing.T) {
 	}
 }
 
+func TestServiceDashboardModuleFallsBackToStoredTaskRuns(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "stored dashboard module")
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+
+	err := service.storage.TaskRunStore().SaveTaskRun(context.Background(), storage.TaskRunRecord{
+		TaskID:      "task_dashboard_finished",
+		SessionID:   "sess_stored",
+		RunID:       "run_dashboard_finished",
+		Title:       "stored dashboard task",
+		SourceType:  "hover_input",
+		Status:      "completed",
+		CurrentStep: "deliver_result",
+		RiskLevel:   "green",
+		StartedAt:   time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 4, 14, 12, 5, 0, 0, time.UTC),
+		FinishedAt:  timePointer(time.Date(2026, 4, 14, 12, 6, 0, 0, time.UTC)),
+		DeliveryResult: map[string]any{
+			"type": "workspace_document",
+			"payload": map[string]any{
+				"path": "workspace/dashboard.md",
+			},
+		},
+		AuditRecords: []map[string]any{{
+			"audit_id":   "audit_dashboard_001",
+			"task_id":    "task_dashboard_finished",
+			"action":     "write_file",
+			"summary":    "stored dashboard audit",
+			"created_at": "2026-04-14T12:06:00Z",
+			"result":     "success",
+			"target":     "workspace/dashboard.md",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("save finished task run failed: %v", err)
+	}
+
+	moduleResult, err := service.DashboardModuleGet(map[string]any{
+		"module": "security",
+		"tab":    "audit",
+	})
+	if err != nil {
+		t.Fatalf("dashboard module get failed: %v", err)
+	}
+
+	summary := moduleResult["summary"].(map[string]any)
+	if summary["completed_tasks"] != 1 {
+		t.Fatalf("expected storage-backed completed task count, got %+v", summary)
+	}
+	if summary["generated_outputs"] != 1 {
+		t.Fatalf("expected storage-backed generated output count, got %+v", summary)
+	}
+	highlights := moduleResult["highlights"].([]string)
+	if len(highlights) == 0 {
+		t.Fatal("expected storage-backed dashboard highlights")
+	}
+}
+
 func TestServiceSecurityAuditListFallsBackToStoredAuditRecords(t *testing.T) {
 	service, _ := newTestServiceWithExecution(t, "executor-backed summary")
 	if service.storage == nil {

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -1391,6 +1391,178 @@ func TestServiceTaskListFallsBackToStoredTaskRuns(t *testing.T) {
 	}
 }
 
+func TestServiceTaskListDoesNotFallbackWhenOffsetExceedsRuntimePage(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "runtime paging")
+
+	_, err := service.StartTask(map[string]any{
+		"session_id": "sess_page",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "runtime finished task",
+		},
+		"intent": map[string]any{
+			"name": "summarize",
+			"arguments": map[string]any{
+				"style": "key_points",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start runtime task failed: %v", err)
+	}
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+	err = service.storage.TaskRunStore().SaveTaskRun(context.Background(), storage.TaskRunRecord{
+		TaskID:      "task_stored_extra",
+		SessionID:   "sess_page",
+		RunID:       "run_stored_extra",
+		Title:       "stored finished task",
+		SourceType:  "hover_input",
+		Status:      "completed",
+		CurrentStep: "deliver_result",
+		RiskLevel:   "green",
+		StartedAt:   time.Date(2026, 4, 14, 14, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 4, 14, 14, 5, 0, 0, time.UTC),
+		FinishedAt:  timePointer(time.Date(2026, 4, 14, 14, 6, 0, 0, time.UTC)),
+	})
+	if err != nil {
+		t.Fatalf("save task run failed: %v", err)
+	}
+
+	listResult, err := service.TaskList(map[string]any{
+		"group":      "finished",
+		"limit":      float64(10),
+		"offset":     float64(100),
+		"sort_by":    "updated_at",
+		"sort_order": "desc",
+	})
+	if err != nil {
+		t.Fatalf("task list failed: %v", err)
+	}
+
+	items := listResult["items"].([]map[string]any)
+	if len(items) != 0 {
+		t.Fatalf("expected empty page beyond runtime total, got %+v", items)
+	}
+	page := listResult["page"].(map[string]any)
+	if page["total"] != 1 {
+		t.Fatalf("expected runtime total to stay unchanged, got %+v", page)
+	}
+}
+
+func TestServiceTaskListFallbackMatchesRuntimeUnknownGroupSemantics(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "stored unknown group")
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+	err := service.storage.TaskRunStore().SaveTaskRun(context.Background(), storage.TaskRunRecord{
+		TaskID:      "task_stored_unfinished",
+		SessionID:   "sess_group",
+		RunID:       "run_stored_unfinished",
+		Title:       "stored unfinished task",
+		SourceType:  "hover_input",
+		Status:      "processing",
+		CurrentStep: "generate_output",
+		RiskLevel:   "green",
+		StartedAt:   time.Date(2026, 4, 14, 15, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 4, 14, 15, 5, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("save unfinished task run failed: %v", err)
+	}
+	err = service.storage.TaskRunStore().SaveTaskRun(context.Background(), storage.TaskRunRecord{
+		TaskID:      "task_stored_finished",
+		SessionID:   "sess_group",
+		RunID:       "run_stored_finished",
+		Title:       "stored finished task",
+		SourceType:  "hover_input",
+		Status:      "completed",
+		CurrentStep: "deliver_result",
+		RiskLevel:   "green",
+		StartedAt:   time.Date(2026, 4, 14, 15, 10, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 4, 14, 15, 15, 0, 0, time.UTC),
+		FinishedAt:  timePointer(time.Date(2026, 4, 14, 15, 16, 0, 0, time.UTC)),
+	})
+	if err != nil {
+		t.Fatalf("save finished task run failed: %v", err)
+	}
+
+	listResult, err := service.TaskList(map[string]any{
+		"group":      "unknown_group",
+		"limit":      float64(10),
+		"offset":     float64(0),
+		"sort_by":    "updated_at",
+		"sort_order": "desc",
+	})
+	if err != nil {
+		t.Fatalf("task list failed: %v", err)
+	}
+
+	items := listResult["items"].([]map[string]any)
+	if len(items) != 1 || items[0]["task_id"] != "task_stored_unfinished" {
+		t.Fatalf("expected unknown group fallback to match runtime unfinished semantics, got %+v", items)
+	}
+}
+
+func TestServiceTaskListFallbackMatchesRuntimeSortTieBreaker(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "stored sort tie")
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+	finishedAt := time.Date(2026, 4, 14, 16, 0, 0, 0, time.UTC)
+	err := service.storage.TaskRunStore().SaveTaskRun(context.Background(), storage.TaskRunRecord{
+		TaskID:      "task_sort_older_update",
+		SessionID:   "sess_sort",
+		RunID:       "run_sort_old",
+		Title:       "older update task",
+		SourceType:  "hover_input",
+		Status:      "completed",
+		CurrentStep: "deliver_result",
+		RiskLevel:   "green",
+		StartedAt:   time.Date(2026, 4, 14, 15, 30, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 4, 14, 15, 40, 0, 0, time.UTC),
+		FinishedAt:  timePointer(finishedAt),
+	})
+	if err != nil {
+		t.Fatalf("save first task run failed: %v", err)
+	}
+	err = service.storage.TaskRunStore().SaveTaskRun(context.Background(), storage.TaskRunRecord{
+		TaskID:      "task_sort_newer_update",
+		SessionID:   "sess_sort",
+		RunID:       "run_sort_new",
+		Title:       "newer update task",
+		SourceType:  "hover_input",
+		Status:      "completed",
+		CurrentStep: "deliver_result",
+		RiskLevel:   "green",
+		StartedAt:   time.Date(2026, 4, 14, 15, 35, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 4, 14, 15, 50, 0, 0, time.UTC),
+		FinishedAt:  timePointer(finishedAt),
+	})
+	if err != nil {
+		t.Fatalf("save second task run failed: %v", err)
+	}
+
+	listResult, err := service.TaskList(map[string]any{
+		"group":      "finished",
+		"limit":      float64(10),
+		"offset":     float64(0),
+		"sort_by":    "finished_at",
+		"sort_order": "desc",
+	})
+	if err != nil {
+		t.Fatalf("task list failed: %v", err)
+	}
+
+	items := listResult["items"].([]map[string]any)
+	if len(items) < 2 || items[0]["task_id"] != "task_sort_newer_update" || items[1]["task_id"] != "task_sort_older_update" {
+		t.Fatalf("expected fallback sort tie-breaker to prefer newer updated_at, got %+v", items)
+	}
+}
+
 func TestServiceDashboardOverviewUsesRuntimeAggregation(t *testing.T) {
 	service := newTestService()
 
@@ -1867,6 +2039,47 @@ func TestServiceSecuritySummaryFallsBackToStoredTaskRuns(t *testing.T) {
 	tokenCostSummary := summary["token_cost_summary"].(map[string]any)
 	if tokenCostSummary["current_task_tokens"] != 88 {
 		t.Fatalf("expected storage-backed token usage, got %+v", tokenCostSummary)
+	}
+}
+
+func TestServiceSecuritySummaryCountsStoredPendingAuthorizations(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "stored waiting auth")
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+
+	err := service.storage.TaskRunStore().SaveTaskRun(context.Background(), storage.TaskRunRecord{
+		TaskID:      "task_waiting_auth_stored",
+		SessionID:   "sess_waiting",
+		RunID:       "run_waiting_auth_stored",
+		Title:       "stored waiting auth task",
+		SourceType:  "hover_input",
+		Status:      "waiting_auth",
+		CurrentStep: "waiting_authorization",
+		RiskLevel:   "yellow",
+		StartedAt:   time.Date(2026, 4, 14, 17, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 4, 14, 17, 5, 0, 0, time.UTC),
+		ApprovalRequest: map[string]any{
+			"approval_id": "appr_waiting_001",
+			"task_id":     "task_waiting_auth_stored",
+			"risk_level":  "yellow",
+		},
+		SecuritySummary: map[string]any{
+			"security_status": "pending_confirmation",
+		},
+	})
+	if err != nil {
+		t.Fatalf("save waiting auth task run failed: %v", err)
+	}
+
+	result, err := service.SecuritySummaryGet()
+	if err != nil {
+		t.Fatalf("security summary failed: %v", err)
+	}
+
+	summary := result["summary"].(map[string]any)
+	if summary["pending_authorizations"] != 1 {
+		t.Fatalf("expected stored waiting_auth task to count as pending authorization, got %+v", summary)
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -1814,6 +1814,62 @@ func TestServiceSecuritySummaryFallsBackToStoredRecoveryPoint(t *testing.T) {
 	}
 }
 
+func TestServiceSecuritySummaryFallsBackToStoredTaskRuns(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "stored security summary")
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+
+	err := service.storage.TaskRunStore().SaveTaskRun(context.Background(), storage.TaskRunRecord{
+		TaskID:      "task_security_finished",
+		SessionID:   "sess_stored",
+		RunID:       "run_security_finished",
+		Title:       "stored security task",
+		SourceType:  "hover_input",
+		Status:      "completed",
+		CurrentStep: "deliver_result",
+		RiskLevel:   "yellow",
+		StartedAt:   time.Date(2026, 4, 14, 13, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 4, 14, 13, 5, 0, 0, time.UTC),
+		FinishedAt:  timePointer(time.Date(2026, 4, 14, 13, 6, 0, 0, time.UTC)),
+		SecuritySummary: map[string]any{
+			"security_status": "recoverable",
+			"latest_restore_point": map[string]any{
+				"recovery_point_id": "rp_security_001",
+				"task_id":           "task_security_finished",
+				"summary":           "stored security recovery point",
+				"created_at":        "2026-04-14T13:06:00Z",
+				"objects":           []string{"workspace/security.md"},
+			},
+		},
+		TokenUsage: map[string]any{
+			"total_tokens":   88,
+			"estimated_cost": 0.42,
+		},
+	})
+	if err != nil {
+		t.Fatalf("save task run failed: %v", err)
+	}
+
+	result, err := service.SecuritySummaryGet()
+	if err != nil {
+		t.Fatalf("security summary failed: %v", err)
+	}
+
+	summary := result["summary"].(map[string]any)
+	if summary["security_status"] != "recoverable" {
+		t.Fatalf("expected storage-backed security status, got %+v", summary)
+	}
+	latestRestorePoint := summary["latest_restore_point"].(map[string]any)
+	if latestRestorePoint["recovery_point_id"] != "rp_security_001" {
+		t.Fatalf("expected storage-backed recovery point from task run, got %+v", latestRestorePoint)
+	}
+	tokenCostSummary := summary["token_cost_summary"].(map[string]any)
+	if tokenCostSummary["current_task_tokens"] != 88 {
+		t.Fatalf("expected storage-backed token usage, got %+v", tokenCostSummary)
+	}
+}
+
 func TestServiceDashboardModuleHighlightsIncludeAuditTrail(t *testing.T) {
 	service, _ := newTestServiceWithExecution(t, "dashboard audit trail")
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -52,6 +52,10 @@ func (s stubModelClient) GenerateText(_ context.Context, request model.GenerateT
 	}, nil
 }
 
+func timePointer(value time.Time) *time.Time {
+	return &value
+}
+
 func newTestServiceWithExecution(t *testing.T, modelOutput string) (*Service, string) {
 	t.Helper()
 
@@ -1347,6 +1351,46 @@ func TestServiceTaskListSupportsSortParams(t *testing.T) {
 	}
 }
 
+func TestServiceTaskListFallsBackToStoredTaskRuns(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "stored task list")
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+
+	err := service.storage.TaskRunStore().SaveTaskRun(context.Background(), storage.TaskRunRecord{
+		TaskID:      "task_stored_001",
+		SessionID:   "sess_stored",
+		RunID:       "run_stored_001",
+		Title:       "stored finished task",
+		SourceType:  "hover_input",
+		Status:      "completed",
+		CurrentStep: "deliver_result",
+		RiskLevel:   "green",
+		StartedAt:   time.Date(2026, 4, 14, 9, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 4, 14, 9, 5, 0, 0, time.UTC),
+		FinishedAt:  timePointer(time.Date(2026, 4, 14, 9, 6, 0, 0, time.UTC)),
+	})
+	if err != nil {
+		t.Fatalf("save task run failed: %v", err)
+	}
+
+	listResult, err := service.TaskList(map[string]any{
+		"group":      "finished",
+		"limit":      float64(10),
+		"offset":     float64(0),
+		"sort_by":    "updated_at",
+		"sort_order": "desc",
+	})
+	if err != nil {
+		t.Fatalf("task list failed: %v", err)
+	}
+
+	items := listResult["items"].([]map[string]any)
+	if len(items) != 1 || items[0]["task_id"] != "task_stored_001" {
+		t.Fatalf("expected storage-backed task list item, got %+v", items)
+	}
+}
+
 func TestServiceDashboardOverviewUsesRuntimeAggregation(t *testing.T) {
 	service := newTestService()
 
@@ -1834,6 +1878,53 @@ func TestServiceTaskDetailGetPreservesStableContractShape(t *testing.T) {
 	}
 	if detailResult["task"].(map[string]any)["task_id"] != taskID {
 		t.Fatalf("expected task detail task_id to match request, got %+v", detailResult["task"])
+	}
+}
+
+func TestServiceTaskDetailGetFallsBackToStoredTaskRun(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "stored task detail")
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+
+	err := service.storage.TaskRunStore().SaveTaskRun(context.Background(), storage.TaskRunRecord{
+		TaskID:      "task_stored_detail",
+		SessionID:   "sess_stored",
+		RunID:       "run_stored_detail",
+		Title:       "stored detail task",
+		SourceType:  "hover_input",
+		Status:      "completed",
+		CurrentStep: "deliver_result",
+		RiskLevel:   "green",
+		StartedAt:   time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 4, 14, 10, 5, 0, 0, time.UTC),
+		FinishedAt:  timePointer(time.Date(2026, 4, 14, 10, 6, 0, 0, time.UTC)),
+		Timeline: []storage.TaskStepSnapshot{{
+			StepID:        "step_deliver_result",
+			TaskID:        "task_stored_detail",
+			Name:          "deliver_result",
+			Status:        "completed",
+			OrderIndex:    1,
+			InputSummary:  "stored input",
+			OutputSummary: "stored output",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("save task run failed: %v", err)
+	}
+
+	detailResult, err := service.TaskDetailGet(map[string]any{"task_id": "task_stored_detail"})
+	if err != nil {
+		t.Fatalf("task detail get failed: %v", err)
+	}
+
+	task := detailResult["task"].(map[string]any)
+	if task["task_id"] != "task_stored_detail" || task["title"] != "stored detail task" {
+		t.Fatalf("expected storage-backed task detail, got %+v", task)
+	}
+	timeline := detailResult["timeline"].([]map[string]any)
+	if len(timeline) != 1 || timeline[0]["name"] != "deliver_result" {
+		t.Fatalf("expected storage-backed timeline, got %+v", timeline)
 	}
 }
 


### PR DESCRIPTION
## Summary

- fall back to stored task runs for `agent.task.list` and `agent.task.detail.get` when runtime state is empty
- backfill `agent.mirror.overview.get` and `agent.dashboard.module.get` from persisted finished task runs
- aggregate `agent.security.summary.get` from stored task runs so security status, recovery points, and token usage survive runtime loss

## Why

Several owner-4 read APIs were still effectively runtime-only. After restart or when runtime state is unavailable, stable task-centric query surfaces could return empty or incomplete results even though the task/run snapshots had already been persisted.

This change keeps the existing RPC contract intact while making task, dashboard, mirror, and security read paths prefer runtime data and cleanly fall back to stored task-run snapshots.

## Testing

- `go test ./services/local-service/internal/orchestrator ./services/local-service/internal/rpc`