### PR TITLE
feat(workers): wire OCR, media, and Playwright runtimes

### DIFF
--- a/workers/playwright-worker/src/index.js
+++ b/workers/playwright-worker/src/index.js
@@ -65,6 +65,14 @@ async function closeIfPossible(target, methodName) {
   }
 }
 
+async function closeResources(context, browser) {
+  try {
+    await closeIfPossible(context, "close");
+  } finally {
+    await closeIfPossible(browser, "close");
+  }
+}
+
 async function openBrowserPage(url, deps, callback) {
   const browser = await deps.launchBrowser();
   let context;
@@ -83,8 +91,7 @@ async function openBrowserPage(url, deps, callback) {
     }
     return await callback(page, response);
   } finally {
-    await closeIfPossible(context, "close");
-    await closeIfPossible(browser, "close");
+    await closeResources(context, browser);
   }
 }
 
@@ -105,8 +112,7 @@ export async function healthResponse(deps = defaultDependencies) {
       },
     };
   } finally {
-    await closeIfPossible(context, "close");
-    await closeIfPossible(browser, "close");
+    await closeResources(context, browser);
   }
 }
 
@@ -144,6 +150,37 @@ async function buildStructuredDOM(url, deps) {
 
 function pageActionTarget(page, selector) {
   return page.locator(selector).first();
+}
+
+function actionNeedsSelector(type) {
+  switch (type) {
+    case "click":
+    case "fill":
+    case "press":
+    case "check":
+    case "uncheck":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function validatePageActions(actions) {
+  for (const action of actions) {
+    const type = String(action?.type ?? "").trim().toLowerCase();
+    const selector = String(action?.selector ?? "").trim();
+    const missingSelector = actionNeedsSelector(type) || (type === "wait_for" && selector === "" && Object.prototype.hasOwnProperty.call(action ?? {}, "selector"));
+    if (missingSelector && selector === "") {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_input",
+          message: `selector is required for page_interact action type '${type}'`,
+        },
+      };
+    }
+  }
+  return null;
 }
 
 async function interactWithPage(url, actions, deps) {
@@ -246,11 +283,16 @@ export async function handleRequest(request, deps = defaultDependencies) {
       };
     }
     case "page_interact": {
+      const actions = Array.isArray(request.actions) ? request.actions : [];
+      const validationError = validatePageActions(actions);
+      if (validationError) {
+        return validationError;
+      }
       return {
         ok: true,
         result: await interactWithPage(
           String(request.url ?? ""),
-          Array.isArray(request.actions) ? request.actions : [],
+          actions,
           deps,
         ),
       };

--- a/workers/playwright-worker/src/index.js
+++ b/workers/playwright-worker/src/index.js
@@ -1,10 +1,18 @@
+import path from "node:path";
 import { stdin as input, stdout as output, stderr as errorOutput } from "node:process";
-import { chromium } from "playwright";
+import { fileURLToPath } from "node:url";
 
-const manifest = {
+export const manifest = {
   worker_name: "playwright_worker",
   transport: ["stdio", "jsonrpc"],
   capabilities: ["page_read", "page_search", "page_interact", "structured_dom"],
+};
+
+const browserTimeoutMS = 15000;
+const workerUserAgent = "CialloClawPlaywrightWorker/0.1";
+
+const defaultDependencies = {
+  launchBrowser,
 };
 
 function readAllStdin() {
@@ -19,8 +27,10 @@ function readAllStdin() {
   });
 }
 
-function normalizeText(html) {
-  return html
+// normalizeText removes markup noise so page content is stable for summaries,
+// searching, and contract tests across worker/runtime boundaries.
+export function normalizeText(html) {
+  return String(html ?? "")
     .replace(/<script[\s\S]*?<\/script>/gi, " ")
     .replace(/<style[\s\S]*?<\/style>/gi, " ")
     .replace(/<[^>]+>/g, " ")
@@ -33,7 +43,7 @@ function normalizeText(html) {
 }
 
 function extractTitle(html, url) {
-  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const titleMatch = String(html ?? "").match(/<title[^>]*>([\s\S]*?)<\/title>/i);
   if (titleMatch?.[1]) {
     return normalizeText(titleMatch[1]);
   }
@@ -44,16 +54,26 @@ function extractTitle(html, url) {
   }
 }
 
-async function fetchPage(url) {
-  const browser = await chromium.launch({ headless: true });
+async function launchBrowser() {
+  const { chromium } = await import("playwright");
+  return chromium.launch({ headless: true });
+}
+
+async function closeIfPossible(target, methodName) {
+  if (target && typeof target[methodName] === "function") {
+    await target[methodName]();
+  }
+}
+
+async function openBrowserPage(url, deps, callback) {
+  const browser = await deps.launchBrowser();
+  let context;
   try {
-    const context = await browser.newContext({
-      userAgent: "CialloClawPlaywrightWorker/0.1",
-    });
+    context = await browser.newContext({ userAgent: workerUserAgent });
     const page = await context.newPage();
     const response = await page.goto(url, {
       waitUntil: "networkidle",
-      timeout: 15000,
+      timeout: browserTimeoutMS,
     });
     if (!response) {
       throw new Error("navigation_failed");
@@ -61,6 +81,37 @@ async function fetchPage(url) {
     if (!response.ok()) {
       throw new Error(`http_${response.status()}`);
     }
+    return await callback(page, response);
+  } finally {
+    await closeIfPossible(context, "close");
+    await closeIfPossible(browser, "close");
+  }
+}
+
+// healthResponse validates that the worker can load Playwright, start a browser,
+// and create a fresh page before the Go runtime marks the sidecar as ready.
+export async function healthResponse(deps = defaultDependencies) {
+  const browser = await deps.launchBrowser();
+  let context;
+  try {
+    context = await browser.newContext({ userAgent: workerUserAgent });
+    await context.newPage();
+    return {
+      ok: true,
+      result: {
+        status: "ok",
+        worker_name: manifest.worker_name,
+        capabilities: manifest.capabilities,
+      },
+    };
+  } finally {
+    await closeIfPossible(context, "close");
+    await closeIfPossible(browser, "close");
+  }
+}
+
+async function fetchPage(url, deps) {
+  return openBrowserPage(url, deps, async (page, response) => {
     const html = await page.content();
     const bodyText = await page.locator("body").innerText().catch(() => html);
     const contentType = response.headers()["content-type"] ?? "text/html";
@@ -71,36 +122,11 @@ async function fetchPage(url) {
       textContent: normalizeText(bodyText),
       contentType,
     };
-  } finally {
-    await browser.close();
-  }
+  });
 }
 
-async function withPage(url, callback) {
-  const browser = await chromium.launch({ headless: true });
-  try {
-    const context = await browser.newContext({
-      userAgent: "CialloClawPlaywrightWorker/0.1",
-    });
-    const page = await context.newPage();
-    const response = await page.goto(url, {
-      waitUntil: "networkidle",
-      timeout: 15000,
-    });
-    if (!response) {
-      throw new Error("navigation_failed");
-    }
-    if (!response.ok()) {
-      throw new Error(`http_${response.status()}`);
-    }
-    return await callback(page, response);
-  } finally {
-    await browser.close();
-  }
-}
-
-async function buildStructuredDOM(url) {
-  return withPage(url, async (page) => {
+async function buildStructuredDOM(url, deps) {
+  return openBrowserPage(url, deps, async (page) => {
     const snapshot = await page.evaluate(() => ({
       headings: Array.from(document.querySelectorAll("h1, h2, h3")).map((node) => node.textContent?.trim()).filter(Boolean).slice(0, 20),
       links: Array.from(document.querySelectorAll("a[href]")).map((node) => node.textContent?.trim() || node.getAttribute("href") || "").filter(Boolean).slice(0, 20),
@@ -116,36 +142,40 @@ async function buildStructuredDOM(url) {
   });
 }
 
-async function interactWithPage(url, actions) {
-  return withPage(url, async (page) => {
+function pageActionTarget(page, selector) {
+  return page.locator(selector).first();
+}
+
+async function interactWithPage(url, actions, deps) {
+  return openBrowserPage(url, deps, async (page) => {
     let applied = 0;
     for (const action of actions) {
       const type = String(action?.type ?? "").trim().toLowerCase();
       const selector = String(action?.selector ?? "").trim();
       switch (type) {
         case "click":
-          await page.locator(selector).first().click({ timeout: 10000 });
+          await pageActionTarget(page, selector).click({ timeout: 10000 });
           applied += 1;
           break;
         case "fill":
-          await page.locator(selector).first().fill(String(action?.value ?? ""), { timeout: 10000 });
+          await pageActionTarget(page, selector).fill(String(action?.value ?? ""), { timeout: 10000 });
           applied += 1;
           break;
         case "press":
-          await page.locator(selector).first().press(String(action?.key ?? "Enter"), { timeout: 10000 });
+          await pageActionTarget(page, selector).press(String(action?.key ?? "Enter"), { timeout: 10000 });
           applied += 1;
           break;
         case "check":
-          await page.locator(selector).first().check({ timeout: 10000 });
+          await pageActionTarget(page, selector).check({ timeout: 10000 });
           applied += 1;
           break;
         case "uncheck":
-          await page.locator(selector).first().uncheck({ timeout: 10000 });
+          await pageActionTarget(page, selector).uncheck({ timeout: 10000 });
           applied += 1;
           break;
         case "wait_for":
           if (selector) {
-            await page.locator(selector).first().waitFor({ timeout: 10000 });
+            await pageActionTarget(page, selector).waitFor({ timeout: 10000 });
           } else {
             await page.waitForTimeout(Number(action?.timeout_ms ?? 500));
           }
@@ -167,25 +197,14 @@ async function interactWithPage(url, actions) {
   });
 }
 
-async function verifyBrowserReady() {
-  const browser = await chromium.launch({ headless: true });
-  await browser.close();
-}
-
-async function handleRequest(request) {
+// handleRequest keeps the worker protocol stable for the Go sidecar runtime and
+// is exported so worker-level tests can exercise real request/response shapes.
+export async function handleRequest(request, deps = defaultDependencies) {
   switch (request.action) {
     case "health":
-      await verifyBrowserReady();
-      return {
-        ok: true,
-        result: {
-          status: "ok",
-          worker_name: manifest.worker_name,
-          capabilities: manifest.capabilities,
-        },
-      };
+      return healthResponse(deps);
     case "page_read": {
-      const page = await fetchPage(request.url);
+      const page = await fetchPage(String(request.url ?? ""), deps);
       return {
         ok: true,
         result: {
@@ -199,21 +218,21 @@ async function handleRequest(request) {
       };
     }
     case "page_search": {
-      const page = await fetchPage(request.url);
-      const normalizedQuery = request.query.trim().toLowerCase();
+      const page = await fetchPage(String(request.url ?? ""), deps);
+      const normalizedQuery = String(request.query ?? "").trim().toLowerCase();
       const rawLimit = Number(request.limit ?? 0);
       const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.floor(rawLimit) : 5;
       const segments = page.textContent
         .split(/[.!?。！？]\s*/)
         .map((segment) => segment.trim())
         .filter(Boolean);
-      const allMatches = segments.filter((segment) => segment.toLowerCase().includes(normalizedQuery));
+      const allMatches = normalizedQuery === "" ? [] : segments.filter((segment) => segment.toLowerCase().includes(normalizedQuery));
       const matches = allMatches.slice(0, limit);
       return {
         ok: true,
         result: {
           url: page.url,
-          query: request.query,
+          query: String(request.query ?? ""),
           match_count: allMatches.length,
           matches,
           source: "playwright_worker_browser",
@@ -223,13 +242,17 @@ async function handleRequest(request) {
     case "structured_dom": {
       return {
         ok: true,
-        result: await buildStructuredDOM(request.url),
+        result: await buildStructuredDOM(String(request.url ?? ""), deps),
       };
     }
     case "page_interact": {
       return {
         ok: true,
-        result: await interactWithPage(request.url, Array.isArray(request.actions) ? request.actions : []),
+        result: await interactWithPage(
+          String(request.url ?? ""),
+          Array.isArray(request.actions) ? request.actions : [],
+          deps,
+        ),
       };
     }
     default:
@@ -241,6 +264,10 @@ async function handleRequest(request) {
         },
       };
   }
+}
+
+function isMainModule() {
+  return process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 }
 
 async function main() {
@@ -256,16 +283,18 @@ async function main() {
   output.write(`${JSON.stringify(response)}\n`);
 }
 
-main().catch((error) => {
-  const message = error instanceof Error ? error.message : String(error);
-  const response = {
-    ok: false,
-    error: {
-      code: "worker_failed",
-      message,
-    },
-  };
-  errorOutput.write(`${message}\n`);
-  output.write(`${JSON.stringify(response)}\n`);
-  process.exitCode = 1;
-});
+if (isMainModule()) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    const response = {
+      ok: false,
+      error: {
+        code: "worker_failed",
+        message,
+      },
+    };
+    errorOutput.write(`${message}\n`);
+    output.write(`${JSON.stringify(response)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/workers/playwright-worker/src/index.test.js
+++ b/workers/playwright-worker/src/index.test.js
@@ -79,12 +79,18 @@ function createDeps(overrides = {}) {
       return {
         async close() {
           lifecycle.push("browser.close");
+          if (overrides.browserCloseError) {
+            throw overrides.browserCloseError;
+          }
         },
         async newContext() {
           lifecycle.push("newContext");
           return {
             async close() {
               lifecycle.push("context.close");
+              if (overrides.contextCloseError) {
+                throw overrides.contextCloseError;
+              }
             },
             async newPage() {
               lifecycle.push("newPage");
@@ -107,6 +113,16 @@ test("health verifies browser startup and page creation", async () => {
 
   assert.equal(response.ok, true);
   assert.equal(response.result.status, "ok");
+  assert.deepEqual(lifecycle, ["launch", "newContext", "newPage", "context.close", "browser.close"]);
+});
+
+test("health still closes browser when context cleanup fails", async () => {
+  const lifecycle = [];
+  await assert.rejects(
+    () => healthResponse(createDeps({ lifecycle, contextCloseError: new Error("context close failed") })),
+    /context close failed/,
+  );
+
   assert.deepEqual(lifecycle, ["launch", "newContext", "newPage", "context.close", "browser.close"]);
 });
 
@@ -165,6 +181,20 @@ test("page_interact applies actions and returns updated content", async () => {
   assert.equal(response.result.actions_applied, 3);
   assert.equal(response.result.text_content, "Interaction complete");
   assert.deepEqual(actionLog.map((entry) => entry.action), ["click", "fill", "waitForTimeout"]);
+});
+
+test("page_interact rejects selector actions without selectors", async () => {
+  const response = await handleRequest({
+    action: "page_interact",
+    url: "https://example.com",
+    actions: [
+      { type: "click" },
+    ],
+  }, createDeps());
+
+  assert.equal(response.ok, false);
+  assert.equal(response.error.code, "invalid_input");
+  assert.match(response.error.message, /selector is required/);
 });
 
 test("unsupported action stays structured", async () => {

--- a/workers/playwright-worker/src/index.test.js
+++ b/workers/playwright-worker/src/index.test.js
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { handleRequest, healthResponse, normalizeText } from "./index.js";
+
+function createResponse(overrides = {}) {
+  return {
+    headers: () => ({ "content-type": overrides.contentType ?? "text/html; charset=utf-8" }),
+    ok: () => overrides.ok ?? true,
+    status: () => overrides.status ?? 200,
+  };
+}
+
+function createPage(overrides = {}) {
+  const actionLog = overrides.actionLog ?? [];
+  const page = {
+    currentURL: overrides.currentURL ?? "https://example.com/final",
+    async content() {
+      return overrides.html ?? "<html><head><title>Demo Page</title></head><body>Hello world. Search target. Another target.</body></html>";
+    },
+    async evaluate() {
+      return overrides.snapshot ?? {
+        headings: ["Heading A"],
+        links: ["Docs"],
+        buttons: ["Submit"],
+        inputs: ["email"],
+      };
+    },
+    goto: async (url) => {
+      page.currentURL = overrides.gotoURL ?? url;
+      return overrides.response ?? createResponse();
+    },
+    locator: (selector) => ({
+      async innerText() {
+        return overrides.bodyText ?? "Hello world. Search target. Another target.";
+      },
+      first() {
+        return {
+          async check(options) {
+            actionLog.push({ action: "check", options, selector });
+          },
+          async click(options) {
+            actionLog.push({ action: "click", options, selector });
+          },
+          async fill(value, options) {
+            actionLog.push({ action: "fill", options, selector, value });
+          },
+          async press(key, options) {
+            actionLog.push({ action: "press", key, options, selector });
+          },
+          async uncheck(options) {
+            actionLog.push({ action: "uncheck", options, selector });
+          },
+          async waitFor(options) {
+            actionLog.push({ action: "waitFor", options, selector });
+          },
+        };
+      },
+    }),
+    async title() {
+      return overrides.title ?? "Demo Page";
+    },
+    url() {
+      return page.currentURL;
+    },
+    async waitForTimeout(timeoutMS) {
+      actionLog.push({ action: "waitForTimeout", timeoutMS });
+    },
+  };
+  return page;
+}
+
+function createDeps(overrides = {}) {
+  const page = overrides.page ?? createPage(overrides);
+  const lifecycle = overrides.lifecycle ?? [];
+  return {
+    async launchBrowser() {
+      lifecycle.push("launch");
+      return {
+        async close() {
+          lifecycle.push("browser.close");
+        },
+        async newContext() {
+          lifecycle.push("newContext");
+          return {
+            async close() {
+              lifecycle.push("context.close");
+            },
+            async newPage() {
+              lifecycle.push("newPage");
+              return page;
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+test("normalizeText removes markup noise", () => {
+  assert.equal(normalizeText("<div>Hello&nbsp;<strong>world</strong></div>"), "Hello world");
+});
+
+test("health verifies browser startup and page creation", async () => {
+  const lifecycle = [];
+  const response = await healthResponse(createDeps({ lifecycle }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.status, "ok");
+  assert.deepEqual(lifecycle, ["launch", "newContext", "newPage", "context.close", "browser.close"]);
+});
+
+test("page_read returns normalized page metadata", async () => {
+  const response = await handleRequest({ action: "page_read", url: "https://example.com" }, createDeps({
+    bodyText: "Hello world from browser",
+    gotoURL: "https://example.com/article",
+    title: "Example Article",
+  }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.url, "https://example.com/article");
+  assert.equal(response.result.title, "Example Article");
+  assert.equal(response.result.text_content, "Hello world from browser");
+  assert.equal(response.result.source, "playwright_worker_browser");
+});
+
+test("page_search returns bounded matches", async () => {
+  const response = await handleRequest({ action: "page_search", url: "https://example.com", query: "target", limit: 1 }, createDeps({
+    bodyText: "First target. Second target. Third miss.",
+  }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.match_count, 2);
+  assert.deepEqual(response.result.matches, ["First target"]);
+});
+
+test("structured_dom returns page snapshot", async () => {
+  const response = await handleRequest({ action: "structured_dom", url: "https://example.com" }, createDeps({
+    snapshot: {
+      headings: ["Heading A", "Heading B"],
+      links: ["Docs"],
+      buttons: ["Submit"],
+      inputs: ["email"],
+    },
+  }));
+
+  assert.equal(response.ok, true);
+  assert.deepEqual(response.result.headings, ["Heading A", "Heading B"]);
+  assert.deepEqual(response.result.links, ["Docs"]);
+});
+
+test("page_interact applies actions and returns updated content", async () => {
+  const actionLog = [];
+  const response = await handleRequest({
+    action: "page_interact",
+    url: "https://example.com",
+    actions: [
+      { type: "click", selector: "button.submit" },
+      { type: "fill", selector: "input[name=email]", value: "demo@example.com" },
+      { type: "wait_for", timeout_ms: 250 },
+    ],
+  }, createDeps({ actionLog, bodyText: "Interaction complete" }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.actions_applied, 3);
+  assert.equal(response.result.text_content, "Interaction complete");
+  assert.deepEqual(actionLog.map((entry) => entry.action), ["click", "fill", "waitForTimeout"]);
+});
+
+test("unsupported action stays structured", async () => {
+  const response = await handleRequest({ action: "unsupported" }, createDeps());
+
+  assert.equal(response.ok, false);
+  assert.equal(response.error.code, "unsupported_action");
+});


### PR DESCRIPTION
## 摘要

- 将 OCR、媒体和高级 Playwright 运行时集成到本地服务执行路径中，包含健康检查、错误映射和工作器元数据通知
- 标准化任务详情和产物 RPC 输出，确保工作器/运行时结果保持协议安全且可从仪表板打开
- 通过将媒体风险检查绑定到实际输出目标，并通过专用测试强化 OCR/Playwright 工作器契约，解决后续治理和工作器审查缺口

## 变更内容

### Worker 和 sidecar 集成

- 为 `extract_text`、`ocr_image` 和 `ocr_pdf` 添加了真实的 OCR 工作器支持
- 为 `transcode_media`、`normalize_recording` 和 `extract_frames` 添加了真实的媒体工作器支持
- 完成了 Playwright 运行时对 `page_read`、`page_search`、`page_interact` 和 `structured_dom` 的支持
- 连接了引导/运行时设置，使工作器可用性、就绪状态和故障清理在 Go 服务内部处理，而不是泄漏到前端
- 扩展了错误映射，使工作器故障被包装到稳定的后端错误处理路径中

### 结果和任务详情契约修复

- 使用工作器/源/输出元数据（如 `source`、`path`、`url` 和 `output_path`）丰富了 `tool_call.completed` 通知
- 将 `agent.task.detail.get`、`agent.task.artifact.list`、`agent.task.artifact.open` 和 `agent.delivery.open` 输出标准化为正式的协议安全形状
- 确保 `timeline`、`artifacts` 和 `mirror_references` 保持为数组，而不是返回 `null`
- 补充了稳定的运行时 `artifact_id` 值，使仅运行时产物可以被一致地列出、打开和持久化

### 治理和工作器强化后续工作

- 更新了治理目标选择，使媒体工具针对其实际写入目标（`output_path` / `output_dir`）进行评估，而不是源输入路径
- 更新了风险预检查和评估逻辑，使媒体输出写入参与审批/检查点和工作区外保护
- 强化了 OCR 工作器健康检查，在报告就绪之前验证所需二进制文件
- 按文件类型路由 OCR 文本提取，并添加了扫描 PDF OCR 回退
- 强化了 Playwright 工作器健康契约，使就绪状态验证真实浏览器启动，并且可以在请求/响应层直接测试工作器

### 测试和文档

- 在引导、执行、协调器、运行引擎、风险、sidecar 运行时、OCR 工作器、媒体工作器和 Playwright 工作器流程中添加和扩展了测试
- 为 `workers/ocr-worker` 和 `workers/playwright-worker` 添加了工作器级契约测试
- 更新了 `docs/module-design.md` 和 `docs/work-priority-plan.md`，以反映已完成的工作器/运行时功能和通知流程

## 原因

前端真实 RPC 集成在某些基于工作器的任务上仍然失败，因为任务详情和产物响应可能泄漏仅运行时形状或 `null` 集合。

同时，新的工作器路径仍有一些治理和就绪性缺口：
- 媒体写入审批检查了错误的目标
- OCR 就绪性可能在没有所需二进制文件的情况下报告成功
- Playwright 工作器健康状况和请求处理在工作器边界无法直接测试

此 PR 在将工作器输出保持在正式的 `tool_call -> event -> delivery_result / artifact` 链中的同时，解决了这些缺口。

## 测试

### 后端

- `go test ./services/local-service/internal/bootstrap ./services/local-service/internal/delivery ./services/local-service/internal/execution ./services/local-service/internal/orchestrator ./services/local-service/internal/runengine ./services/local-service/internal/tools ./services/local-service/internal/tools/sidecarclient ./services/local-service/internal/risk`
- `go test -cover ./services/local-service/internal/tools/sidecarclient ./services/local-service/internal/execution ./services/local-service/internal/orchestrator`

### 工作器

- `node --check workers/ocr-worker/src/index.js`
- `node --test --experimental-test-coverage workers/ocr-worker/src/index.test.js`
- `node --check workers/playwright-worker/src/index.js`
- `node --test --experimental-test-coverage workers/playwright-worker/src/index.test.js`
- `node --check workers/media-worker/src/index.js`