### PR TITLE
 Fix clipboard fallback handling for dashboard resource open flows

### DIFF
--- a/apps/desktop/src/features/dashboard/notes/NotePage.tsx
+++ b/apps/desktop/src/features/dashboard/notes/NotePage.tsx
@@ -243,7 +243,11 @@ export function NotePage() {
       return;
     }
 
-    showFeedback(await performNoteResourceOpenExecution(plan));
+    try {
+      showFeedback(await performNoteResourceOpenExecution(plan));
+    } catch {
+      showFeedback(plan.path || plan.url ? `${plan.feedback} 地址：${plan.path || plan.url}` : plan.feedback);
+    }
   }
 
   useEffect(() => {

--- a/apps/desktop/src/features/dashboard/notes/NotePage.tsx
+++ b/apps/desktop/src/features/dashboard/notes/NotePage.tsx
@@ -243,11 +243,7 @@ export function NotePage() {
       return;
     }
 
-    try {
-      showFeedback(await performNoteResourceOpenExecution(plan));
-    } catch {
-      showFeedback(plan.path || plan.url ? `${plan.feedback} 地址：${plan.path || plan.url}` : plan.feedback);
-    }
+    showFeedback(await performNoteResourceOpenExecution(plan));
   }
 
   useEffect(() => {

--- a/apps/desktop/src/features/dashboard/notes/notePage.service.ts
+++ b/apps/desktop/src/features/dashboard/notes/notePage.service.ts
@@ -394,8 +394,12 @@ export function resolveNoteResourceOpenExecutionPlan(resource: NoteResource): No
 export async function performNoteResourceOpenExecution(plan: NoteResourceOpenExecutionPlan): Promise<string> {
   if (plan.mode === "copy_path" && plan.path) {
     if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(plan.path);
-      return `${plan.feedback} 已复制路径。`;
+      try {
+        await navigator.clipboard.writeText(plan.path);
+        return `${plan.feedback} 已复制路径。`;
+      } catch {
+        return `${plan.feedback} 路径：${plan.path}`;
+      }
     }
 
     return `${plan.feedback} 路径：${plan.path}`;

--- a/apps/desktop/src/features/dashboard/tasks/taskOutput.service.ts
+++ b/apps/desktop/src/features/dashboard/tasks/taskOutput.service.ts
@@ -152,8 +152,12 @@ export async function performTaskOpenExecution(plan: TaskOpenExecutionPlan): Pro
 
   if (plan.mode === "copy_path" && plan.path) {
     if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(plan.path);
-      return `${plan.feedback} 已复制路径。`;
+      try {
+        await navigator.clipboard.writeText(plan.path);
+        return `${plan.feedback} 已复制路径。`;
+      } catch {
+        return `${plan.feedback} 路径：${plan.path}`;
+      }
     }
 
     return `${plan.feedback} 路径：${plan.path}`;


### PR DESCRIPTION
## Summary
- add a stable fallback for note related-resource opens when clipboard copy is unavailable or rejected
- add the same fallback for task artifact open flows that currently depend on clipboard copy
- prevent silent failures and unhandled async errors by returning visible path or URL feedback

## Testing
- not run