### PR TITLE
ci: run desktop tauri build only when apps/desktop changes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      desktop: ${{ steps.filter.outputs.desktop }}
+  
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+  
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            desktop:
+              - 'CialloClaw/apps/desktop/**'
+
   test:
     runs-on: ubuntu-latest
 
@@ -33,3 +55,53 @@ jobs:
           token: ${{secrets.CODECOV_TOKEN}}
           disable_search: true
           files: coverage.out
+  desktop:
+    needs: changes
+    if: ${{ needs.changes.outputs.desktop == 'true' }}
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: CialloClaw/apps/desktop
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: CialloClaw/pnpm-lock.yaml
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Tauri dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        run: pnpm build
+
+      - name: Build Tauri app
+        run: pnpm tauri build --debug


### PR DESCRIPTION
## Summary

This PR updates the GitHub Actions CI workflow to add a desktop job for the Tauri app.

## Changes

- add a `changes` job to detect modifications under `CialloClaw/apps/desktop/**`
- add a `desktop` job that runs only when desktop files are changed
- install Node.js, pnpm, and Tauri build dependencies in CI
- run frontend build and Tauri debug build for the desktop app
- keep existing Go test and code coverage workflow unchanged

## Why

Previously, CI only covered Go tests and did not verify the desktop frontend/Tauri app.
This change ensures desktop-related changes are validated in CI without running the desktop build on unrelated changes.

## Notes

- `desktop` job is skipped when files outside `CialloClaw/apps/desktop/**` are changed
- existing backend test workflow remains unchanged