### PR TITLE
ci(desktop): add frontend workflow

### DIFF
--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -27,37 +27,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  desktop-contracts:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.6.1
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install workspace dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Typecheck desktop workspace
-        run: pnpm --filter @cialloclaw/desktop typecheck
-
-      - name: Run shell ball contract tests
-        run: pnpm --filter @cialloclaw/desktop test:shell-ball
-
-      - name: Run memory contract tests
-        run: pnpm --filter @cialloclaw/desktop test:memory
-
   desktop-windows-build:
     runs-on: windows-latest
 

--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -68,4 +68,5 @@ jobs:
         run: pnpm --filter @cialloclaw/desktop build
 
       - name: Build Tauri app
-        run: pnpm --dir apps/desktop tauri build --debug
+        working-directory: apps/desktop
+        run: pnpm exec tauri build --debug

--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -1,0 +1,71 @@
+name: Desktop Test
+
+on:
+  push:
+    paths:
+      - ".github/workflows/desktop-test.yml"
+      - "apps/desktop/**"
+      - "packages/protocol/**"
+      - "packages/ui/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+  pull_request:
+    paths:
+      - ".github/workflows/desktop-test.yml"
+      - "apps/desktop/**"
+      - "packages/protocol/**"
+      - "packages/ui/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  desktop:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Tauri dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build desktop frontend
+        run: pnpm --filter @cialloclaw/desktop build
+
+      - name: Build Tauri app
+        run: pnpm --dir apps/desktop tauri build --debug

--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/desktop-test.yml"
       - "apps/desktop/**"
+      - "packages/config/**"
       - "packages/protocol/**"
       - "packages/ui/**"
       - "package.json"
@@ -14,6 +15,7 @@ on:
     paths:
       - ".github/workflows/desktop-test.yml"
       - "apps/desktop/**"
+      - "packages/config/**"
       - "packages/protocol/**"
       - "packages/ui/**"
       - "package.json"
@@ -25,8 +27,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  desktop:
+  desktop-contracts:
     runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck desktop workspace
+        run: pnpm --filter @cialloclaw/desktop typecheck
+
+      - name: Run shell ball contract tests
+        run: pnpm --filter @cialloclaw/desktop test:shell-ball
+
+      - name: Run memory contract tests
+        run: pnpm --filter @cialloclaw/desktop test:memory
+
+  desktop-windows-build:
+    runs-on: windows-latest
 
     steps:
       - name: Check out code
@@ -47,26 +80,9 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install Tauri dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            build-essential \
-            curl \
-            wget \
-            file \
-            libxdo-dev \
-            libssl-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev
-
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build desktop frontend
-        run: pnpm --filter @cialloclaw/desktop build
-
-      - name: Build Tauri app
+      - name: Build Windows Tauri app
         working-directory: apps/desktop
-        run: pnpm exec tauri build --debug
+        run: pnpm exec tauri build --debug --no-bundle


### PR DESCRIPTION
## Summary
- add a dedicated desktop frontend GitHub Actions workflow
- use native path filters for desktop and workspace dependency changes
- keep the existing Go test workflow separate

## Changes
- add `.github/workflows/desktop-test.yml`
- trigger only when desktop or its workspace dependencies change
- install workspace dependencies with pnpm
- build the desktop frontend
- build the Tauri desktop app in debug mode

## Notes
- existing Go CI in `.github/workflows/check.yml` is unchanged
- this PR does not change protocol, data schema, or runtime logic
