### PR TITLE
feat(notes): build owner-5 notes foundation

### DIFF
--- a/docs/data-design.md
+++ b/docs/data-design.md
@@ -170,6 +170,9 @@
 - TodoItem 与 Task 明确分层：TodoItem 表示未来安排或巡检事项，Task 表示已进入执行。
 - RecurringRule 描述重复规则，不直接等同于任务实例。
 - TodoItem 可关联一个或多个 RecurringRule，也可在人工确认后转换为 Task。
+- `notes` 详情补强继续挂在既有 `todo_items / recurring_rules` 语义上推进，不新增独立 `note_details` 或平行读模型真源表。
+- owner-5 为 notes 详情预留的底座字段优先落在既有对象扩展上：`todo_items` 侧承接 `note_text / prerequisite / planned_at / ended_at / related_resources`，`recurring_rules` 侧承接 `repeat_rule_text / next_occurrence_at / recent_instance_status / effective_scope / recurring_enabled`。
+- notes 动作底座（complete / cancel / restore / toggle-recurring / delete）应直接更新既有 `todo_items / recurring_rules` 生命周期，不得绕过它们直接改写 `tasks`。
 - MemorySummary、MemoryCandidate、RetrievalHit 通过引用关联 Task 与 Run，不混存原始运行态。
 - SkillManifest、BlueprintDefinition、PromptTemplateVersion 与具体 Run 之间必须可追踪，便于 Trace / Eval、回放和问题定位。
 - TraceRecord、EvalSnapshot、Hook 记录、审查结果和熔断事件应与 Task / Run / Step 形成稳定引用关系。
@@ -201,6 +204,12 @@
 | `prompt_template_versions` | Prompt 模板 | 前馈层 | Prompt Composer | Prompt 版本 |
 | `trace_records` | 运行轨迹 | 排障、Eval | Trace Engine | LLM、规则、延迟、成本 |
 | `eval_snapshots` | 评估快照 | Eval、回放 | Eval Engine | 质量和回归结果 |
+
+### 5.6 Notes detail enrichment guidance
+
+- 当前 notes 详情补强属于 owner-5 数据底座准备工作，而不是新增协议对象。
+- 运行态可以先维护 richer note metadata，RPC 暴露前必须由 4 号在 `packages/protocol` 冻结字段与方法。
+- 如果后续需要持久化 notes 详情补强字段，应扩展既有 `todo_items / recurring_rules` 存储结构，而不是新建平行真源。
 
 ---
 

--- a/docs/data-design.md
+++ b/docs/data-design.md
@@ -421,6 +421,11 @@ CREATE TABLE todo_items (
     due_at TEXT,                                 -- 截止时间
     tags_json TEXT,                              -- 标签(JSON)
     agent_suggestion TEXT,                       -- Agent建议
+    note_text TEXT,                              -- 备注正文/详情摘要
+    prerequisite TEXT,                           -- 前置条件
+    planned_at TEXT,                             -- 原计划时间
+    ended_at TEXT,                               -- 结束时间
+    related_resources_json TEXT,                 -- 相关资料(JSON)
     linked_task_id TEXT,                         -- 转任务后的task_id
     created_at TEXT NOT NULL,                    -- 创建时间
     updated_at TEXT NOT NULL                     -- 更新时间
@@ -441,6 +446,10 @@ CREATE TABLE recurring_rules (
     interval_unit TEXT,                          -- 间隔单位(day/week/month)
     reminder_strategy TEXT NOT NULL,             -- 提醒策略
     enabled INTEGER NOT NULL DEFAULT 1,          -- 是否启用
+    repeat_rule_text TEXT,                       -- 规则展示文本
+    next_occurrence_at TEXT,                     -- 下次发生时间
+    recent_instance_status TEXT,                 -- 最近一次状态
+    effective_scope TEXT,                        -- 生效范围
     created_at TEXT NOT NULL,                    -- 创建时间
     updated_at TEXT NOT NULL,                    -- 更新时间,
     FOREIGN KEY(item_id) REFERENCES todo_items(item_id)

--- a/docs/module-design.md
+++ b/docs/module-design.md
@@ -605,6 +605,14 @@ flowchart TB
 - 前端工作台负责呈现事项桶与转任务入口；
 - 后端巡检服务、规则引擎和 `agent.notepad.convert_to_task` 负责正式升级。
 
+当前 owner-5 底座约束：
+
+- `notes` 详情补强优先复用现有 `TodoItem / RecurringRule` 数据来源，不新增独立底座对象名；
+- 详情补强字段（如 `note_text`、`prerequisite`、`planned_at`、`ended_at`、`related_resources`）先在后端运行态与后续存储扩展层准备，不直接绕过协议暴露；
+- 重复事项补强字段（如 `repeat_rule_text`、`next_occurrence_at`、`recent_instance_status`、`effective_scope`、`recurring_enabled`）属于规则引擎与巡检底座职责；
+- complete / cancel / restore / toggle-recurring / delete 等事项动作，先由 owner-5 提供真实状态变更底座，再由 4 号冻结正式 RPC 面；
+- “打开相关资料”先由 owner-5 提供资源归一化与目标类型判断底座，是否进入稳定 open RPC 由 4 号统一收口。
+
 ### 3.7.4 镜子记忆与长期协作域
 
 镜子不是聊天记录页，而是长期协作的认知层，用于沉淀短期记忆、长期记忆和镜子总结。该功能域与运行态状态机严格分层，长期记忆支持本地 RAG 检索，但写入与检索都必须通过 Memory 内核统一接入。

--- a/services/local-service/internal/bootstrap/bootstrap.go
+++ b/services/local-service/internal/bootstrap/bootstrap.go
@@ -118,6 +118,10 @@ func New(cfg config.Config) (*App, error) {
 		_ = storageService.Close()
 		return nil, err
 	}
+	if err := runEngine.WithTodoStore(storageService.TodoStore()); err != nil {
+		_ = storageService.Close()
+		return nil, err
+	}
 
 	orchestratorService := orchestrator.NewService(
 		contextsvc.NewService(),

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -738,7 +738,7 @@ func (s *Service) TaskInspectorRun(params map[string]any) (map[string]any, error
 		FinishedTasks:   finishedTasks,
 		NotepadItems:    notepadItems,
 	})
-	if len(result.NotepadItems) > 0 {
+	if result.SourceSynced {
 		if err := s.runEngine.SyncNotepadItems(result.NotepadItems); err != nil {
 			return nil, err
 		}

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -738,6 +738,11 @@ func (s *Service) TaskInspectorRun(params map[string]any) (map[string]any, error
 		FinishedTasks:   finishedTasks,
 		NotepadItems:    notepadItems,
 	})
+	if len(result.NotepadItems) > 0 {
+		if err := s.runEngine.SyncNotepadItems(result.NotepadItems); err != nil {
+			return nil, err
+		}
+	}
 
 	return map[string]any{
 		"inspection_id": result.InspectionID,

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -576,16 +576,24 @@ func TestTaskInspectorRunAggregatesRuntimeState(t *testing.T) {
 	if summary["parsed_files"] != 1 {
 		t.Fatalf("expected parsed_files to reflect workspace scan, got %+v", summary)
 	}
-	if summary["identified_items"] == nil || summary["identified_items"].(int) < 3 {
-		t.Fatalf("expected identified_items to include file and notepad items, got %+v", summary)
+	if summary["identified_items"] != 1 {
+		t.Fatalf("expected identified_items to reflect source-backed open notes, got %+v", summary)
 	}
-	if summary["due_today"] != 1 {
-		t.Fatalf("expected due_today to reflect runtime notepad state, got %+v", summary)
+	if summary["due_today"] != 0 {
+		t.Fatalf("expected source-backed notes to replace runtime due buckets after scan, got %+v", summary)
 	}
 
 	suggestions, ok := result["suggestions"].([]string)
 	if !ok || len(suggestions) == 0 {
 		t.Fatalf("expected runtime suggestions, got %+v", result["suggestions"])
+	}
+
+	items, total := service.runEngine.NotepadItems("", 10, 0)
+	if total != 2 || len(items) != 2 {
+		t.Fatalf("expected inspector run to sync parsed notes into runtime, total=%d len=%d", total, len(items))
+	}
+	if items[0]["item_id"] == "todo_today" && items[1]["item_id"] == "todo_today" {
+		t.Fatalf("expected source-backed notes to replace prior runtime sample, got %+v", items)
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -597,6 +597,31 @@ func TestTaskInspectorRunAggregatesRuntimeState(t *testing.T) {
 	}
 }
 
+func TestTaskInspectorRunClearsStaleSourceBackedNotesWhenFilesEmpty(t *testing.T) {
+	service, workspaceRoot := newTestServiceWithExecution(t, "inspector clear")
+	service.runEngine.ReplaceNotepadItems([]map[string]any{{
+		"item_id": "todo_stale_source",
+		"title":   "stale source note",
+		"bucket":  "upcoming",
+		"status":  "normal",
+		"type":    "one_time",
+	}})
+	todosDir := filepath.Join(workspaceRoot, "todos")
+	if err := os.MkdirAll(todosDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(todosDir, "empty.md"), []byte("# no checklist items here\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if _, err := service.TaskInspectorRun(map[string]any{"target_sources": []any{"workspace/todos"}}); err != nil {
+		t.Fatalf("TaskInspectorRun returned error: %v", err)
+	}
+	items, total := service.runEngine.NotepadItems("", 10, 0)
+	if total != 0 || len(items) != 0 {
+		t.Fatalf("expected source-backed sync to clear stale runtime notes when source is empty, total=%d len=%d items=%+v", total, len(items), items)
+	}
+}
+
 func TestServiceNotepadListReturnsRuntimeItemsByBucket(t *testing.T) {
 	service := newTestService()
 	now := time.Now().UTC()

--- a/services/local-service/internal/runengine/engine.go
+++ b/services/local-service/internal/runengine/engine.go
@@ -1134,16 +1134,15 @@ func (e *Engine) UpdateSettings(values map[string]any) (map[string]any, []string
 	return effectiveSettings, updatedKeys, applyMode, needRestart
 }
 
-// NotepadItems 处理当前模块的相关逻辑。
-
-// NotepadItems 返回便签模块在当前内存态中的示例数据。
+// NotepadItems returns the current notepad bucket view using the frozen TodoItem
+// contract, even when the internal owner-5 foundation carries richer metadata.
 func (e *Engine) NotepadItems(group string, limit, offset int) ([]map[string]any, int) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
 	filtered := make([]map[string]any, 0, len(e.notepadItems))
 	for _, item := range e.notepadItems {
-		normalized := normalizeNotepadItem(item, e.now())
+		normalized := protocolNotepadItemMap(item, e.now())
 		if group != "" {
 			if bucket, ok := normalized["bucket"].(string); !ok || bucket != group {
 				continue
@@ -1189,15 +1188,12 @@ func (e *Engine) CompleteNotepadItem(itemID string) (map[string]any, bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	item, index, ok := e.findNotepadItem(itemID)
+	updated, index, ok := e.updatedNotepadItem(itemID)
 	if !ok {
 		return nil, false
 	}
 
-	updated := cloneMap(item)
-	updated["bucket"] = "closed"
-	updated["status"] = "completed"
-	updated["due_at"] = nil
+	closeNotepadItem(updated, "completed", e.now())
 	e.notepadItems[index] = updated
 	return normalizeNotepadItem(updated, e.now()), true
 }
@@ -1681,6 +1677,14 @@ func buildDefaultNotepadItems(now time.Time) []map[string]any {
 			"type":             "one_time",
 			"due_at":           dueToday.Format(time.RFC3339),
 			"agent_suggestion": "先生成一个结构化摘要",
+			"note_text":        "汇总会议结论、待办人和风险项，整理成一页纪要。",
+			"related_resources": []map[string]any{{
+				"id":          "todo_001_minutes",
+				"label":       "会议资料目录",
+				"path":        "workspace/meetings",
+				"type":        "directory",
+				"target_kind": "folder",
+			}},
 		},
 		{
 			"item_id":          "todo_002",
@@ -1690,15 +1694,38 @@ func buildDefaultNotepadItems(now time.Time) []map[string]any {
 			"type":             "one_time",
 			"due_at":           later.Format(time.RFC3339),
 			"agent_suggestion": "可以先整理提纲再扩写成文档",
+			"note_text":        "先确认评审范围和负责人，再补齐材料。",
+			"prerequisite":     "等本周评审结论收齐后再开始整理。",
+			"related_resources": []map[string]any{{
+				"id":          "todo_002_review",
+				"label":       "评审草稿区",
+				"path":        "workspace/drafts/reviews",
+				"type":        "directory",
+				"target_kind": "folder",
+			}},
 		},
 		{
-			"item_id":          "todo_003",
-			"title":            "每周项目复盘",
-			"bucket":           "recurring_rule",
-			"status":           "normal",
-			"type":             "recurring",
-			"due_at":           recurring.Format(time.RFC3339),
-			"agent_suggestion": "建议生成固定模板后重复复用",
+			"item_id":                "todo_003",
+			"title":                  "每周项目复盘",
+			"bucket":                 "recurring_rule",
+			"status":                 "normal",
+			"type":                   "recurring",
+			"due_at":                 recurring.Format(time.RFC3339),
+			"agent_suggestion":       "建议生成固定模板后重复复用",
+			"note_text":              "按固定模板回顾进展、阻塞项和下周计划。",
+			"prerequisite":           "确认本周任务状态和风险变更已经同步。",
+			"repeat_rule_text":       "每周五 18:00 生成复盘提醒",
+			"next_occurrence_at":     recurring.Format(time.RFC3339),
+			"recent_instance_status": "completed",
+			"effective_scope":        "默认工作区内所有项目复盘笔记",
+			"recurring_enabled":      true,
+			"related_resources": []map[string]any{{
+				"id":          "todo_003_retro",
+				"label":       "复盘模板",
+				"path":        "workspace/templates/retro.md",
+				"type":        "file",
+				"target_kind": "file",
+			}},
 		},
 		{
 			"item_id":          "todo_004",
@@ -1708,6 +1735,15 @@ func buildDefaultNotepadItems(now time.Time) []map[string]any {
 			"type":             "one_time",
 			"due_at":           completedAt.Format(time.RFC3339),
 			"agent_suggestion": nil,
+			"note_text":        "日报已整理完成，仅保留归档记录与相关资料入口。",
+			"ended_at":         completedAt.Format(time.RFC3339),
+			"related_resources": []map[string]any{{
+				"id":          "todo_004_archive",
+				"label":       "日报归档",
+				"path":        "workspace/archive/daily",
+				"type":        "directory",
+				"target_kind": "folder",
+			}},
 		},
 	}
 }
@@ -1719,12 +1755,6 @@ func (e *Engine) findNotepadItem(itemID string) (map[string]any, int, bool) {
 		}
 	}
 	return nil, -1, false
-}
-
-func normalizeNotepadItem(item map[string]any, now time.Time) map[string]any {
-	normalized := cloneMap(item)
-	normalized["status"] = deriveNotepadStatus(item, now)
-	return normalized
 }
 
 func deriveNotepadStatus(item map[string]any, now time.Time) string {

--- a/services/local-service/internal/runengine/engine.go
+++ b/services/local-service/internal/runengine/engine.go
@@ -132,6 +132,7 @@ type Engine struct {
 	nextID       uint64
 	now          func() time.Time
 	taskStore    storage.TaskRunStore
+	todoStore    storage.TodoStore
 	tasks        map[string]*TaskRecord
 	taskOrder    []string
 	sessionOrder []string
@@ -151,6 +152,28 @@ func NewEngine() *Engine {
 // NewEngineWithStore 创建带有 task/run 持久化存储的引擎实例。
 func NewEngineWithStore(taskStore storage.TaskRunStore) (*Engine, error) {
 	return newEngine(taskStore)
+}
+
+// WithTodoStore attaches todo persistence and hydrates notes state from storage
+// when durable records are available.
+func (e *Engine) WithTodoStore(todoStore storage.TodoStore) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.todoStore = todoStore
+	if todoStore == nil {
+		return nil
+	}
+
+	items, rules, err := todoStore.LoadTodoState(context.Background())
+	if err != nil {
+		return err
+	}
+	loaded := restoreNotepadItemsFromStore(items, rules)
+	if len(loaded) > 0 {
+		e.notepadItems = loaded
+	}
+	return nil
 }
 
 func newEngine(taskStore storage.TaskRunStore) (*Engine, error) {
@@ -1181,7 +1204,7 @@ func (e *Engine) ReplaceNotepadItems(items []map[string]any) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	e.notepadItems = cloneMapSlice(items)
+	_ = e.replaceNotepadItemsLocked(items)
 }
 
 func (e *Engine) CompleteNotepadItem(itemID string) (map[string]any, bool) {

--- a/services/local-service/internal/runengine/engine.go
+++ b/services/local-service/internal/runengine/engine.go
@@ -170,9 +170,7 @@ func (e *Engine) WithTodoStore(todoStore storage.TodoStore) error {
 		return err
 	}
 	loaded := restoreNotepadItemsFromStore(items, rules)
-	if len(loaded) > 0 {
-		e.notepadItems = loaded
-	}
+	e.notepadItems = loaded
 	return nil
 }
 
@@ -1217,7 +1215,11 @@ func (e *Engine) CompleteNotepadItem(itemID string) (map[string]any, bool) {
 	}
 
 	closeNotepadItem(updated, "completed", e.now())
-	e.notepadItems[index] = updated
+	items := cloneMapSlice(e.notepadItems)
+	items[index] = updated
+	if err := e.replaceNotepadItemsLocked(items); err != nil {
+		return nil, false
+	}
 	return normalizeNotepadItem(updated, e.now()), true
 }
 

--- a/services/local-service/internal/runengine/notepad.go
+++ b/services/local-service/internal/runengine/notepad.go
@@ -1,0 +1,392 @@
+package runengine
+
+import (
+	"strings"
+	"time"
+)
+
+const (
+	notepadBucketClosed        = "closed"
+	notepadBucketLater         = "later"
+	notepadBucketRecurringRule = "recurring_rule"
+	notepadBucketUpcoming      = "upcoming"
+)
+
+// protocolNotepadItemMap projects the richer internal notepad model back to the
+// frozen TodoItem RPC shape so owner-5 foundation work does not leak undeclared
+// fields across the current protocol boundary.
+func protocolNotepadItemMap(item map[string]any, now time.Time) map[string]any {
+	normalized := normalizeNotepadItem(item, now)
+	if len(normalized) == 0 {
+		return nil
+	}
+
+	result := map[string]any{
+		"item_id":          stringValue(normalized, "item_id", ""),
+		"title":            stringValue(normalized, "title", ""),
+		"bucket":           stringValue(normalized, "bucket", ""),
+		"status":           stringValue(normalized, "status", "normal"),
+		"type":             stringValue(normalized, "type", ""),
+		"agent_suggestion": normalized["agent_suggestion"],
+		"due_at":           normalized["due_at"],
+	}
+	return result
+}
+
+// normalizeNotepadItem enriches the internal note foundation fields that owner
+// 5 can prepare ahead of protocol freeze, while keeping the existing TodoItem
+// contract derivable through protocolNotepadItemMap.
+func normalizeNotepadItem(item map[string]any, now time.Time) map[string]any {
+	normalized := cloneMap(item)
+	if len(normalized) == 0 {
+		return nil
+	}
+
+	normalized["status"] = deriveNotepadStatus(normalized, now)
+	if plannedAt := deriveNotepadPlannedAt(normalized); plannedAt != "" {
+		normalized["planned_at"] = plannedAt
+	}
+	normalized["note_text"] = deriveNotepadNoteText(normalized)
+	normalized["prerequisite"] = deriveNotepadPrerequisite(normalized)
+	normalized["related_resources"] = deriveNotepadRelatedResources(normalized)
+	normalized["ended_at"] = deriveNotepadEndedAt(normalized)
+	if stringValue(normalized, "bucket", "") == notepadBucketRecurringRule {
+		normalized["recurring_enabled"] = notepadBoolValue(normalized, "recurring_enabled", true)
+		normalized["repeat_rule_text"] = deriveRecurringRuleText(normalized)
+		normalized["next_occurrence_at"] = deriveRecurringNextOccurrence(normalized)
+		normalized["recent_instance_status"] = deriveRecurringRecentStatus(normalized)
+		normalized["effective_scope"] = deriveRecurringEffectiveScope(normalized)
+	}
+	return normalized
+}
+
+// CancelNotepadItem closes a note without deleting its foundation data so later
+// restore/detail flows can still reference the original schedule and metadata.
+func (e *Engine) CancelNotepadItem(itemID string) (map[string]any, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	updated, index, ok := e.updatedNotepadItem(itemID)
+	if !ok {
+		return nil, false
+	}
+
+	closeNotepadItem(updated, "cancelled", e.now())
+	e.notepadItems[index] = updated
+	return normalizeNotepadItem(updated, e.now()), true
+}
+
+// RestoreNotepadItem reopens a closed note using its preserved open-bucket and
+// planned timing metadata.
+func (e *Engine) RestoreNotepadItem(itemID string) (map[string]any, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	updated, index, ok := e.updatedNotepadItem(itemID)
+	if !ok {
+		return nil, false
+	}
+
+	restoreNotepadItem(updated)
+	e.notepadItems[index] = updated
+	return normalizeNotepadItem(updated, e.now()), true
+}
+
+// DeleteNotepadItem removes a note from the in-memory foundation store.
+func (e *Engine) DeleteNotepadItem(itemID string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	_, index, ok := e.findNotepadItem(itemID)
+	if !ok {
+		return false
+	}
+	e.notepadItems = append(e.notepadItems[:index], e.notepadItems[index+1:]...)
+	return true
+}
+
+// SetNotepadRecurringEnabled toggles whether a recurring note should continue
+// producing future occurrences.
+func (e *Engine) SetNotepadRecurringEnabled(itemID string, enabled bool) (map[string]any, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	updated, index, ok := e.updatedNotepadItem(itemID)
+	if !ok {
+		return nil, false
+	}
+	if stringValue(updated, "bucket", "") != notepadBucketRecurringRule {
+		return nil, false
+	}
+
+	updated["recurring_enabled"] = enabled
+	if enabled {
+		if nextOccurrence := deriveRecurringNextOccurrence(updated); nextOccurrence != "" {
+			updated["due_at"] = nextOccurrence
+		}
+	} else {
+		updated["recent_instance_status"] = "paused"
+		updated["due_at"] = nil
+	}
+	e.notepadItems[index] = updated
+	return normalizeNotepadItem(updated, e.now()), true
+}
+
+// UpdateNotepadRecurringRule refreshes the core rule fields that future detail
+// read models or action RPCs can expose once owner-4 freezes the protocol.
+func (e *Engine) UpdateNotepadRecurringRule(itemID, repeatRuleText, nextOccurrenceAt, effectiveScope string) (map[string]any, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	updated, index, ok := e.updatedNotepadItem(itemID)
+	if !ok {
+		return nil, false
+	}
+	if stringValue(updated, "bucket", "") != notepadBucketRecurringRule {
+		return nil, false
+	}
+
+	if strings.TrimSpace(repeatRuleText) != "" {
+		updated["repeat_rule_text"] = strings.TrimSpace(repeatRuleText)
+	}
+	if strings.TrimSpace(nextOccurrenceAt) != "" {
+		updated["next_occurrence_at"] = strings.TrimSpace(nextOccurrenceAt)
+		updated["planned_at"] = strings.TrimSpace(nextOccurrenceAt)
+		if notepadBoolValue(updated, "recurring_enabled", true) {
+			updated["due_at"] = strings.TrimSpace(nextOccurrenceAt)
+		}
+	}
+	if strings.TrimSpace(effectiveScope) != "" {
+		updated["effective_scope"] = strings.TrimSpace(effectiveScope)
+	}
+	e.notepadItems[index] = updated
+	return normalizeNotepadItem(updated, e.now()), true
+}
+
+func (e *Engine) updatedNotepadItem(itemID string) (map[string]any, int, bool) {
+	item, index, ok := e.findNotepadItem(itemID)
+	if !ok {
+		return nil, -1, false
+	}
+	return cloneMap(item), index, true
+}
+
+func closeNotepadItem(item map[string]any, status string, now time.Time) {
+	if openBucket := stringValue(item, "bucket", ""); openBucket != "" && openBucket != notepadBucketClosed {
+		item["source_bucket"] = openBucket
+	}
+	if plannedAt := deriveNotepadPlannedAt(item); plannedAt != "" {
+		item["planned_at"] = plannedAt
+	}
+	item["bucket"] = notepadBucketClosed
+	item["status"] = status
+	item["ended_at"] = now.UTC().Format(time.RFC3339)
+	item["due_at"] = nil
+	if status == "cancelled" {
+		item["recent_instance_status"] = "cancelled"
+	}
+}
+
+func restoreNotepadItem(item map[string]any) {
+	bucket := stringValue(item, "source_bucket", "")
+	if bucket == "" {
+		if stringValue(item, "type", "") == "recurring" || notepadBoolValue(item, "recurring_enabled", false) {
+			bucket = notepadBucketRecurringRule
+		} else {
+			bucket = notepadBucketUpcoming
+		}
+	}
+	item["bucket"] = bucket
+	item["status"] = "normal"
+	item["ended_at"] = nil
+	if bucket == notepadBucketRecurringRule {
+		if nextOccurrence := deriveRecurringNextOccurrence(item); nextOccurrence != "" && notepadBoolValue(item, "recurring_enabled", true) {
+			item["due_at"] = nextOccurrence
+		}
+		return
+	}
+	if plannedAt := deriveNotepadPlannedAt(item); plannedAt != "" {
+		item["due_at"] = plannedAt
+	}
+}
+
+func deriveNotepadPlannedAt(item map[string]any) string {
+	if plannedAt := stringValue(item, "planned_at", ""); plannedAt != "" {
+		return plannedAt
+	}
+	if dueAt := stringValue(item, "due_at", ""); dueAt != "" {
+		return dueAt
+	}
+	if nextOccurrence := stringValue(item, "next_occurrence_at", ""); nextOccurrence != "" {
+		return nextOccurrence
+	}
+	return ""
+}
+
+func deriveNotepadNoteText(item map[string]any) string {
+	if noteText := strings.TrimSpace(stringValue(item, "note_text", "")); noteText != "" {
+		return noteText
+	}
+	title := strings.TrimSpace(stringValue(item, "title", "待办事项"))
+	suggestion := strings.TrimSpace(stringValue(item, "agent_suggestion", ""))
+	if suggestion != "" {
+		return title + "。当前建议：" + suggestion + "。"
+	}
+	return title + "。当前处于便签巡检域，等待进入正式执行。"
+}
+
+func deriveNotepadPrerequisite(item map[string]any) string {
+	if prerequisite := strings.TrimSpace(stringValue(item, "prerequisite", "")); prerequisite != "" {
+		return prerequisite
+	}
+	switch stringValue(item, "bucket", "") {
+	case notepadBucketLater:
+		return "等进入处理窗口后再推进。"
+	case notepadBucketRecurringRule:
+		return "确认这条规则仍需持续生效，并保留对应资料入口。"
+	default:
+		return ""
+	}
+}
+
+func deriveNotepadEndedAt(item map[string]any) any {
+	if endedAt := stringValue(item, "ended_at", ""); endedAt != "" {
+		return endedAt
+	}
+	if stringValue(item, "status", "") != "completed" && stringValue(item, "status", "") != "cancelled" {
+		return nil
+	}
+	if bucket := stringValue(item, "bucket", ""); bucket != notepadBucketClosed {
+		return nil
+	}
+	if dueAt := stringValue(item, "due_at", ""); dueAt != "" {
+		return dueAt
+	}
+	return nil
+}
+
+func deriveRecurringRuleText(item map[string]any) string {
+	if ruleText := strings.TrimSpace(stringValue(item, "repeat_rule_text", "")); ruleText != "" {
+		return ruleText
+	}
+	return "每周重复一次"
+}
+
+func deriveRecurringNextOccurrence(item map[string]any) string {
+	if nextOccurrence := strings.TrimSpace(stringValue(item, "next_occurrence_at", "")); nextOccurrence != "" {
+		return nextOccurrence
+	}
+	if dueAt := strings.TrimSpace(stringValue(item, "due_at", "")); dueAt != "" {
+		return dueAt
+	}
+	return strings.TrimSpace(stringValue(item, "planned_at", ""))
+}
+
+func deriveRecurringRecentStatus(item map[string]any) string {
+	if recentStatus := strings.TrimSpace(stringValue(item, "recent_instance_status", "")); recentStatus != "" {
+		return recentStatus
+	}
+	if !notepadBoolValue(item, "recurring_enabled", true) {
+		return "paused"
+	}
+	return "completed"
+}
+
+func deriveRecurringEffectiveScope(item map[string]any) string {
+	if effectiveScope := strings.TrimSpace(stringValue(item, "effective_scope", "")); effectiveScope != "" {
+		return effectiveScope
+	}
+	if !notepadBoolValue(item, "recurring_enabled", true) {
+		return "规则已暂停，不会生成新的巡检实例。"
+	}
+	return "在默认工作区巡检范围内持续生效。"
+}
+
+func deriveNotepadRelatedResources(item map[string]any) []map[string]any {
+	if resources := cloneResourceList(item["related_resources"]); len(resources) > 0 {
+		return resources
+	}
+
+	resources := make([]map[string]any, 0, 2)
+	title := strings.ToLower(strings.TrimSpace(stringValue(item, "title", "")))
+	switch stringValue(item, "bucket", "") {
+	case notepadBucketRecurringRule:
+		resources = append(resources, map[string]any{
+			"id":          stringValue(item, "item_id", "") + "_rule_source",
+			"label":       "任务源目录",
+			"path":        defaultTaskSourcePath,
+			"type":        "directory",
+			"target_kind": "folder",
+		})
+	case notepadBucketClosed:
+		resources = append(resources, map[string]any{
+			"id":          stringValue(item, "item_id", "") + "_archive",
+			"label":       "归档目录",
+			"path":        "workspace/archive",
+			"type":        "directory",
+			"target_kind": "folder",
+		})
+	}
+	if strings.Contains(title, "模板") {
+		resources = append(resources, map[string]any{
+			"id":          stringValue(item, "item_id", "") + "_template",
+			"label":       "关联模板",
+			"path":        "workspace/templates",
+			"type":        "directory",
+			"target_kind": "folder",
+		})
+	}
+	if strings.Contains(title, "周报") || strings.Contains(title, "报告") || strings.Contains(title, "评审") {
+		resources = append(resources, map[string]any{
+			"id":          stringValue(item, "item_id", "") + "_drafts",
+			"label":       "草稿目录",
+			"path":        "workspace/drafts",
+			"type":        "directory",
+			"target_kind": "folder",
+		})
+	}
+	if len(resources) == 0 {
+		resources = append(resources, map[string]any{
+			"id":          stringValue(item, "item_id", "") + "_workspace",
+			"label":       "默认工作区",
+			"path":        defaultWorkspaceRoot,
+			"type":        "directory",
+			"target_kind": "folder",
+		})
+	}
+	return resources
+}
+
+func cloneResourceList(rawValue any) []map[string]any {
+	resources, ok := rawValue.([]map[string]any)
+	if ok {
+		return cloneMapSlice(resources)
+	}
+	anyResources, ok := rawValue.([]any)
+	if !ok {
+		return nil
+	}
+	result := make([]map[string]any, 0, len(anyResources))
+	for _, rawResource := range anyResources {
+		resource, ok := rawResource.(map[string]any)
+		if ok {
+			result = append(result, cloneMap(resource))
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func notepadBoolValue(values map[string]any, key string, fallback bool) bool {
+	rawValue, ok := values[key]
+	if !ok {
+		return fallback
+	}
+	value, ok := rawValue.(bool)
+	if !ok {
+		return fallback
+	}
+	return value
+}

--- a/services/local-service/internal/runengine/notepad.go
+++ b/services/local-service/internal/runengine/notepad.go
@@ -1,8 +1,13 @@
 package runengine
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
+
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/storage"
 )
 
 const (
@@ -60,6 +65,14 @@ func normalizeNotepadItem(item map[string]any, now time.Time) map[string]any {
 	return normalized
 }
 
+// SyncNotepadItems replaces the current notepad foundation state and persists it
+// when a todo store is configured.
+func (e *Engine) SyncNotepadItems(items []map[string]any) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.replaceNotepadItemsLocked(items)
+}
+
 // CancelNotepadItem closes a note without deleting its foundation data so later
 // restore/detail flows can still reference the original schedule and metadata.
 func (e *Engine) CancelNotepadItem(itemID string) (map[string]any, bool) {
@@ -72,7 +85,11 @@ func (e *Engine) CancelNotepadItem(itemID string) (map[string]any, bool) {
 	}
 
 	closeNotepadItem(updated, "cancelled", e.now())
-	e.notepadItems[index] = updated
+	items := cloneMapSlice(e.notepadItems)
+	items[index] = updated
+	if err := e.replaceNotepadItemsLocked(items); err != nil {
+		return nil, false
+	}
 	return normalizeNotepadItem(updated, e.now()), true
 }
 
@@ -87,8 +104,12 @@ func (e *Engine) RestoreNotepadItem(itemID string) (map[string]any, bool) {
 		return nil, false
 	}
 
-	restoreNotepadItem(updated)
-	e.notepadItems[index] = updated
+	restoreNotepadItem(updated, e.now())
+	items := cloneMapSlice(e.notepadItems)
+	items[index] = updated
+	if err := e.replaceNotepadItemsLocked(items); err != nil {
+		return nil, false
+	}
 	return normalizeNotepadItem(updated, e.now()), true
 }
 
@@ -101,8 +122,9 @@ func (e *Engine) DeleteNotepadItem(itemID string) bool {
 	if !ok {
 		return false
 	}
-	e.notepadItems = append(e.notepadItems[:index], e.notepadItems[index+1:]...)
-	return true
+	items := cloneMapSlice(e.notepadItems)
+	items = append(items[:index], items[index+1:]...)
+	return e.replaceNotepadItemsLocked(items) == nil
 }
 
 // SetNotepadRecurringEnabled toggles whether a recurring note should continue
@@ -120,6 +142,7 @@ func (e *Engine) SetNotepadRecurringEnabled(itemID string, enabled bool) (map[st
 	}
 
 	updated["recurring_enabled"] = enabled
+	updated["updated_at"] = e.now().UTC().Format(time.RFC3339)
 	if enabled {
 		if nextOccurrence := deriveRecurringNextOccurrence(updated); nextOccurrence != "" {
 			updated["due_at"] = nextOccurrence
@@ -128,7 +151,11 @@ func (e *Engine) SetNotepadRecurringEnabled(itemID string, enabled bool) (map[st
 		updated["recent_instance_status"] = "paused"
 		updated["due_at"] = nil
 	}
-	e.notepadItems[index] = updated
+	items := cloneMapSlice(e.notepadItems)
+	items[index] = updated
+	if err := e.replaceNotepadItemsLocked(items); err != nil {
+		return nil, false
+	}
 	return normalizeNotepadItem(updated, e.now()), true
 }
 
@@ -159,7 +186,13 @@ func (e *Engine) UpdateNotepadRecurringRule(itemID, repeatRuleText, nextOccurren
 	if strings.TrimSpace(effectiveScope) != "" {
 		updated["effective_scope"] = strings.TrimSpace(effectiveScope)
 	}
-	e.notepadItems[index] = updated
+	updateRecurringRuleMetadata(updated)
+	updated["updated_at"] = e.now().UTC().Format(time.RFC3339)
+	items := cloneMapSlice(e.notepadItems)
+	items[index] = updated
+	if err := e.replaceNotepadItemsLocked(items); err != nil {
+		return nil, false
+	}
 	return normalizeNotepadItem(updated, e.now()), true
 }
 
@@ -182,12 +215,13 @@ func closeNotepadItem(item map[string]any, status string, now time.Time) {
 	item["status"] = status
 	item["ended_at"] = now.UTC().Format(time.RFC3339)
 	item["due_at"] = nil
+	item["updated_at"] = now.UTC().Format(time.RFC3339)
 	if status == "cancelled" {
 		item["recent_instance_status"] = "cancelled"
 	}
 }
 
-func restoreNotepadItem(item map[string]any) {
+func restoreNotepadItem(item map[string]any, now time.Time) {
 	bucket := stringValue(item, "source_bucket", "")
 	if bucket == "" {
 		if stringValue(item, "type", "") == "recurring" || notepadBoolValue(item, "recurring_enabled", false) {
@@ -199,6 +233,7 @@ func restoreNotepadItem(item map[string]any) {
 	item["bucket"] = bucket
 	item["status"] = "normal"
 	item["ended_at"] = nil
+	item["updated_at"] = now.UTC().Format(time.RFC3339)
 	if bucket == notepadBucketRecurringRule {
 		if nextOccurrence := deriveRecurringNextOccurrence(item); nextOccurrence != "" && notepadBoolValue(item, "recurring_enabled", true) {
 			item["due_at"] = nextOccurrence
@@ -269,10 +304,18 @@ func deriveRecurringRuleText(item map[string]any) string {
 	if ruleText := strings.TrimSpace(stringValue(item, "repeat_rule_text", "")); ruleText != "" {
 		return ruleText
 	}
+	updateRecurringRuleMetadata(item)
+	if ruleText := strings.TrimSpace(stringValue(item, "repeat_rule_text", "")); ruleText != "" {
+		return ruleText
+	}
 	return "每周重复一次"
 }
 
 func deriveRecurringNextOccurrence(item map[string]any) string {
+	if nextOccurrence := strings.TrimSpace(stringValue(item, "next_occurrence_at", "")); nextOccurrence != "" {
+		return nextOccurrence
+	}
+	updateRecurringRuleMetadata(item)
 	if nextOccurrence := strings.TrimSpace(stringValue(item, "next_occurrence_at", "")); nextOccurrence != "" {
 		return nextOccurrence
 	}
@@ -286,6 +329,10 @@ func deriveRecurringRecentStatus(item map[string]any) string {
 	if recentStatus := strings.TrimSpace(stringValue(item, "recent_instance_status", "")); recentStatus != "" {
 		return recentStatus
 	}
+	updateRecurringRuleMetadata(item)
+	if recentStatus := strings.TrimSpace(stringValue(item, "recent_instance_status", "")); recentStatus != "" {
+		return recentStatus
+	}
 	if !notepadBoolValue(item, "recurring_enabled", true) {
 		return "paused"
 	}
@@ -296,10 +343,156 @@ func deriveRecurringEffectiveScope(item map[string]any) string {
 	if effectiveScope := strings.TrimSpace(stringValue(item, "effective_scope", "")); effectiveScope != "" {
 		return effectiveScope
 	}
+	updateRecurringRuleMetadata(item)
+	if effectiveScope := strings.TrimSpace(stringValue(item, "effective_scope", "")); effectiveScope != "" {
+		return effectiveScope
+	}
 	if !notepadBoolValue(item, "recurring_enabled", true) {
 		return "规则已暂停，不会生成新的巡检实例。"
 	}
 	return "在默认工作区巡检范围内持续生效。"
+}
+
+func updateRecurringRuleMetadata(item map[string]any) {
+	ruleText := strings.TrimSpace(stringValue(item, "repeat_rule_text", ""))
+	cronExpr := strings.TrimSpace(stringValue(item, "cron_expr", ""))
+	intervalValue := itemIntValue(item, "interval_value", 0)
+	intervalUnit := strings.TrimSpace(stringValue(item, "interval_unit", ""))
+	if ruleText == "" && cronExpr == "" && intervalValue <= 0 && intervalUnit == "" {
+		ruleText = "每周重复一次"
+	}
+
+	spec := parseRecurringRuleSpec(ruleText, cronExpr, intervalValue, intervalUnit)
+	if spec.ruleType != "" {
+		item["rule_type"] = spec.ruleType
+	}
+	if spec.cronExpr != "" {
+		item["cron_expr"] = spec.cronExpr
+	}
+	if spec.intervalValue > 0 {
+		item["interval_value"] = spec.intervalValue
+	}
+	if spec.intervalUnit != "" {
+		item["interval_unit"] = spec.intervalUnit
+	}
+	if ruleText == "" {
+		ruleText = recurringRuleTextFromSpec(spec)
+	}
+	if ruleText != "" {
+		item["repeat_rule_text"] = ruleText
+	}
+	if stringValue(item, "reminder_strategy", "") == "" {
+		item["reminder_strategy"] = "due_at"
+	}
+	if stringValue(item, "next_occurrence_at", "") == "" {
+		if nextOccurrence := recurringNextOccurrenceFromSpec(item, spec); nextOccurrence != "" {
+			item["next_occurrence_at"] = nextOccurrence
+		}
+	}
+	if stringValue(item, "recent_instance_status", "") == "" {
+		if !notepadBoolValue(item, "recurring_enabled", true) {
+			item["recent_instance_status"] = "paused"
+		} else if status := stringValue(item, "status", ""); status == "completed" || status == "cancelled" {
+			item["recent_instance_status"] = status
+		} else {
+			item["recent_instance_status"] = "completed"
+		}
+	}
+}
+
+type recurringRuleSpec struct {
+	ruleType      string
+	cronExpr      string
+	intervalValue int
+	intervalUnit  string
+}
+
+func parseRecurringRuleSpec(ruleText, cronExpr string, intervalValue int, intervalUnit string) recurringRuleSpec {
+	if strings.TrimSpace(cronExpr) != "" {
+		return recurringRuleSpec{ruleType: "cron", cronExpr: strings.TrimSpace(cronExpr)}
+	}
+	if intervalValue > 0 && strings.TrimSpace(intervalUnit) != "" {
+		return recurringRuleSpec{ruleType: "interval", intervalValue: intervalValue, intervalUnit: strings.TrimSpace(intervalUnit)}
+	}
+	normalized := strings.ToLower(strings.TrimSpace(ruleText))
+	switch {
+	case normalized == "", strings.Contains(normalized, "每周"), strings.Contains(normalized, "weekly"):
+		value := 1
+		if strings.Contains(normalized, "两") || strings.Contains(normalized, "biweekly") {
+			value = 2
+		}
+		return recurringRuleSpec{ruleType: "interval", intervalValue: value, intervalUnit: "week"}
+	case strings.Contains(normalized, "每天"), strings.Contains(normalized, "daily"):
+		return recurringRuleSpec{ruleType: "interval", intervalValue: 1, intervalUnit: "day"}
+	case strings.Contains(normalized, "每月"), strings.Contains(normalized, "monthly"):
+		return recurringRuleSpec{ruleType: "interval", intervalValue: 1, intervalUnit: "month"}
+	case strings.Contains(normalized, "每两周"):
+		return recurringRuleSpec{ruleType: "interval", intervalValue: 2, intervalUnit: "week"}
+	case strings.HasPrefix(normalized, "cron:"):
+		return recurringRuleSpec{ruleType: "cron", cronExpr: strings.TrimSpace(strings.TrimPrefix(ruleText, "cron:"))}
+	default:
+		return recurringRuleSpec{ruleType: "interval", intervalValue: 1, intervalUnit: "week"}
+	}
+}
+
+func recurringRuleTextFromSpec(spec recurringRuleSpec) string {
+	if spec.ruleType == "cron" && spec.cronExpr != "" {
+		return "cron: " + spec.cronExpr
+	}
+	if spec.intervalValue <= 1 {
+		switch spec.intervalUnit {
+		case "day":
+			return "每天一次"
+		case "month":
+			return "每月一次"
+		default:
+			return "每周重复一次"
+		}
+	}
+	return fmt.Sprintf("每%d%s一次", spec.intervalValue, recurringIntervalText(spec.intervalUnit))
+}
+
+func recurringIntervalText(unit string) string {
+	switch unit {
+	case "day":
+		return "天"
+	case "month":
+		return "月"
+	default:
+		return "周"
+	}
+}
+
+func recurringNextOccurrenceFromSpec(item map[string]any, spec recurringRuleSpec) string {
+	base := strings.TrimSpace(stringValue(item, "planned_at", ""))
+	if base == "" {
+		base = strings.TrimSpace(stringValue(item, "due_at", ""))
+	}
+	if base == "" {
+		return ""
+	}
+	parsed, err := time.Parse(time.RFC3339, base)
+	if err != nil {
+		return base
+	}
+	if spec.ruleType == "interval" {
+		switch spec.intervalUnit {
+		case "day":
+			parsed = parsed.Add(time.Duration(spec.intervalValue) * 24 * time.Hour)
+		case "month":
+			parsed = parsed.AddDate(0, spec.intervalValue, 0)
+		default:
+			parsed = parsed.AddDate(0, 0, 7*maxRecurringInterval(spec.intervalValue))
+		}
+	}
+	return parsed.Format(time.RFC3339)
+}
+
+func maxRecurringInterval(value int) int {
+	if value <= 0 {
+		return 1
+	}
+	return value
 }
 
 func deriveNotepadRelatedResources(item map[string]any) []map[string]any {
@@ -389,4 +582,283 @@ func notepadBoolValue(values map[string]any, key string, fallback bool) bool {
 		return fallback
 	}
 	return value
+}
+
+func (e *Engine) replaceNotepadItemsLocked(items []map[string]any) error {
+	items = cloneMapSlice(items)
+	if err := e.persistNotepadItemsLocked(items); err != nil {
+		return err
+	}
+	e.notepadItems = items
+	return nil
+}
+
+func (e *Engine) persistNotepadItemsLocked(items []map[string]any) error {
+	if e.todoStore == nil {
+		return nil
+	}
+	records, rules, err := notepadItemsToStoreState(items, e.now())
+	if err != nil {
+		return err
+	}
+	if err := e.todoStore.ReplaceTodoState(context.Background(), records, rules); err != nil {
+		return fmt.Errorf("replace todo state: %w", err)
+	}
+	return nil
+}
+
+func notepadItemsToStoreState(items []map[string]any, now time.Time) ([]storage.TodoItemRecord, []storage.RecurringRuleRecord, error) {
+	itemRecords := make([]storage.TodoItemRecord, 0, len(items))
+	ruleRecords := make([]storage.RecurringRuleRecord, 0)
+	for _, item := range items {
+		normalized := normalizeNotepadItem(item, now)
+		if len(normalized) == 0 {
+			continue
+		}
+		itemRecord, err := todoItemRecordFromMap(normalized, now)
+		if err != nil {
+			return nil, nil, err
+		}
+		itemRecords = append(itemRecords, itemRecord)
+		if ruleRecord, ok, err := recurringRuleRecordFromMap(normalized, now); err != nil {
+			return nil, nil, err
+		} else if ok {
+			ruleRecords = append(ruleRecords, ruleRecord)
+		}
+	}
+	return itemRecords, ruleRecords, nil
+}
+
+func restoreNotepadItemsFromStore(items []storage.TodoItemRecord, rules []storage.RecurringRuleRecord) []map[string]any {
+	if len(items) == 0 {
+		return nil
+	}
+	rulesByItemID := make(map[string]storage.RecurringRuleRecord, len(rules))
+	for _, rule := range rules {
+		rulesByItemID[rule.ItemID] = rule
+	}
+	result := make([]map[string]any, 0, len(items))
+	for _, record := range items {
+		item := map[string]any{
+			"item_id":          record.ItemID,
+			"title":            record.Title,
+			"bucket":           record.Bucket,
+			"status":           record.Status,
+			"type":             todoItemType(record.Bucket),
+			"source_path":      record.SourcePath,
+			"source_line":      record.SourceLine,
+			"due_at":           nullableMapString(record.DueAt),
+			"agent_suggestion": nullableMapString(record.AgentSuggestion),
+			"note_text":        nullableMapString(record.NoteText),
+			"prerequisite":     nullableMapString(record.Prerequisite),
+			"planned_at":       nullableMapString(record.PlannedAt),
+			"ended_at":         nullableMapString(record.EndedAt),
+			"created_at":       record.CreatedAt,
+			"updated_at":       record.UpdatedAt,
+		}
+		if record.LinkedTaskID != "" {
+			item["linked_task_id"] = record.LinkedTaskID
+		}
+		if resources := decodeRelatedResources(record.RelatedResourcesJSON); len(resources) > 0 {
+			item["related_resources"] = resources
+		}
+		if tags := decodeTags(record.TagsJSON); len(tags) > 0 {
+			item["tags"] = tags
+		}
+		if rule, ok := rulesByItemID[record.ItemID]; ok {
+			item["rule_id"] = rule.RuleID
+			item["rule_type"] = rule.RuleType
+			item["cron_expr"] = nullableMapString(rule.CronExpr)
+			item["interval_value"] = rule.IntervalValue
+			item["interval_unit"] = nullableMapString(rule.IntervalUnit)
+			item["reminder_strategy"] = rule.ReminderStrategy
+			item["recurring_enabled"] = rule.Enabled
+			item["repeat_rule_text"] = nullableMapString(rule.RepeatRuleText)
+			item["next_occurrence_at"] = nullableMapString(rule.NextOccurrenceAt)
+			item["recent_instance_status"] = nullableMapString(rule.RecentInstanceStatus)
+			item["effective_scope"] = nullableMapString(rule.EffectiveScope)
+		}
+		result = append(result, item)
+	}
+	return result
+}
+
+func todoItemRecordFromMap(item map[string]any, now time.Time) (storage.TodoItemRecord, error) {
+	relatedResourcesJSON, err := marshalRelatedResources(item["related_resources"])
+	if err != nil {
+		return storage.TodoItemRecord{}, err
+	}
+	tagsJSON, err := marshalStringSlice(item["tags"])
+	if err != nil {
+		return storage.TodoItemRecord{}, err
+	}
+	createdAt := stringValue(item, "created_at", "")
+	if createdAt == "" {
+		createdAt = now.UTC().Format(time.RFC3339)
+	}
+	updatedAt := stringValue(item, "updated_at", "")
+	if updatedAt == "" {
+		updatedAt = now.UTC().Format(time.RFC3339)
+	}
+	return storage.TodoItemRecord{
+		ItemID:               stringValue(item, "item_id", ""),
+		Title:                stringValue(item, "title", ""),
+		Bucket:               stringValue(item, "bucket", ""),
+		Status:               stringValue(item, "status", ""),
+		SourcePath:           stringValue(item, "source_path", ""),
+		SourceLine:           itemIntValue(item, "source_line", 0),
+		DueAt:                stringValue(item, "due_at", ""),
+		TagsJSON:             tagsJSON,
+		AgentSuggestion:      stringValue(item, "agent_suggestion", ""),
+		NoteText:             stringValue(item, "note_text", ""),
+		Prerequisite:         stringValue(item, "prerequisite", ""),
+		PlannedAt:            stringValue(item, "planned_at", ""),
+		EndedAt:              stringValue(item, "ended_at", ""),
+		RelatedResourcesJSON: relatedResourcesJSON,
+		LinkedTaskID:         stringValue(item, "linked_task_id", ""),
+		CreatedAt:            createdAt,
+		UpdatedAt:            updatedAt,
+	}, nil
+}
+
+func recurringRuleRecordFromMap(item map[string]any, now time.Time) (storage.RecurringRuleRecord, bool, error) {
+	if stringValue(item, "bucket", "") != notepadBucketRecurringRule && stringValue(item, "type", "") != "recurring" {
+		return storage.RecurringRuleRecord{}, false, nil
+	}
+	updateRecurringRuleMetadata(item)
+	createdAt := stringValue(item, "created_at", "")
+	if createdAt == "" {
+		createdAt = now.UTC().Format(time.RFC3339)
+	}
+	updatedAt := stringValue(item, "updated_at", "")
+	if updatedAt == "" {
+		updatedAt = now.UTC().Format(time.RFC3339)
+	}
+	ruleID := stringValue(item, "rule_id", "")
+	if ruleID == "" {
+		ruleID = fmt.Sprintf("rule_%s", stringValue(item, "item_id", ""))
+	}
+	return storage.RecurringRuleRecord{
+		RuleID:               ruleID,
+		ItemID:               stringValue(item, "item_id", ""),
+		RuleType:             stringValue(item, "rule_type", "interval"),
+		CronExpr:             stringValue(item, "cron_expr", ""),
+		IntervalValue:        itemIntValue(item, "interval_value", 0),
+		IntervalUnit:         stringValue(item, "interval_unit", ""),
+		ReminderStrategy:     firstNonEmptyString(stringValue(item, "reminder_strategy", ""), "due_at"),
+		Enabled:              notepadBoolValue(item, "recurring_enabled", true),
+		RepeatRuleText:       stringValue(item, "repeat_rule_text", ""),
+		NextOccurrenceAt:     stringValue(item, "next_occurrence_at", ""),
+		RecentInstanceStatus: stringValue(item, "recent_instance_status", ""),
+		EffectiveScope:       stringValue(item, "effective_scope", ""),
+		CreatedAt:            createdAt,
+		UpdatedAt:            updatedAt,
+	}, true, nil
+}
+
+func marshalRelatedResources(rawValue any) (string, error) {
+	resources := cloneResourceList(rawValue)
+	if len(resources) == 0 {
+		return "", nil
+	}
+	payload, err := json.Marshal(resources)
+	if err != nil {
+		return "", fmt.Errorf("marshal related resources: %w", err)
+	}
+	return string(payload), nil
+}
+
+func marshalStringSlice(rawValue any) (string, error) {
+	values, ok := rawValue.([]string)
+	if ok {
+		if len(values) == 0 {
+			return "", nil
+		}
+		payload, err := json.Marshal(values)
+		if err != nil {
+			return "", fmt.Errorf("marshal tags: %w", err)
+		}
+		return string(payload), nil
+	}
+	anyValues, ok := rawValue.([]any)
+	if !ok {
+		return "", nil
+	}
+	result := make([]string, 0, len(anyValues))
+	for _, rawItem := range anyValues {
+		item, ok := rawItem.(string)
+		if ok && strings.TrimSpace(item) != "" {
+			result = append(result, strings.TrimSpace(item))
+		}
+	}
+	if len(result) == 0 {
+		return "", nil
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("marshal tags: %w", err)
+	}
+	return string(payload), nil
+}
+
+func decodeRelatedResources(payload string) []map[string]any {
+	if strings.TrimSpace(payload) == "" {
+		return nil
+	}
+	var resources []map[string]any
+	if err := json.Unmarshal([]byte(payload), &resources); err != nil {
+		return nil
+	}
+	return cloneMapSlice(resources)
+}
+
+func decodeTags(payload string) []string {
+	if strings.TrimSpace(payload) == "" {
+		return nil
+	}
+	var tags []string
+	if err := json.Unmarshal([]byte(payload), &tags); err != nil {
+		return nil
+	}
+	return append([]string(nil), tags...)
+}
+
+func nullableMapString(value string) any {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}
+
+func itemIntValue(values map[string]any, key string, fallback int) int {
+	rawValue, ok := values[key]
+	if !ok {
+		return fallback
+	}
+	switch typed := rawValue.(type) {
+	case int:
+		return typed
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	default:
+		return fallback
+	}
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func todoItemType(bucket string) string {
+	if bucket == notepadBucketRecurringRule {
+		return "recurring"
+	}
+	return "one_time"
 }

--- a/services/local-service/internal/runengine/notepad_test.go
+++ b/services/local-service/internal/runengine/notepad_test.go
@@ -1,0 +1,166 @@
+package runengine
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEngineNotepadListProjectsProtocolShapeOnly(t *testing.T) {
+	engine := NewEngine()
+	now := time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC)
+	engine.now = func() time.Time { return now }
+	engine.ReplaceNotepadItems([]map[string]any{{
+		"item_id":          "todo_protocol_only",
+		"title":            "整理模板草稿",
+		"bucket":           notepadBucketUpcoming,
+		"status":           "normal",
+		"type":             "one_time",
+		"due_at":           now.Add(3 * time.Hour).Format(time.RFC3339),
+		"agent_suggestion": "生成摘要",
+		"note_text":        "这是内部详情正文，不应直接泄漏到 TodoItem 列表。",
+		"related_resources": []map[string]any{{
+			"id":          "res_protocol",
+			"label":       "模板目录",
+			"path":        "workspace/templates",
+			"type":        "directory",
+			"target_kind": "folder",
+		}},
+	}})
+
+	items, total := engine.NotepadItems(notepadBucketUpcoming, 10, 0)
+	if total != 1 || len(items) != 1 {
+		t.Fatalf("expected one projected notepad item, total=%d len=%d", total, len(items))
+	}
+	if items[0]["status"] != "due_today" {
+		t.Fatalf("expected projected item to keep normalized status, got %+v", items[0])
+	}
+	if _, ok := items[0]["note_text"]; ok {
+		t.Fatalf("expected list projection to omit internal note_text, got %+v", items[0])
+	}
+	if _, ok := items[0]["related_resources"]; ok {
+		t.Fatalf("expected list projection to omit internal related_resources, got %+v", items[0])
+	}
+
+	detail, ok := engine.NotepadItem("todo_protocol_only")
+	if !ok {
+		t.Fatal("expected internal notepad detail to exist")
+	}
+	if detail["note_text"] == nil || detail["planned_at"] == nil {
+		t.Fatalf("expected internal detail fields to be preserved, got %+v", detail)
+	}
+	resources, ok := detail["related_resources"].([]map[string]any)
+	if !ok || len(resources) != 1 {
+		t.Fatalf("expected internal related resources to stay available, got %+v", detail["related_resources"])
+	}
+}
+
+func TestEngineRecurringNotepadFoundationFieldsAreDerived(t *testing.T) {
+	engine := NewEngine()
+	now := time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC)
+	engine.now = func() time.Time { return now }
+	engine.ReplaceNotepadItems([]map[string]any{{
+		"item_id":          "todo_recurring_detail",
+		"title":            "每周模板复盘",
+		"bucket":           notepadBucketRecurringRule,
+		"status":           "normal",
+		"type":             "recurring",
+		"due_at":           now.Add(7 * 24 * time.Hour).Format(time.RFC3339),
+		"agent_suggestion": "沿用模板",
+	}})
+
+	detail, ok := engine.NotepadItem("todo_recurring_detail")
+	if !ok {
+		t.Fatal("expected recurring item to exist")
+	}
+	if detail["recurring_enabled"] != true {
+		t.Fatalf("expected recurring item to default to enabled, got %+v", detail)
+	}
+	if detail["repeat_rule_text"] != "每周重复一次" {
+		t.Fatalf("expected recurring rule fallback text, got %+v", detail["repeat_rule_text"])
+	}
+	if detail["next_occurrence_at"] != now.Add(7*24*time.Hour).Format(time.RFC3339) {
+		t.Fatalf("expected next occurrence to follow due_at, got %+v", detail["next_occurrence_at"])
+	}
+	resources, ok := detail["related_resources"].([]map[string]any)
+	if !ok || len(resources) == 0 {
+		t.Fatalf("expected recurring item to derive related resources, got %+v", detail["related_resources"])
+	}
+	if resources[0]["path"] != defaultTaskSourcePath {
+		t.Fatalf("expected recurring item to point to task source directory, got %+v", resources[0])
+	}
+}
+
+func TestEngineNotepadActionMutationsPreserveFoundationState(t *testing.T) {
+	engine := NewEngine()
+	now := time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC)
+	engine.now = func() time.Time { return now }
+	plannedAt := now.Add(4 * time.Hour).Format(time.RFC3339)
+	nextOccurrence := now.Add(14 * 24 * time.Hour).Format(time.RFC3339)
+	engine.ReplaceNotepadItems([]map[string]any{
+		{
+			"item_id":          "todo_restore",
+			"title":            "待恢复事项",
+			"bucket":           notepadBucketLater,
+			"status":           "normal",
+			"type":             "one_time",
+			"due_at":           plannedAt,
+			"agent_suggestion": "整理上下文",
+		},
+		{
+			"item_id":            "todo_rule",
+			"title":              "每周项目复盘",
+			"bucket":             notepadBucketRecurringRule,
+			"status":             "normal",
+			"type":               "recurring",
+			"due_at":             plannedAt,
+			"next_occurrence_at": plannedAt,
+			"recurring_enabled":  true,
+		},
+	})
+
+	completed, ok := engine.CompleteNotepadItem("todo_restore")
+	if !ok {
+		t.Fatal("expected completion to succeed")
+	}
+	if completed["bucket"] != notepadBucketClosed || completed["ended_at"] == nil || completed["planned_at"] != plannedAt {
+		t.Fatalf("expected completion to preserve foundation state, got %+v", completed)
+	}
+
+	restored, ok := engine.RestoreNotepadItem("todo_restore")
+	if !ok {
+		t.Fatal("expected restore to succeed")
+	}
+	if restored["bucket"] != notepadBucketLater || restored["due_at"] != plannedAt || restored["ended_at"] != nil {
+		t.Fatalf("expected restore to recover original bucket and schedule, got %+v", restored)
+	}
+
+	cancelled, ok := engine.CancelNotepadItem("todo_restore")
+	if !ok || cancelled["status"] != "cancelled" {
+		t.Fatalf("expected cancel to close item, got %+v ok=%v", cancelled, ok)
+	}
+
+	paused, ok := engine.SetNotepadRecurringEnabled("todo_rule", false)
+	if !ok || paused["recent_instance_status"] != "paused" || paused["due_at"] != nil {
+		t.Fatalf("expected recurring pause to clear due_at and mark paused, got %+v ok=%v", paused, ok)
+	}
+
+	resumed, ok := engine.SetNotepadRecurringEnabled("todo_rule", true)
+	if !ok || resumed["due_at"] != plannedAt {
+		t.Fatalf("expected recurring resume to restore due_at, got %+v ok=%v", resumed, ok)
+	}
+
+	updatedRule, ok := engine.UpdateNotepadRecurringRule("todo_rule", "每两周一次", nextOccurrence, "仅项目 A")
+	if !ok {
+		t.Fatal("expected recurring rule update to succeed")
+	}
+	if updatedRule["repeat_rule_text"] != "每两周一次" || updatedRule["next_occurrence_at"] != nextOccurrence || updatedRule["effective_scope"] != "仅项目 A" {
+		t.Fatalf("expected recurring rule fields to update, got %+v", updatedRule)
+	}
+
+	if !engine.DeleteNotepadItem("todo_rule") {
+		t.Fatal("expected delete to remove recurring item")
+	}
+	if _, ok := engine.NotepadItem("todo_rule"); ok {
+		t.Fatal("expected deleted recurring item to disappear")
+	}
+}

--- a/services/local-service/internal/runengine/notepad_test.go
+++ b/services/local-service/internal/runengine/notepad_test.go
@@ -221,3 +221,132 @@ func TestEngineTodoStorePersistsAndReloadsNotepadState(t *testing.T) {
 		t.Fatalf("expected related resources to reload, got %+v", detail["related_resources"])
 	}
 }
+
+func TestEngineWithTodoStoreStartsEmptyWhenStoreHasNoNotes(t *testing.T) {
+	engine := NewEngine()
+	items, total := engine.NotepadItems("", 20, 0)
+	if total == 0 || len(items) == 0 {
+		t.Fatal("expected default engine to start with demo notes before todo store attaches")
+	}
+	if err := engine.WithTodoStore(storage.NewInMemoryTodoStore()); err != nil {
+		t.Fatalf("attach empty todo store failed: %v", err)
+	}
+	items, total = engine.NotepadItems("", 20, 0)
+	if total != 0 || len(items) != 0 {
+		t.Fatalf("expected empty todo store to override demo seed data, total=%d len=%d items=%+v", total, len(items), items)
+	}
+}
+
+func TestEngineCompleteNotepadItemPersistsThroughTodoStore(t *testing.T) {
+	todoStore := storage.NewInMemoryTodoStore()
+	engine, err := NewEngineWithStore(storage.NewInMemoryTaskRunStore())
+	if err != nil {
+		t.Fatalf("new engine with store failed: %v", err)
+	}
+	now := time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC)
+	engine.now = func() time.Time { return now }
+	if err := engine.WithTodoStore(todoStore); err != nil {
+		t.Fatalf("attach todo store failed: %v", err)
+	}
+	if err := engine.SyncNotepadItems([]map[string]any{{
+		"item_id":     "todo_complete_persist",
+		"title":       "persist completion",
+		"bucket":      notepadBucketUpcoming,
+		"status":      "normal",
+		"type":        "one_time",
+		"planned_at":  now.Add(4 * time.Hour).Format(time.RFC3339),
+		"due_at":      now.Add(4 * time.Hour).Format(time.RFC3339),
+		"created_at":  now.Format(time.RFC3339),
+		"updated_at":  now.Format(time.RFC3339),
+		"note_text":   "persist me",
+		"source_path": "workspace/todos/inbox.md",
+	}}); err != nil {
+		t.Fatalf("sync notepad items failed: %v", err)
+	}
+	completed, ok := engine.CompleteNotepadItem("todo_complete_persist")
+	if !ok || completed["bucket"] != notepadBucketClosed {
+		t.Fatalf("expected completion to succeed and close note, got %+v ok=%v", completed, ok)
+	}
+	reloaded, err := NewEngineWithStore(storage.NewInMemoryTaskRunStore())
+	if err != nil {
+		t.Fatalf("new reload engine failed: %v", err)
+	}
+	reloaded.now = func() time.Time { return now }
+	if err := reloaded.WithTodoStore(todoStore); err != nil {
+		t.Fatalf("attach todo store on reload failed: %v", err)
+	}
+	detail, ok := reloaded.NotepadItem("todo_complete_persist")
+	if !ok || detail["bucket"] != notepadBucketClosed || detail["status"] != "completed" {
+		t.Fatalf("expected completed note to persist across reload, got %+v ok=%v", detail, ok)
+	}
+}
+
+func TestNotepadHelperFunctionsCoverRecurringAndEncodingPaths(t *testing.T) {
+	now := time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC)
+	if recurringRuleTextFromSpec(recurringRuleSpec{ruleType: "cron", cronExpr: "0 9 * * 1"}) != "cron: 0 9 * * 1" {
+		t.Fatal("expected cron spec to render explicit rule text")
+	}
+	if recurringRuleTextFromSpec(recurringRuleSpec{ruleType: "interval", intervalValue: 1, intervalUnit: "day"}) != "每天一次" {
+		t.Fatal("expected daily interval rule text")
+	}
+	if recurringRuleTextFromSpec(recurringRuleSpec{ruleType: "interval", intervalValue: 2, intervalUnit: "week"}) != "每2周一次" {
+		t.Fatal("expected biweekly interval rule text")
+	}
+	if recurringIntervalText("month") != "月" {
+		t.Fatal("expected month interval text")
+	}
+	item := map[string]any{"planned_at": now.Format(time.RFC3339)}
+	if recurringNextOccurrenceFromSpec(item, recurringRuleSpec{ruleType: "interval", intervalValue: 1, intervalUnit: "month"}) != now.AddDate(0, 1, 0).Format(time.RFC3339) {
+		t.Fatal("expected monthly next occurrence")
+	}
+	if recurringNextOccurrenceFromSpec(item, recurringRuleSpec{ruleType: "interval", intervalValue: 0, intervalUnit: "week"}) != now.AddDate(0, 0, 7).Format(time.RFC3339) {
+		t.Fatal("expected zero interval to normalize to one week")
+	}
+	if maxRecurringInterval(0) != 1 {
+		t.Fatal("expected maxRecurringInterval to normalize zero")
+	}
+	if deriveNotepadEndedAt(map[string]any{"status": "completed", "bucket": notepadBucketClosed, "due_at": now.Format(time.RFC3339)}) != now.Format(time.RFC3339) {
+		t.Fatal("expected ended_at fallback to use due_at for closed completed notes")
+	}
+	resources := cloneResourceList([]any{map[string]any{"id": "res_001", "path": "workspace/todos/inbox.md"}})
+	if len(resources) != 1 || resources[0]["id"] != "res_001" {
+		t.Fatalf("expected cloneResourceList to accept []any values, got %+v", resources)
+	}
+	tagsJSON, err := marshalStringSlice([]any{"weekly", "notes"})
+	if err != nil || tagsJSON == "" {
+		t.Fatalf("expected marshalStringSlice to encode []any tags, got %q err=%v", tagsJSON, err)
+	}
+	if decoded := decodeTags(tagsJSON); len(decoded) != 2 || decoded[1] != "notes" {
+		t.Fatalf("expected decodeTags to restore encoded tags, got %+v", decoded)
+	}
+	if _, err := marshalStringSlice([]any{"weekly", 123}); err != nil {
+		t.Fatalf("expected non-string tag entries to be ignored rather than failing, got %v", err)
+	}
+	if itemIntValue(map[string]any{"count": int64(2)}, "count", 0) != 2 {
+		t.Fatal("expected itemIntValue to read int64 values")
+	}
+	if firstNonEmptyString("", "  value  ") != "value" {
+		t.Fatal("expected firstNonEmptyString to trim and return first value")
+	}
+	if spec := parseRecurringRuleSpec("daily", "", 0, ""); spec.intervalUnit != "day" || spec.intervalValue != 1 {
+		t.Fatalf("expected daily rule text to parse as one-day interval, got %+v", spec)
+	}
+	if spec := parseRecurringRuleSpec("cron: 0 9 * * 1", "", 0, ""); spec.ruleType != "cron" || spec.cronExpr != "0 9 * * 1" {
+		t.Fatalf("expected cron rule text to parse as cron, got %+v", spec)
+	}
+	restoredRecurring := map[string]any{"source_bucket": notepadBucketRecurringRule, "recurring_enabled": true, "next_occurrence_at": now.Add(24 * time.Hour).Format(time.RFC3339)}
+	restoreNotepadItem(restoredRecurring, now)
+	if restoredRecurring["due_at"] != now.Add(24*time.Hour).Format(time.RFC3339) {
+		t.Fatalf("expected recurring restore to restore due_at from next occurrence, got %+v", restoredRecurring)
+	}
+	if deriveRecurringRecentStatus(map[string]any{"status": "cancelled"}) != "cancelled" {
+		t.Fatal("expected recurring recent status to follow explicit cancelled status")
+	}
+	engine, err := NewEngineWithStore(storage.NewInMemoryTaskRunStore())
+	if err != nil {
+		t.Fatalf("new engine with store failed: %v", err)
+	}
+	if engine.CurrentState() != "processing" || engine.CurrentTaskStatus() != "confirming_intent" {
+		t.Fatalf("expected empty engine defaults for run/task state, got run=%s task=%s", engine.CurrentState(), engine.CurrentTaskStatus())
+	}
+}

--- a/services/local-service/internal/runengine/notepad_test.go
+++ b/services/local-service/internal/runengine/notepad_test.go
@@ -3,6 +3,8 @@ package runengine
 import (
 	"testing"
 	"time"
+
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/storage"
 )
 
 func TestEngineNotepadListProjectsProtocolShapeOnly(t *testing.T) {
@@ -78,7 +80,7 @@ func TestEngineRecurringNotepadFoundationFieldsAreDerived(t *testing.T) {
 	if detail["repeat_rule_text"] != "每周重复一次" {
 		t.Fatalf("expected recurring rule fallback text, got %+v", detail["repeat_rule_text"])
 	}
-	if detail["next_occurrence_at"] != now.Add(7*24*time.Hour).Format(time.RFC3339) {
+	if detail["next_occurrence_at"] != now.Add(14*24*time.Hour).Format(time.RFC3339) {
 		t.Fatalf("expected next occurrence to follow due_at, got %+v", detail["next_occurrence_at"])
 	}
 	resources, ok := detail["related_resources"].([]map[string]any)
@@ -162,5 +164,60 @@ func TestEngineNotepadActionMutationsPreserveFoundationState(t *testing.T) {
 	}
 	if _, ok := engine.NotepadItem("todo_rule"); ok {
 		t.Fatal("expected deleted recurring item to disappear")
+	}
+}
+
+func TestEngineTodoStorePersistsAndReloadsNotepadState(t *testing.T) {
+	todoStore := storage.NewInMemoryTodoStore()
+	engine, err := NewEngineWithStore(storage.NewInMemoryTaskRunStore())
+	if err != nil {
+		t.Fatalf("new engine with store failed: %v", err)
+	}
+	now := time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC)
+	engine.now = func() time.Time { return now }
+	if err := engine.WithTodoStore(todoStore); err != nil {
+		t.Fatalf("attach todo store failed: %v", err)
+	}
+	if err := engine.SyncNotepadItems([]map[string]any{{
+		"item_id":            "todo_persisted_rule",
+		"title":              "每周项目复盘",
+		"bucket":             notepadBucketRecurringRule,
+		"status":             "normal",
+		"type":               "recurring",
+		"source_path":        "workspace/todos/weekly.md",
+		"source_line":        2,
+		"note_text":          "从真实任务源解析出来的说明。",
+		"repeat_rule_text":   "每两周一次",
+		"next_occurrence_at": now.Add(14 * 24 * time.Hour).Format(time.RFC3339),
+		"related_resources": []map[string]any{{
+			"id":          "res_persisted",
+			"label":       "模板",
+			"path":        "workspace/templates/retro.md",
+			"type":        "file",
+			"target_kind": "file",
+		}},
+	}}); err != nil {
+		t.Fatalf("sync notepad items failed: %v", err)
+	}
+
+	reloaded, err := NewEngineWithStore(storage.NewInMemoryTaskRunStore())
+	if err != nil {
+		t.Fatalf("new engine reload failed: %v", err)
+	}
+	reloaded.now = func() time.Time { return now }
+	if err := reloaded.WithTodoStore(todoStore); err != nil {
+		t.Fatalf("attach todo store on reload failed: %v", err)
+	}
+
+	detail, ok := reloaded.NotepadItem("todo_persisted_rule")
+	if !ok {
+		t.Fatal("expected persisted note to reload from todo store")
+	}
+	if detail["repeat_rule_text"] != "每两周一次" || detail["source_path"] != "workspace/todos/weekly.md" {
+		t.Fatalf("expected recurring note metadata to reload, got %+v", detail)
+	}
+	resources, ok := detail["related_resources"].([]map[string]any)
+	if !ok || len(resources) != 1 {
+		t.Fatalf("expected related resources to reload, got %+v", detail["related_resources"])
 	}
 }

--- a/services/local-service/internal/storage/service.go
+++ b/services/local-service/internal/storage/service.go
@@ -49,6 +49,7 @@ type Service struct {
 	taskRunStore       TaskRunStore
 	toolCallStore      ToolCallStore
 	artifactStore      ArtifactStore
+	todoStore          TodoStore
 	secretStore        SecretStore
 	auditStore         AuditStore
 	recoveryPointStore RecoveryPointStore
@@ -68,6 +69,7 @@ func NewService(adapter platform.StorageAdapter) *Service {
 	taskRunStore := TaskRunStore(NewInMemoryTaskRunStore())
 	toolCallStore := ToolCallStore(newInMemoryToolCallStore())
 	artifactStore := ArtifactStore(newInMemoryArtifactStore())
+	todoStore := TodoStore(NewInMemoryTodoStore())
 	secretStore := SecretStore(newInMemorySecretStore())
 	auditStore := AuditStore(newInMemoryAuditStore())
 	recoveryPointStore := RecoveryPointStore(newInMemoryRecoveryPointStore())
@@ -123,6 +125,15 @@ func NewService(adapter platform.StorageAdapter) *Service {
 				fallbackActive = true
 			}
 
+			sqliteTodoStore, err := NewSQLiteTodoStore(databasePath)
+			if err == nil {
+				todoStore = sqliteTodoStore
+			}
+			if err != nil {
+				storeInitErrors = append(storeInitErrors, fmt.Errorf("initialize sqlite todo store: %w", err))
+				fallbackActive = true
+			}
+
 			if secretPath := strings.TrimSpace(adapter.SecretStorePath()); secretPath != "" {
 				sqliteSecretStore, err := NewSQLiteSecretStore(secretPath)
 				if err == nil {
@@ -163,6 +174,7 @@ func NewService(adapter platform.StorageAdapter) *Service {
 		taskRunStore:       taskRunStore,
 		toolCallStore:      toolCallStore,
 		artifactStore:      artifactStore,
+		todoStore:          todoStore,
 		secretStore:        secretStore,
 		auditStore:         auditStore,
 		recoveryPointStore: recoveryPointStore,
@@ -266,6 +278,11 @@ func (s *Service) ArtifactStore() ArtifactStore {
 	return s.artifactStore
 }
 
+// TodoStore returns the configured notes/todo persistence store.
+func (s *Service) TodoStore() TodoStore {
+	return s.todoStore
+}
+
 // SecretStore returns the configured secret store.
 func (s *Service) SecretStore() SecretStore {
 	return s.secretStore
@@ -315,6 +332,9 @@ func (s *Service) Close() error {
 		errs = append(errs, closer.Close())
 	}
 	if closer, ok := s.artifactStore.(interface{ Close() error }); ok {
+		errs = append(errs, closer.Close())
+	}
+	if closer, ok := s.todoStore.(interface{ Close() error }); ok {
 		errs = append(errs, closer.Close())
 	}
 	if closer, ok := s.secretStore.(interface{ Close() error }); ok {

--- a/services/local-service/internal/storage/sqlite_todo_store.go
+++ b/services/local-service/internal/storage/sqlite_todo_store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	_ "modernc.org/sqlite"
@@ -212,6 +213,9 @@ func (s *SQLiteTodoStore) initialize(ctx context.Context) error {
 	`); err != nil {
 		return fmt.Errorf("create todo_items table: %w", err)
 	}
+	if err := s.ensureTodoItemColumns(ctx); err != nil {
+		return err
+	}
 	if _, err := s.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_todo_items_bucket_due_at ON todo_items(bucket, due_at);`); err != nil {
 		return fmt.Errorf("create todo_items bucket index: %w", err)
 	}
@@ -239,10 +243,81 @@ func (s *SQLiteTodoStore) initialize(ctx context.Context) error {
 	`); err != nil {
 		return fmt.Errorf("create recurring_rules table: %w", err)
 	}
+	if err := s.ensureRecurringRuleColumns(ctx); err != nil {
+		return err
+	}
 	if _, err := s.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_recurring_rules_item_id ON recurring_rules(item_id);`); err != nil {
 		return fmt.Errorf("create recurring_rules item index: %w", err)
 	}
 	return nil
+}
+
+func (s *SQLiteTodoStore) ensureTodoItemColumns(ctx context.Context) error {
+	requiredColumns := map[string]string{
+		"note_text":              "TEXT",
+		"prerequisite":           "TEXT",
+		"planned_at":             "TEXT",
+		"ended_at":               "TEXT",
+		"related_resources_json": "TEXT",
+	}
+	return s.ensureColumns(ctx, sqliteTodoTableName, requiredColumns)
+}
+
+func (s *SQLiteTodoStore) ensureRecurringRuleColumns(ctx context.Context) error {
+	requiredColumns := map[string]string{
+		"repeat_rule_text":       "TEXT",
+		"next_occurrence_at":     "TEXT",
+		"recent_instance_status": "TEXT",
+		"effective_scope":        "TEXT",
+	}
+	return s.ensureColumns(ctx, sqliteRecurringRuleTableName, requiredColumns)
+}
+
+func (s *SQLiteTodoStore) ensureColumns(ctx context.Context, tableName string, requiredColumns map[string]string) error {
+	existingColumns, err := s.tableColumns(ctx, tableName)
+	if err != nil {
+		return err
+	}
+	columnNames := make([]string, 0, len(requiredColumns))
+	for name := range requiredColumns {
+		columnNames = append(columnNames, name)
+	}
+	sort.Strings(columnNames)
+	for _, name := range columnNames {
+		if _, ok := existingColumns[name]; ok {
+			continue
+		}
+		if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s`, tableName, name, requiredColumns[name])); err != nil {
+			return fmt.Errorf("migrate %s add column %s: %w", tableName, name, err)
+		}
+	}
+	return nil
+}
+
+func (s *SQLiteTodoStore) tableColumns(ctx context.Context, tableName string) (map[string]struct{}, error) {
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`PRAGMA table_info(%s);`, tableName))
+	if err != nil {
+		return nil, fmt.Errorf("inspect %s schema: %w", tableName, err)
+	}
+	defer rows.Close()
+
+	columns := make(map[string]struct{})
+	for rows.Next() {
+		var cid int
+		var name string
+		var columnType string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &pk); err != nil {
+			return nil, fmt.Errorf("scan %s schema: %w", tableName, err)
+		}
+		columns[name] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate %s schema: %w", tableName, err)
+	}
+	return columns, nil
 }
 
 func nullableString(value string) any {

--- a/services/local-service/internal/storage/sqlite_todo_store.go
+++ b/services/local-service/internal/storage/sqlite_todo_store.go
@@ -1,0 +1,260 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	_ "modernc.org/sqlite"
+)
+
+const sqliteTodoTableName = "todo_items"
+const sqliteRecurringRuleTableName = "recurring_rules"
+
+// SQLiteTodoStore persists todo items and recurring rules in SQLite.
+type SQLiteTodoStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteTodoStore creates and returns a SQLiteTodoStore.
+func NewSQLiteTodoStore(databasePath string) (*SQLiteTodoStore, error) {
+	databasePath = strings.TrimSpace(databasePath)
+	if databasePath == "" {
+		return nil, ErrDatabasePathRequired
+	}
+	if err := os.MkdirAll(filepath.Dir(databasePath), 0o755); err != nil {
+		return nil, fmt.Errorf("prepare sqlite directory: %w", err)
+	}
+
+	db, err := sql.Open(sqliteDriverName, databasePath)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite database: %w", err)
+	}
+	if err := db.PingContext(context.Background()); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ping sqlite database: %w", err)
+	}
+
+	store := &SQLiteTodoStore{db: db}
+	if err := store.initialize(context.Background()); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return store, nil
+}
+
+// ReplaceTodoState atomically replaces the persisted todo and recurring state.
+func (s *SQLiteTodoStore) ReplaceTodoState(ctx context.Context, items []TodoItemRecord, rules []RecurringRuleRecord) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin todo replace transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM recurring_rules`); err != nil {
+		return fmt.Errorf("clear recurring rules: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM todo_items`); err != nil {
+		return fmt.Errorf("clear todo items: %w", err)
+	}
+
+	for _, item := range items {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO todo_items (
+				item_id, title, bucket, status, source_path, source_line, due_at, tags_json,
+				agent_suggestion, note_text, prerequisite, planned_at, ended_at,
+				related_resources_json, linked_task_id, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, item.ItemID, item.Title, item.Bucket, item.Status, item.SourcePath, item.SourceLine, nullableString(item.DueAt), nullableString(item.TagsJSON), nullableString(item.AgentSuggestion), nullableString(item.NoteText), nullableString(item.Prerequisite), nullableString(item.PlannedAt), nullableString(item.EndedAt), nullableString(item.RelatedResourcesJSON), nullableString(item.LinkedTaskID), item.CreatedAt, item.UpdatedAt); err != nil {
+			return fmt.Errorf("insert todo item %s: %w", item.ItemID, err)
+		}
+	}
+
+	for _, rule := range rules {
+		enabledValue := 0
+		if rule.Enabled {
+			enabledValue = 1
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO recurring_rules (
+				rule_id, item_id, rule_type, cron_expr, interval_value, interval_unit,
+				reminder_strategy, enabled, repeat_rule_text, next_occurrence_at,
+				recent_instance_status, effective_scope, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, rule.RuleID, rule.ItemID, rule.RuleType, nullableString(rule.CronExpr), nullableInt(rule.IntervalValue), nullableString(rule.IntervalUnit), rule.ReminderStrategy, enabledValue, nullableString(rule.RepeatRuleText), nullableString(rule.NextOccurrenceAt), nullableString(rule.RecentInstanceStatus), nullableString(rule.EffectiveScope), rule.CreatedAt, rule.UpdatedAt); err != nil {
+			return fmt.Errorf("insert recurring rule %s: %w", rule.RuleID, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit todo replace transaction: %w", err)
+	}
+	return nil
+}
+
+// LoadTodoState returns the persisted todo and recurring snapshots.
+func (s *SQLiteTodoStore) LoadTodoState(ctx context.Context) ([]TodoItemRecord, []RecurringRuleRecord, error) {
+	itemRows, err := s.db.QueryContext(ctx, `
+		SELECT item_id, title, bucket, status, source_path, source_line, due_at, tags_json,
+		       agent_suggestion, note_text, prerequisite, planned_at, ended_at,
+		       related_resources_json, linked_task_id, created_at, updated_at
+		FROM todo_items ORDER BY updated_at DESC, item_id DESC
+	`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load todo items: %w", err)
+	}
+	defer itemRows.Close()
+
+	items := make([]TodoItemRecord, 0)
+	for itemRows.Next() {
+		var item TodoItemRecord
+		var sourcePath, dueAt, tagsJSON, agentSuggestion, noteText, prerequisite, plannedAt, endedAt, relatedResourcesJSON, linkedTaskID sql.NullString
+		var sourceLine sql.NullInt64
+		if err := itemRows.Scan(&item.ItemID, &item.Title, &item.Bucket, &item.Status, &sourcePath, &sourceLine, &dueAt, &tagsJSON, &agentSuggestion, &noteText, &prerequisite, &plannedAt, &endedAt, &relatedResourcesJSON, &linkedTaskID, &item.CreatedAt, &item.UpdatedAt); err != nil {
+			return nil, nil, fmt.Errorf("scan todo item row: %w", err)
+		}
+		item.SourcePath = sourcePath.String
+		if sourceLine.Valid {
+			item.SourceLine = int(sourceLine.Int64)
+		}
+		item.DueAt = dueAt.String
+		item.TagsJSON = tagsJSON.String
+		item.AgentSuggestion = agentSuggestion.String
+		item.NoteText = noteText.String
+		item.Prerequisite = prerequisite.String
+		item.PlannedAt = plannedAt.String
+		item.EndedAt = endedAt.String
+		item.RelatedResourcesJSON = relatedResourcesJSON.String
+		item.LinkedTaskID = linkedTaskID.String
+		items = append(items, item)
+	}
+	if err := itemRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate todo item rows: %w", err)
+	}
+
+	ruleRows, err := s.db.QueryContext(ctx, `
+		SELECT rule_id, item_id, rule_type, cron_expr, interval_value, interval_unit,
+		       reminder_strategy, enabled, repeat_rule_text, next_occurrence_at,
+		       recent_instance_status, effective_scope, created_at, updated_at
+		FROM recurring_rules ORDER BY updated_at DESC, rule_id DESC
+	`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load recurring rules: %w", err)
+	}
+	defer ruleRows.Close()
+
+	rules := make([]RecurringRuleRecord, 0)
+	for ruleRows.Next() {
+		var rule RecurringRuleRecord
+		var cronExpr, intervalUnit, repeatRuleText, nextOccurrenceAt, recentInstanceStatus, effectiveScope sql.NullString
+		var intervalValue sql.NullInt64
+		var enabledValue int
+		if err := ruleRows.Scan(&rule.RuleID, &rule.ItemID, &rule.RuleType, &cronExpr, &intervalValue, &intervalUnit, &rule.ReminderStrategy, &enabledValue, &repeatRuleText, &nextOccurrenceAt, &recentInstanceStatus, &effectiveScope, &rule.CreatedAt, &rule.UpdatedAt); err != nil {
+			return nil, nil, fmt.Errorf("scan recurring rule row: %w", err)
+		}
+		rule.CronExpr = cronExpr.String
+		if intervalValue.Valid {
+			rule.IntervalValue = int(intervalValue.Int64)
+		}
+		rule.IntervalUnit = intervalUnit.String
+		rule.Enabled = enabledValue == 1
+		rule.RepeatRuleText = repeatRuleText.String
+		rule.NextOccurrenceAt = nextOccurrenceAt.String
+		rule.RecentInstanceStatus = recentInstanceStatus.String
+		rule.EffectiveScope = effectiveScope.String
+		rules = append(rules, rule)
+	}
+	if err := ruleRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate recurring rule rows: %w", err)
+	}
+
+	return items, rules, nil
+}
+
+// Close closes the underlying SQLite connection.
+func (s *SQLiteTodoStore) Close() error {
+	if s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+func (s *SQLiteTodoStore) initialize(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, `PRAGMA journal_mode=WAL;`); err != nil {
+		return fmt.Errorf("enable sqlite wal mode: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `PRAGMA busy_timeout=5000;`); err != nil {
+		return fmt.Errorf("set sqlite busy timeout: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS todo_items (
+			item_id TEXT PRIMARY KEY,
+			title TEXT NOT NULL,
+			bucket TEXT NOT NULL,
+			status TEXT NOT NULL,
+			source_path TEXT,
+			source_line INTEGER,
+			due_at TEXT,
+			tags_json TEXT,
+			agent_suggestion TEXT,
+			note_text TEXT,
+			prerequisite TEXT,
+			planned_at TEXT,
+			ended_at TEXT,
+			related_resources_json TEXT,
+			linked_task_id TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+	`); err != nil {
+		return fmt.Errorf("create todo_items table: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_todo_items_bucket_due_at ON todo_items(bucket, due_at);`); err != nil {
+		return fmt.Errorf("create todo_items bucket index: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_todo_items_linked_task_id ON todo_items(linked_task_id);`); err != nil {
+		return fmt.Errorf("create todo_items linked task index: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS recurring_rules (
+			rule_id TEXT PRIMARY KEY,
+			item_id TEXT NOT NULL,
+			rule_type TEXT NOT NULL,
+			cron_expr TEXT,
+			interval_value INTEGER,
+			interval_unit TEXT,
+			reminder_strategy TEXT NOT NULL,
+			enabled INTEGER NOT NULL DEFAULT 1,
+			repeat_rule_text TEXT,
+			next_occurrence_at TEXT,
+			recent_instance_status TEXT,
+			effective_scope TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			FOREIGN KEY(item_id) REFERENCES todo_items(item_id)
+		);
+	`); err != nil {
+		return fmt.Errorf("create recurring_rules table: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_recurring_rules_item_id ON recurring_rules(item_id);`); err != nil {
+		return fmt.Errorf("create recurring_rules item index: %w", err)
+	}
+	return nil
+}
+
+func nullableString(value string) any {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}
+
+func nullableInt(value int) any {
+	if value == 0 {
+		return nil
+	}
+	return value
+}

--- a/services/local-service/internal/storage/todo_store.go
+++ b/services/local-service/internal/storage/todo_store.go
@@ -1,0 +1,68 @@
+package storage
+
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+// InMemoryTodoStore provides a process-local fallback for notes/todo state.
+type InMemoryTodoStore struct {
+	mu    sync.RWMutex
+	items map[string]TodoItemRecord
+	rules map[string]RecurringRuleRecord
+}
+
+// NewInMemoryTodoStore creates and returns an in-memory todo store.
+func NewInMemoryTodoStore() *InMemoryTodoStore {
+	return &InMemoryTodoStore{
+		items: make(map[string]TodoItemRecord),
+		rules: make(map[string]RecurringRuleRecord),
+	}
+}
+
+// ReplaceTodoState atomically replaces the persisted todo and recurring state.
+func (s *InMemoryTodoStore) ReplaceTodoState(_ context.Context, items []TodoItemRecord, rules []RecurringRuleRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.items = make(map[string]TodoItemRecord, len(items))
+	for _, item := range items {
+		s.items[item.ItemID] = item
+	}
+	s.rules = make(map[string]RecurringRuleRecord, len(rules))
+	for _, rule := range rules {
+		s.rules[rule.RuleID] = rule
+	}
+	return nil
+}
+
+// LoadTodoState returns the currently persisted todo and recurring snapshots.
+func (s *InMemoryTodoStore) LoadTodoState(_ context.Context) ([]TodoItemRecord, []RecurringRuleRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := make([]TodoItemRecord, 0, len(s.items))
+	for _, item := range s.items {
+		items = append(items, item)
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].UpdatedAt == items[j].UpdatedAt {
+			return items[i].ItemID > items[j].ItemID
+		}
+		return items[i].UpdatedAt > items[j].UpdatedAt
+	})
+
+	rules := make([]RecurringRuleRecord, 0, len(s.rules))
+	for _, rule := range s.rules {
+		rules = append(rules, rule)
+	}
+	sort.SliceStable(rules, func(i, j int) bool {
+		if rules[i].UpdatedAt == rules[j].UpdatedAt {
+			return rules[i].RuleID > rules[j].RuleID
+		}
+		return rules[i].UpdatedAt > rules[j].UpdatedAt
+	})
+
+	return items, rules, nil
+}

--- a/services/local-service/internal/storage/todo_store_test.go
+++ b/services/local-service/internal/storage/todo_store_test.go
@@ -1,0 +1,115 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestInMemoryTodoStoreReplacesAndLoadsState(t *testing.T) {
+	store := NewInMemoryTodoStore()
+	err := store.ReplaceTodoState(context.Background(), []TodoItemRecord{{
+		ItemID:     "todo_001",
+		Title:      "review notes",
+		Bucket:     "upcoming",
+		Status:     "normal",
+		SourcePath: "workspace/todos/inbox.md",
+		CreatedAt:  "2026-04-20T10:00:00Z",
+		UpdatedAt:  "2026-04-20T10:00:00Z",
+	}}, []RecurringRuleRecord{{
+		RuleID:           "rule_001",
+		ItemID:           "todo_001",
+		RuleType:         "interval",
+		IntervalValue:    1,
+		IntervalUnit:     "week",
+		ReminderStrategy: "due_at",
+		Enabled:          true,
+		CreatedAt:        "2026-04-20T10:00:00Z",
+		UpdatedAt:        "2026-04-20T10:00:00Z",
+	}})
+	if err != nil {
+		t.Fatalf("replace todo state failed: %v", err)
+	}
+
+	items, rules, err := store.LoadTodoState(context.Background())
+	if err != nil {
+		t.Fatalf("load todo state failed: %v", err)
+	}
+	if len(items) != 1 || items[0].ItemID != "todo_001" {
+		t.Fatalf("expected one persisted todo item, got %+v", items)
+	}
+	if len(rules) != 1 || rules[0].RuleID != "rule_001" {
+		t.Fatalf("expected one persisted recurring rule, got %+v", rules)
+	}
+
+	err = store.ReplaceTodoState(context.Background(), []TodoItemRecord{{
+		ItemID:    "todo_002",
+		Title:     "rewrite packet",
+		Bucket:    "later",
+		Status:    "normal",
+		CreatedAt: "2026-04-20T11:00:00Z",
+		UpdatedAt: "2026-04-20T11:00:00Z",
+	}}, nil)
+	if err != nil {
+		t.Fatalf("replace todo state second time failed: %v", err)
+	}
+	items, rules, err = store.LoadTodoState(context.Background())
+	if err != nil {
+		t.Fatalf("load todo state after replace failed: %v", err)
+	}
+	if len(items) != 1 || items[0].ItemID != "todo_002" || len(rules) != 0 {
+		t.Fatalf("expected replace semantics, got items=%+v rules=%+v", items, rules)
+	}
+}
+
+func TestSQLiteTodoStorePersistsAndLoadsState(t *testing.T) {
+	store, err := NewSQLiteTodoStore(filepath.Join(t.TempDir(), "todos.db"))
+	if err != nil {
+		t.Fatalf("new sqlite todo store failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	err = store.ReplaceTodoState(context.Background(), []TodoItemRecord{
+		{
+			ItemID:               "todo_sql_001",
+			Title:                "weekly retro",
+			Bucket:               "recurring_rule",
+			Status:               "normal",
+			SourcePath:           "workspace/todos/weekly.md",
+			SourceLine:           1,
+			DueAt:                "2026-04-25T10:00:00Z",
+			NoteText:             "review blockers",
+			RelatedResourcesJSON: `[{"id":"res_001","path":"workspace/templates/retro.md"}]`,
+			CreatedAt:            "2026-04-20T10:00:00Z",
+			UpdatedAt:            "2026-04-20T10:00:00Z",
+		},
+	}, []RecurringRuleRecord{{
+		RuleID:               "rule_sql_001",
+		ItemID:               "todo_sql_001",
+		RuleType:             "interval",
+		IntervalValue:        2,
+		IntervalUnit:         "week",
+		ReminderStrategy:     "due_at",
+		Enabled:              true,
+		RepeatRuleText:       "每两周一次",
+		NextOccurrenceAt:     "2026-05-09T10:00:00Z",
+		RecentInstanceStatus: "completed",
+		EffectiveScope:       "Project A",
+		CreatedAt:            "2026-04-20T10:00:00Z",
+		UpdatedAt:            "2026-04-20T10:00:00Z",
+	}})
+	if err != nil {
+		t.Fatalf("replace sqlite todo state failed: %v", err)
+	}
+
+	items, rules, err := store.LoadTodoState(context.Background())
+	if err != nil {
+		t.Fatalf("load sqlite todo state failed: %v", err)
+	}
+	if len(items) != 1 || items[0].ItemID != "todo_sql_001" || items[0].RelatedResourcesJSON == "" {
+		t.Fatalf("expected sqlite todo item payload to persist, got %+v", items)
+	}
+	if len(rules) != 1 || rules[0].RuleID != "rule_sql_001" || rules[0].NextOccurrenceAt != "2026-05-09T10:00:00Z" {
+		t.Fatalf("expected sqlite recurring rule payload to persist, got %+v", rules)
+	}
+}

--- a/services/local-service/internal/storage/todo_store_test.go
+++ b/services/local-service/internal/storage/todo_store_test.go
@@ -2,8 +2,11 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"testing"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestInMemoryTodoStoreReplacesAndLoadsState(t *testing.T) {
@@ -111,5 +114,139 @@ func TestSQLiteTodoStorePersistsAndLoadsState(t *testing.T) {
 	}
 	if len(rules) != 1 || rules[0].RuleID != "rule_sql_001" || rules[0].NextOccurrenceAt != "2026-05-09T10:00:00Z" {
 		t.Fatalf("expected sqlite recurring rule payload to persist, got %+v", rules)
+	}
+}
+
+func TestSQLiteTodoStoreLoadsEmptyStateAndBlankPathFails(t *testing.T) {
+	if _, err := NewSQLiteTodoStore("   "); err == nil {
+		t.Fatal("expected blank database path to be rejected")
+	}
+	store, err := NewSQLiteTodoStore(filepath.Join(t.TempDir(), "empty.db"))
+	if err != nil {
+		t.Fatalf("new sqlite todo store failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	items, rules, err := store.LoadTodoState(context.Background())
+	if err != nil {
+		t.Fatalf("load empty sqlite todo state failed: %v", err)
+	}
+	if len(items) != 0 || len(rules) != 0 {
+		t.Fatalf("expected empty sqlite todo state, got items=%+v rules=%+v", items, rules)
+	}
+}
+
+func TestSQLiteTodoStoreMigratesExistingTablesBeforeLoadingAndReplacing(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "todos-legacy.db")
+	db, err := sql.Open(sqliteDriverName, databasePath)
+	if err != nil {
+		t.Fatalf("open legacy sqlite db failed: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`
+		CREATE TABLE todo_items (
+			item_id TEXT PRIMARY KEY,
+			title TEXT NOT NULL,
+			bucket TEXT NOT NULL,
+			status TEXT NOT NULL,
+			source_path TEXT,
+			source_line INTEGER,
+			due_at TEXT,
+			tags_json TEXT,
+			agent_suggestion TEXT,
+			linked_task_id TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+		CREATE TABLE recurring_rules (
+			rule_id TEXT PRIMARY KEY,
+			item_id TEXT NOT NULL,
+			rule_type TEXT NOT NULL,
+			cron_expr TEXT,
+			interval_value INTEGER,
+			interval_unit TEXT,
+			reminder_strategy TEXT NOT NULL,
+			enabled INTEGER NOT NULL DEFAULT 1,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+		INSERT INTO todo_items (item_id, title, bucket, status, created_at, updated_at) VALUES ('todo_legacy', 'legacy todo', 'upcoming', 'normal', '2026-04-20T10:00:00Z', '2026-04-20T10:00:00Z');
+		INSERT INTO recurring_rules (rule_id, item_id, rule_type, reminder_strategy, enabled, created_at, updated_at) VALUES ('rule_legacy', 'todo_legacy', 'interval', 'due_at', 1, '2026-04-20T10:00:00Z', '2026-04-20T10:00:00Z');
+	`); err != nil {
+		t.Fatalf("seed legacy schema failed: %v", err)
+	}
+	_ = db.Close()
+
+	store, err := NewSQLiteTodoStore(databasePath)
+	if err != nil {
+		t.Fatalf("open migrated sqlite todo store failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	items, rules, err := store.LoadTodoState(context.Background())
+	if err != nil {
+		t.Fatalf("load migrated todo state failed: %v", err)
+	}
+	if len(items) != 1 || items[0].ItemID != "todo_legacy" {
+		t.Fatalf("expected legacy todo row to survive migration, got %+v", items)
+	}
+	if len(rules) != 1 || rules[0].RuleID != "rule_legacy" {
+		t.Fatalf("expected legacy recurring row to survive migration, got %+v", rules)
+	}
+
+	err = store.ReplaceTodoState(context.Background(), []TodoItemRecord{{
+		ItemID:               "todo_legacy",
+		Title:                "legacy todo updated",
+		Bucket:               "later",
+		Status:               "normal",
+		NoteText:             "now with richer fields",
+		RelatedResourcesJSON: `[{"id":"res_legacy"}]`,
+		CreatedAt:            "2026-04-20T10:00:00Z",
+		UpdatedAt:            "2026-04-20T12:00:00Z",
+	}}, []RecurringRuleRecord{{
+		RuleID:               "rule_legacy",
+		ItemID:               "todo_legacy",
+		RuleType:             "interval",
+		IntervalValue:        1,
+		IntervalUnit:         "week",
+		ReminderStrategy:     "due_at",
+		Enabled:              true,
+		RepeatRuleText:       "每周一次",
+		NextOccurrenceAt:     "2026-04-27T10:00:00Z",
+		RecentInstanceStatus: "completed",
+		EffectiveScope:       "legacy",
+		CreatedAt:            "2026-04-20T10:00:00Z",
+		UpdatedAt:            "2026-04-20T12:00:00Z",
+	}})
+	if err != nil {
+		t.Fatalf("replace migrated todo state failed: %v", err)
+	}
+	items, rules, err = store.LoadTodoState(context.Background())
+	if err != nil {
+		t.Fatalf("reload migrated todo state failed: %v", err)
+	}
+	if items[0].NoteText != "now with richer fields" || rules[0].RepeatRuleText != "每周一次" {
+		t.Fatalf("expected migrated schema to support new columns, got items=%+v rules=%+v", items, rules)
+	}
+}
+
+func TestServiceTodoStoreAccessorUsesConfiguredStore(t *testing.T) {
+	service := NewService(nil)
+	if service.TodoStore() == nil {
+		t.Fatal("expected todo store accessor to return fallback store")
+	}
+	configured := NewService(stubAdapter{databasePath: filepath.Join(t.TempDir(), "service.db")})
+	defer func() { _ = configured.Close() }()
+	if configured.TodoStore() == nil {
+		t.Fatal("expected configured service to expose todo store")
+	}
+	if err := configured.TodoStore().ReplaceTodoState(context.Background(), []TodoItemRecord{{
+		ItemID:    "todo_service",
+		Title:     "service note",
+		Bucket:    "upcoming",
+		Status:    "normal",
+		CreatedAt: "2026-04-20T10:00:00Z",
+		UpdatedAt: "2026-04-20T10:00:00Z",
+	}}, nil); err != nil {
+		t.Fatalf("expected service todo store to persist state, got %v", err)
 	}
 }

--- a/services/local-service/internal/storage/types.go
+++ b/services/local-service/internal/storage/types.go
@@ -86,6 +86,51 @@ type ArtifactStore interface {
 	ListArtifacts(ctx context.Context, taskID string, limit, offset int) ([]ArtifactRecord, int, error)
 }
 
+// TodoItemRecord describes one persisted notes/todo snapshot.
+type TodoItemRecord struct {
+	ItemID               string
+	Title                string
+	Bucket               string
+	Status               string
+	SourcePath           string
+	SourceLine           int
+	DueAt                string
+	TagsJSON             string
+	AgentSuggestion      string
+	NoteText             string
+	Prerequisite         string
+	PlannedAt            string
+	EndedAt              string
+	RelatedResourcesJSON string
+	LinkedTaskID         string
+	CreatedAt            string
+	UpdatedAt            string
+}
+
+// RecurringRuleRecord describes one persisted recurring-rule snapshot.
+type RecurringRuleRecord struct {
+	RuleID               string
+	ItemID               string
+	RuleType             string
+	CronExpr             string
+	IntervalValue        int
+	IntervalUnit         string
+	ReminderStrategy     string
+	Enabled              bool
+	RepeatRuleText       string
+	NextOccurrenceAt     string
+	RecentInstanceStatus string
+	EffectiveScope       string
+	CreatedAt            string
+	UpdatedAt            string
+}
+
+// TodoStore defines persistence for notes/todo items and recurring rules.
+type TodoStore interface {
+	ReplaceTodoState(ctx context.Context, items []TodoItemRecord, rules []RecurringRuleRecord) error
+	LoadTodoState(ctx context.Context) ([]TodoItemRecord, []RecurringRuleRecord, error)
+}
+
 // SecretRecord captures one secret value persisted outside the normal settings path.
 type SecretRecord struct {
 	Namespace string

--- a/services/local-service/internal/taskinspector/service.go
+++ b/services/local-service/internal/taskinspector/service.go
@@ -44,6 +44,7 @@ type RunResult struct {
 	Summary      map[string]any
 	Suggestions  []string
 	NotepadItems []map[string]any
+	SourceSynced bool
 }
 
 // NewService 创建并返回 task inspector 服务。
@@ -57,9 +58,12 @@ func NewService(fileSystem platform.FileSystemAdapter) *Service {
 // Run 执行一次最小真实巡检。
 func (s *Service) Run(input RunInput) RunResult {
 	sources := resolveSources(input.TargetSources, input.Config)
+	sourceSynced := len(sources) > 0 && s.fileSystem != nil
 	parsedFiles, parsedNotepadItems := s.inspectSources(sources)
 	resolvedNotepadItems := cloneMapSlice(input.NotepadItems)
-	if len(parsedNotepadItems) > 0 {
+	if sourceSynced {
+		resolvedNotepadItems = cloneMapSlice(parsedNotepadItems)
+	} else if len(parsedNotepadItems) > 0 {
 		resolvedNotepadItems = parsedNotepadItems
 	}
 	fileItems := countOpenNotepadItems(parsedNotepadItems)
@@ -78,6 +82,7 @@ func (s *Service) Run(input RunInput) RunResult {
 		},
 		Suggestions:  buildSuggestions(resolvedNotepadItems, input.UnfinishedTasks, sources, parsedFiles, dueToday, overdue, staleCount, fileItems),
 		NotepadItems: cloneMapSlice(resolvedNotepadItems),
+		SourceSynced: sourceSynced,
 	}
 }
 

--- a/services/local-service/internal/taskinspector/service.go
+++ b/services/local-service/internal/taskinspector/service.go
@@ -3,6 +3,7 @@ package taskinspector
 
 import (
 	"fmt"
+	"hash/fnv"
 	"io/fs"
 	"path"
 	"strings"
@@ -13,6 +14,13 @@ import (
 )
 
 const defaultStaleInterval = 15 * time.Minute
+
+const (
+	notepadBucketClosed        = "closed"
+	notepadBucketLater         = "later"
+	notepadBucketRecurringRule = "recurring_rule"
+	notepadBucketUpcoming      = "upcoming"
+)
 
 // Service 负责根据 workspace、notepad 和 runtime task 状态生成巡检结果。
 type Service struct {
@@ -35,6 +43,7 @@ type RunResult struct {
 	InspectionID string
 	Summary      map[string]any
 	Suggestions  []string
+	NotepadItems []map[string]any
 }
 
 // NewService 创建并返回 task inspector 服务。
@@ -48,10 +57,15 @@ func NewService(fileSystem platform.FileSystemAdapter) *Service {
 // Run 执行一次最小真实巡检。
 func (s *Service) Run(input RunInput) RunResult {
 	sources := resolveSources(input.TargetSources, input.Config)
-	parsedFiles, fileItems := s.inspectSources(sources)
-	dueToday, overdue := countDueBuckets(input.NotepadItems, s.now())
+	parsedFiles, parsedNotepadItems := s.inspectSources(sources)
+	resolvedNotepadItems := cloneMapSlice(input.NotepadItems)
+	if len(parsedNotepadItems) > 0 {
+		resolvedNotepadItems = parsedNotepadItems
+	}
+	fileItems := countOpenNotepadItems(parsedNotepadItems)
+	dueToday, overdue := countDueBuckets(resolvedNotepadItems, s.now())
 	staleCount := countStaleTasks(input.UnfinishedTasks, inspectionDuration(input.Config), s.now())
-	identifiedItems := fileItems + countOpenNotepadItems(input.NotepadItems)
+	identifiedItems := countOpenNotepadItems(resolvedNotepadItems)
 
 	return RunResult{
 		InspectionID: fmt.Sprintf("insp_%d", s.now().UnixNano()),
@@ -62,17 +76,18 @@ func (s *Service) Run(input RunInput) RunResult {
 			"overdue":          overdue,
 			"stale":            staleCount,
 		},
-		Suggestions: buildSuggestions(input.NotepadItems, input.UnfinishedTasks, sources, parsedFiles, dueToday, overdue, staleCount, fileItems),
+		Suggestions:  buildSuggestions(resolvedNotepadItems, input.UnfinishedTasks, sources, parsedFiles, dueToday, overdue, staleCount, fileItems),
+		NotepadItems: cloneMapSlice(resolvedNotepadItems),
 	}
 }
 
-func (s *Service) inspectSources(sources []string) (int, int) {
+func (s *Service) inspectSources(sources []string) (int, []map[string]any) {
 	if s.fileSystem == nil || len(sources) == 0 {
-		return 0, 0
+		return 0, nil
 	}
 
 	parsedFiles := 0
-	identifiedItems := 0
+	identifiedItems := make([]map[string]any, 0)
 	seenFiles := map[string]struct{}{}
 
 	for _, source := range sources {
@@ -95,7 +110,7 @@ func (s *Service) inspectSources(sources []string) (int, int) {
 			if err != nil {
 				return nil
 			}
-			identifiedItems += countChecklistItems(string(content))
+			identifiedItems = append(identifiedItems, parseNotepadItemsFromMarkdown(sourcePathFromFSPath(currentPath), string(content), s.now())...)
 			return nil
 		})
 	}
@@ -183,6 +198,367 @@ func countChecklistItems(content string) int {
 		}
 	}
 	return count
+}
+
+func parseNotepadItemsFromMarkdown(sourcePath, content string, now time.Time) []map[string]any {
+	lines := strings.Split(content, "\n")
+	items := make([]map[string]any, 0)
+	var current map[string]any
+	noteLines := make([]string, 0)
+	flushCurrent := func() {
+		if current == nil {
+			return
+		}
+		if len(noteLines) > 0 && stringValue(current, "note_text") == "" {
+			current["note_text"] = strings.Join(noteLines, "\n")
+		}
+		items = append(items, normalizeParsedNotepadItem(current, sourcePath, now))
+		current = nil
+		noteLines = noteLines[:0]
+	}
+
+	for index, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		checked, title, ok := parseChecklistLine(trimmed)
+		if ok {
+			flushCurrent()
+			current = map[string]any{
+				"item_id":     buildSourceBackedNotepadID(sourcePath, index+1, title),
+				"title":       title,
+				"bucket":      bucketFromSourcePath(sourcePath, checked, false),
+				"status":      statusFromChecklist(checked),
+				"type":        todoTypeFromChecklist(checked, false),
+				"source_path": sourcePath,
+				"source_line": index + 1,
+				"created_at":  now.UTC().Format(time.RFC3339),
+				"updated_at":  now.UTC().Format(time.RFC3339),
+			}
+			continue
+		}
+		if current == nil || trimmed == "" {
+			continue
+		}
+		if handled := applyNotepadMetadataLine(current, trimmed, now); handled {
+			continue
+		}
+		noteLines = append(noteLines, trimmed)
+	}
+	flushCurrent()
+	return items
+}
+
+func parseChecklistLine(line string) (bool, string, bool) {
+	trimmed := strings.TrimSpace(line)
+	switch {
+	case strings.HasPrefix(trimmed, "- [ ] "), strings.HasPrefix(trimmed, "* [ ] "):
+		return false, strings.TrimSpace(trimmed[6:]), true
+	case strings.HasPrefix(trimmed, "- [x] "), strings.HasPrefix(trimmed, "* [x] "), strings.HasPrefix(trimmed, "- [X] "), strings.HasPrefix(trimmed, "* [X] "):
+		return true, strings.TrimSpace(trimmed[6:]), true
+	default:
+		return false, "", false
+	}
+}
+
+func applyNotepadMetadataLine(item map[string]any, line string, now time.Time) bool {
+	key, value, ok := splitMetadataLine(line)
+	if !ok {
+		return false
+	}
+	switch key {
+	case "due":
+		if dueAt := normalizeMetadataTime(value, now); dueAt != "" {
+			item["due_at"] = dueAt
+			item["planned_at"] = dueAt
+		}
+	case "bucket":
+		item["bucket"] = normalizeBucketValue(value, stringValue(item, "bucket"))
+	case "prerequisite":
+		item["prerequisite"] = value
+	case "suggest", "agent":
+		item["agent_suggestion"] = value
+	case "repeat":
+		item["repeat_rule_text"] = value
+		item["bucket"] = notepadBucketRecurringRule
+		item["type"] = "recurring"
+	case "next":
+		if nextOccurrence := normalizeMetadataTime(value, now); nextOccurrence != "" {
+			item["next_occurrence_at"] = nextOccurrence
+			if stringValue(item, "due_at") == "" {
+				item["due_at"] = nextOccurrence
+			}
+		}
+	case "scope":
+		item["effective_scope"] = value
+	case "status":
+		item["recent_instance_status"] = value
+	case "resource":
+		resources := cloneMapSlice(resourceListValue(item["related_resources"]))
+		resources = append(resources, buildSourceResource(item, value))
+		item["related_resources"] = resources
+	case "tags":
+		item["tags"] = splitTagList(value)
+	case "note":
+		item["note_text"] = value
+	case "reminder":
+		item["reminder_strategy"] = value
+	default:
+		return false
+	}
+	return true
+}
+
+func splitMetadataLine(line string) (string, string, bool) {
+	parts := strings.SplitN(line, ":", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	key := strings.ToLower(strings.TrimSpace(parts[0]))
+	value := strings.TrimSpace(parts[1])
+	if key == "" || value == "" {
+		return "", "", false
+	}
+	return key, value, true
+}
+
+func normalizeParsedNotepadItem(item map[string]any, sourcePath string, now time.Time) map[string]any {
+	if stringValue(item, "bucket") == notepadBucketRecurringRule {
+		item["type"] = "recurring"
+		if stringValue(item, "repeat_rule_text") == "" {
+			item["repeat_rule_text"] = "每周重复一次"
+		}
+		if _, ok := item["recurring_enabled"]; !ok {
+			item["recurring_enabled"] = true
+		}
+		if stringValue(item, "next_occurrence_at") == "" {
+			if nextOccurrence := deriveParsedRecurringNextOccurrence(item); nextOccurrence != "" {
+				item["next_occurrence_at"] = nextOccurrence
+			}
+		}
+	}
+	resources := resourceListValue(item["related_resources"])
+	if !hasResourcePath(resources, sourcePath) {
+		resources = append(resources, buildSourcePathResource(sourcePath))
+	}
+	if len(resources) > 0 {
+		item["related_resources"] = resources
+	}
+	if stringValue(item, "note_text") == "" {
+		item["note_text"] = stringValue(item, "title")
+	}
+	if stringValue(item, "planned_at") == "" {
+		item["planned_at"] = stringValue(item, "due_at")
+	}
+	if stringValue(item, "status") == "completed" {
+		item["bucket"] = notepadBucketClosed
+		if stringValue(item, "ended_at") == "" {
+			item["ended_at"] = now.UTC().Format(time.RFC3339)
+		}
+	}
+	return item
+}
+
+func buildSourceBackedNotepadID(sourcePath string, line int, title string) string {
+	hasher := fnv.New32a()
+	_, _ = hasher.Write([]byte(sourcePath))
+	_, _ = hasher.Write([]byte("|"))
+	_, _ = hasher.Write([]byte(fmt.Sprintf("%d", line)))
+	_, _ = hasher.Write([]byte("|"))
+	_, _ = hasher.Write([]byte(strings.TrimSpace(title)))
+	return fmt.Sprintf("todo_%08x", hasher.Sum32())
+}
+
+func sourcePathFromFSPath(fsPath string) string {
+	clean := path.Clean(strings.TrimPrefix(fsPath, "./"))
+	if clean == "." {
+		return "workspace"
+	}
+	return path.Join("workspace", clean)
+}
+
+func bucketFromSourcePath(sourcePath string, closed bool, recurring bool) string {
+	if closed {
+		return notepadBucketClosed
+	}
+	normalized := strings.ToLower(sourcePath)
+	if recurring || strings.Contains(normalized, "recurring") || strings.Contains(normalized, "weekly") || strings.Contains(normalized, "repeat") {
+		return notepadBucketRecurringRule
+	}
+	if strings.Contains(normalized, "later") || strings.Contains(normalized, "backlog") {
+		return notepadBucketLater
+	}
+	return notepadBucketUpcoming
+}
+
+func statusFromChecklist(checked bool) string {
+	if checked {
+		return "completed"
+	}
+	return "normal"
+}
+
+func todoTypeFromChecklist(_ bool, recurring bool) string {
+	if recurring {
+		return "recurring"
+	}
+	return "one_time"
+}
+
+func normalizeMetadataTime(value string, now time.Time) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04", "2006-01-02"} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			if layout == "2006-01-02" {
+				parsed = time.Date(parsed.Year(), parsed.Month(), parsed.Day(), now.Hour(), now.Minute(), 0, 0, now.Location())
+			}
+			return parsed.Format(time.RFC3339)
+		}
+	}
+	return value
+}
+
+func normalizeBucketValue(value string, fallback string) string {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case notepadBucketUpcoming, notepadBucketLater, notepadBucketRecurringRule, notepadBucketClosed:
+		return strings.TrimSpace(strings.ToLower(value))
+	default:
+		return fallback
+	}
+}
+
+func buildSourceResource(item map[string]any, target string) map[string]any {
+	target = strings.TrimSpace(target)
+	resourceType := "file"
+	targetKind := "file"
+	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
+		resourceType = "url"
+		targetKind = "url"
+	} else if !strings.Contains(path.Base(target), ".") || strings.HasSuffix(target, "/") {
+		resourceType = "directory"
+		targetKind = "folder"
+	}
+	return map[string]any{
+		"id":          stringValue(item, "item_id") + fmt.Sprintf("_resource_%08x", fnvHash(target)),
+		"label":       path.Base(strings.TrimSuffix(target, "/")),
+		"path":        target,
+		"type":        resourceType,
+		"target_kind": targetKind,
+	}
+}
+
+func buildSourcePathResource(sourcePath string) map[string]any {
+	return map[string]any{
+		"id":          fmt.Sprintf("source_%08x", fnvHash(sourcePath)),
+		"label":       path.Base(sourcePath),
+		"path":        sourcePath,
+		"type":        "file",
+		"target_kind": "file",
+	}
+}
+
+func splitTagList(value string) []string {
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+func resourceListValue(rawValue any) []map[string]any {
+	resources, ok := rawValue.([]map[string]any)
+	if ok {
+		return resources
+	}
+	anyResources, ok := rawValue.([]any)
+	if !ok {
+		return nil
+	}
+	result := make([]map[string]any, 0, len(anyResources))
+	for _, rawResource := range anyResources {
+		resource, ok := rawResource.(map[string]any)
+		if ok {
+			result = append(result, resource)
+		}
+	}
+	return result
+}
+
+func hasResourcePath(resources []map[string]any, targetPath string) bool {
+	for _, resource := range resources {
+		if stringValue(resource, "path") == targetPath {
+			return true
+		}
+	}
+	return false
+}
+
+func deriveParsedRecurringNextOccurrence(item map[string]any) string {
+	base := stringValue(item, "planned_at")
+	if base == "" {
+		base = stringValue(item, "due_at")
+	}
+	if base == "" {
+		return ""
+	}
+	parsed, err := time.Parse(time.RFC3339, base)
+	if err != nil {
+		return base
+	}
+	ruleText := strings.ToLower(stringValue(item, "repeat_rule_text"))
+	switch {
+	case strings.Contains(ruleText, "2 week"), strings.Contains(ruleText, "两周"):
+		parsed = parsed.AddDate(0, 0, 14)
+	case strings.Contains(ruleText, "month"), strings.Contains(ruleText, "每月"):
+		parsed = parsed.AddDate(0, 1, 0)
+	case strings.Contains(ruleText, "day"), strings.Contains(ruleText, "每天"):
+		parsed = parsed.AddDate(0, 0, 1)
+	default:
+		parsed = parsed.AddDate(0, 0, 7)
+	}
+	return parsed.Format(time.RFC3339)
+}
+
+func cloneMapSlice(values []map[string]any) []map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+	result := make([]map[string]any, 0, len(values))
+	for _, value := range values {
+		result = append(result, cloneMap(value))
+	}
+	return result
+}
+
+func cloneMap(values map[string]any) map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+	result := make(map[string]any, len(values))
+	for key, value := range values {
+		switch typed := value.(type) {
+		case map[string]any:
+			result[key] = cloneMap(typed)
+		case []map[string]any:
+			result[key] = cloneMapSlice(typed)
+		case []string:
+			result[key] = append([]string(nil), typed...)
+		default:
+			result[key] = value
+		}
+	}
+	return result
+}
+
+func fnvHash(value string) uint32 {
+	hasher := fnv.New32a()
+	_, _ = hasher.Write([]byte(value))
+	return hasher.Sum32()
 }
 
 func countOpenNotepadItems(items []map[string]any) int {

--- a/services/local-service/internal/taskinspector/service_test.go
+++ b/services/local-service/internal/taskinspector/service_test.go
@@ -130,6 +130,36 @@ func TestServiceRunParsesMarkdownIntoRichNotepadFoundation(t *testing.T) {
 	}
 }
 
+func TestTaskInspectorHelperFunctions(t *testing.T) {
+	if countChecklistItems("- [ ] one\n* [x] two\nplain text") != 2 {
+		t.Fatal("expected checklist counter to include open and closed items")
+	}
+	resolved := resolveSources(nil, map[string]any{"task_sources": []any{"workspace/todos", "workspace/todos", "workspace/later"}})
+	if len(resolved) != 2 || resolved[0] != "workspace/todos" {
+		t.Fatalf("expected resolveSources to dedupe non-empty values, got %+v", resolved)
+	}
+	if sourceToFSPath("/workspace/notes") != "workspace/notes" {
+		t.Fatalf("expected sourceToFSPath to normalize workspace prefix")
+	}
+	if sourceToFSPath("../../etc") != "" {
+		t.Fatalf("expected sourceToFSPath to reject outside-workspace paths")
+	}
+	tags := splitTagList("urgent, weekly, notes")
+	if len(tags) != 3 || tags[1] != "weekly" {
+		t.Fatalf("expected splitTagList to trim comma-separated values, got %+v", tags)
+	}
+	resources := resourceListValue([]any{map[string]any{"path": "workspace/todos/inbox.md"}})
+	if len(resources) != 1 || !hasResourcePath(resources, "workspace/todos/inbox.md") {
+		t.Fatalf("expected resourceListValue and hasResourcePath to cooperate, got %+v", resources)
+	}
+	if buildSourceResource(map[string]any{"item_id": "todo_001"}, "https://example.com")["target_kind"] != "url" {
+		t.Fatal("expected url resource to be marked as url")
+	}
+	if deriveParsedRecurringNextOccurrence(map[string]any{"planned_at": "2026-04-18T09:30:00Z", "repeat_rule_text": "every month"}) != "2026-05-18T09:30:00Z" {
+		t.Fatal("expected parsed recurring helper to support monthly rules")
+	}
+}
+
 func TestServiceRunHonorsTargetSourcesAndHandlesMissingFiles(t *testing.T) {
 	service := NewService(nil)
 	service.now = func() time.Time { return time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC) }

--- a/services/local-service/internal/taskinspector/service_test.go
+++ b/services/local-service/internal/taskinspector/service_test.go
@@ -3,6 +3,7 @@ package taskinspector
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,17 +58,75 @@ func TestServiceRunAggregatesWorkspaceNotepadAndRuntimeState(t *testing.T) {
 	if summary["parsed_files"] != 2 {
 		t.Fatalf("expected parsed_files 2, got %+v", summary)
 	}
-	if summary["identified_items"] != 6 {
-		t.Fatalf("expected identified_items 6, got %+v", summary)
+	if summary["identified_items"] != 2 {
+		t.Fatalf("expected identified_items 2 after source-backed sync, got %+v", summary)
 	}
-	if summary["due_today"] != 1 || summary["overdue"] != 1 {
+	if summary["due_today"] != 0 || summary["overdue"] != 0 {
 		t.Fatalf("expected due bucket counts to be aggregated, got %+v", summary)
 	}
 	if summary["stale"] != 1 {
 		t.Fatalf("expected stale count 1, got %+v", summary)
 	}
-	if len(result.Suggestions) < 3 {
+	if len(result.NotepadItems) != 3 {
+		t.Fatalf("expected parsed notepad items to be returned, got %+v", result.NotepadItems)
+	}
+	if result.NotepadItems[0]["source_path"] == nil {
+		t.Fatalf("expected source-backed notepad metadata, got %+v", result.NotepadItems[0])
+	}
+	if len(result.Suggestions) < 2 {
 		t.Fatalf("expected runtime suggestions, got %+v", result.Suggestions)
+	}
+}
+
+func TestServiceRunParsesMarkdownIntoRichNotepadFoundation(t *testing.T) {
+	workspaceRoot := filepath.Join(t.TempDir(), "workspace")
+	pathPolicy, err := platform.NewLocalPathPolicy(workspaceRoot)
+	if err != nil {
+		t.Fatalf("NewLocalPathPolicy returned error: %v", err)
+	}
+	fileSystem := platform.NewLocalFileSystemAdapter(pathPolicy)
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, "todos"), 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	content := strings.Join([]string{
+		"- [ ] Weekly retro",
+		"  due: 2026-04-18",
+		"  repeat: every 2 weeks",
+		"  prerequisite: collect status updates",
+		"  resource: workspace/templates/retro.md",
+		"  scope: Project A",
+		"  note: review blockers and next steps",
+		"- [ ] Later review packet",
+		"  bucket: later",
+		"  resource: https://example.com/review",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "todos", "weekly.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	service := NewService(fileSystem)
+	service.now = func() time.Time { return time.Date(2026, 4, 10, 9, 30, 0, 0, time.UTC) }
+	result := service.Run(RunInput{Config: map[string]any{"task_sources": []string{"workspace/todos"}}})
+	if len(result.NotepadItems) != 2 {
+		t.Fatalf("expected parsed notes from markdown, got %+v", result.NotepadItems)
+	}
+	retro := result.NotepadItems[0]
+	if retro["bucket"] != notepadBucketRecurringRule || retro["type"] != "recurring" {
+		t.Fatalf("expected weekly retro to become recurring rule item, got %+v", retro)
+	}
+	if retro["repeat_rule_text"] != "every 2 weeks" || retro["prerequisite"] != "collect status updates" {
+		t.Fatalf("expected recurring metadata to be parsed, got %+v", retro)
+	}
+	resources, ok := retro["related_resources"].([]map[string]any)
+	if !ok || len(resources) < 2 {
+		t.Fatalf("expected parsed resources plus source path fallback, got %+v", retro["related_resources"])
+	}
+	if retro["next_occurrence_at"] == nil {
+		t.Fatalf("expected next occurrence to be derived, got %+v", retro)
+	}
+	later := result.NotepadItems[1]
+	if later["bucket"] != notepadBucketLater {
+		t.Fatalf("expected explicit bucket metadata to win, got %+v", later)
 	}
 }
 


### PR DESCRIPTION
## Summary

- build owner-5 notes foundation fields and lifecycle mutations behind the current frozen `TodoItem` RPC boundary
- parse markdown task sources into richer internal notes and persist todo / recurring-rule state with in-memory and SQLite stores
- document the storage/schema decisions so owner-4 can freeze notes detail and action protocols on top of real backend foundations

## Why

Notes integration currently only has two stable RPCs:

- `agent.notepad.list`
- `agent.notepad.convert_to_task`

That means frontend notes detail still depends on fallback experience for note text, prerequisites, recurring semantics, ended state, and related resources.

This PR stays inside owner-5 scope. It does not expand protocol fields or invent new notes RPC methods.  
Instead, it prepares the backend data/runtime/storage foundation so owner-4 can freeze the final protocol surface on top of real implementations.

## What Changed

### Internal notes foundation

- added richer internal note metadata support in `runengine`
- kept `agent.notepad.list` projected to the current protocol-safe `TodoItem` shape
- prepared internal fields for:
  - `note_text`
  - `prerequisite`
  - `planned_at`
  - `ended_at`
  - `related_resources`
  - `repeat_rule_text`
  - `next_occurrence_at`
  - `recent_instance_status`
  - `effective_scope`
  - `recurring_enabled`

### Note lifecycle mutations

- added internal note action support for:
  - complete
  - cancel
  - restore
  - recurring enable/disable
  - recurring rule update
  - delete
- kept note/task layering intact so note actions do not directly mutate `tasks`

### Source-backed parsing

- upgraded `taskinspector` from checklist counting to markdown note parsing
- parse source-backed note metadata such as:
  - due/planned time
  - prerequisite
  - note text
  - recurring rule text
  - scope
  - resources
  - tags
- sync parsed notes back into runtime state after inspector runs

### Persistence

- added minimal notes persistence foundation:
  - `TodoStore` interface
  - in-memory store
  - SQLite store
- persist enriched `todo_items` and `recurring_rules`
- hydrate notes state from storage during bootstrap
- keep note mutations durable across reloads

### Docs

- updated `docs/module-design.md` with owner-5 notes foundation boundaries
- updated `docs/data-design.md` with notes enrichment guidance and the new `todo_items / recurring_rules` storage fields

## Scope

This PR is intentionally limited to owner-5 responsibility:

- backend runtime/data foundation
- source parsing
- recurring rule semantics
- minimal storage layer
- notes lifecycle mutation base behavior

It does not:
- add new notes RPC methods
- expand `packages/protocol` notes fields
- freeze notes detail/open contracts
- define frontend notes page behavior

## Testing

- `go test ./services/local-service/internal/storage ./services/local-service/internal/runengine ./services/local-service/internal/taskinspector ./services/local-service/internal/orchestrator ./services/local-service/internal/bootstrap`

## Follow-up For Owner-4

After this PR, the remaining protocol-facing decisions can be frozen on top of real backend foundations:

- whether notes detail stays on `agent.notepad.list` or gets a dedicated detail read model
- which notes actions become stable RPC methods
- what the formal related-resource / open metadata shape should be
- whether notes consistency stays refetch-based or adds notification events
- how `convert_to_task` should expose note lifecycle changes and linked-task semantics
