### PR TITLE
feat(task-events): add run and type filters for task event queries

### DIFF
--- a/docs/protocol-design.md
+++ b/docs/protocol-design.md
@@ -892,8 +892,6 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
 | 字段      | 中文说明    |
 | --------- | ----------- |
 | `task_id` | 目标任务 ID |
-| `run_id`  | 可选，用于只看某一次执行的事件 |
-| `type`    | 可选，用于按事件类型过滤，如 `loop.failed` |
 | `limit`   | 每页条数    |
 | `offset`  | 偏移量      |
 
@@ -910,8 +908,6 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
       "client_time": "2026-04-07T10:43:00+08:00"
     },
     "task_id": "task_201",
-    "run_id": "run_201",
-    "type": "loop.round.completed",
     "limit": 20,
     "offset": 0
   }
@@ -1569,6 +1565,8 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
 | 字段      | 中文说明    |
 | --------- | ----------- |
 | `task_id` | 目标任务 ID |
+| `run_id`  | 可选，用于只看某一次执行的事件 |
+| `type`    | 可选，用于按事件类型过滤，如 `loop.failed` |
 | `limit`   | 每页条数    |
 | `offset`  | 偏移量      |
 
@@ -1585,6 +1583,8 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
       "client_time": "2026-04-18T10:43:00+08:00"
     },
     "task_id": "task_201",
+    "run_id": "run_201",
+    "type": "loop.round.completed",
     "limit": 20,
     "offset": 0
   }

--- a/docs/protocol-design.md
+++ b/docs/protocol-design.md
@@ -892,6 +892,8 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
 | 字段      | 中文说明    |
 | --------- | ----------- |
 | `task_id` | 目标任务 ID |
+| `run_id`  | 可选，用于只看某一次执行的事件 |
+| `type`    | 可选，用于按事件类型过滤，如 `loop.failed` |
 | `limit`   | 每页条数    |
 | `offset`  | 偏移量      |
 
@@ -908,6 +910,8 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
       "client_time": "2026-04-07T10:43:00+08:00"
     },
     "task_id": "task_201",
+    "run_id": "run_201",
+    "type": "loop.round.completed",
     "limit": 20,
     "offset": 0
   }

--- a/packages/protocol/rpc/methods.ts
+++ b/packages/protocol/rpc/methods.ts
@@ -308,6 +308,8 @@ export interface TaskEvent {
 export interface AgentTaskEventsListParams {
   request_meta: RequestMeta;
   task_id: string;
+  run_id?: string;
+  type?: string;
   limit?: number;
   offset?: number;
 }

--- a/services/local-service/internal/execution/service_test.go
+++ b/services/local-service/internal/execution/service_test.go
@@ -461,7 +461,7 @@ func TestExecuteAgentLoopPersistsRuntimeEventsAndStopReason(t *testing.T) {
 	if result.Content != "Loop runtime finished cleanly." {
 		t.Fatalf("unexpected loop runtime result: %+v", result)
 	}
-	events, total, err := loopStore.ListEvents(context.Background(), "task_loop_runtime", 20, 0)
+	events, total, err := loopStore.ListEvents(context.Background(), "task_loop_runtime", "", "", 20, 0)
 	if err != nil {
 		t.Fatalf("ListEvents returned error: %v", err)
 	}
@@ -501,7 +501,7 @@ func TestExecuteAgentLoopPersistsPlannerErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected planner error to surface")
 	}
-	events, total, listErr := loopStore.ListEvents(context.Background(), "task_loop_planner_error", 20, 0)
+	events, total, listErr := loopStore.ListEvents(context.Background(), "task_loop_planner_error", "", "", 20, 0)
 	if listErr != nil {
 		t.Fatalf("ListEvents returned error: %v", listErr)
 	}

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -757,13 +757,15 @@ func (s *Service) TaskEventsList(params map[string]any) (map[string]any, error) 
 	limit := clampListLimit(intValue(params, "limit", 20))
 	offset := clampListOffset(intValue(params, "offset", 0))
 	taskID := stringValue(params, "task_id", "")
+	runID := stringValue(params, "run_id", "")
+	eventType := stringValue(params, "type", "")
 	if strings.TrimSpace(taskID) == "" {
 		return nil, errors.New("task_id is required")
 	}
 	if s.storage == nil || s.storage.LoopRuntimeStore() == nil {
 		return map[string]any{"items": []map[string]any{}, "page": pageMap(limit, offset, 0)}, nil
 	}
-	records, total, err := s.storage.LoopRuntimeStore().ListEvents(context.Background(), taskID, limit, offset)
+	records, total, err := s.storage.LoopRuntimeStore().ListEvents(context.Background(), taskID, runID, eventType, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrStorageQueryFailed, err)
 	}

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -6604,6 +6604,28 @@ func TestServiceTaskEventsListReturnsNormalizedLoopEvents(t *testing.T) {
 	}
 }
 
+func TestServiceTaskEventsListSupportsRunAndTypeFilters(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "loop event filters")
+	if service.storage == nil || service.storage.LoopRuntimeStore() == nil {
+		t.Fatal("expected loop runtime store to be wired")
+	}
+	if err := service.storage.LoopRuntimeStore().SaveEvents(context.Background(), []storage.EventRecord{
+		{EventID: "evt_loop_filter_001", RunID: "run_loop_filter_a", TaskID: "task_loop_filter_001", StepID: "step_a", Type: "loop.round.started", Level: "info", PayloadJSON: `{}`, CreatedAt: "2026-04-17T10:00:00Z"},
+		{EventID: "evt_loop_filter_002", RunID: "run_loop_filter_b", TaskID: "task_loop_filter_001", StepID: "step_b", Type: "loop.failed", Level: "error", PayloadJSON: `{}`, CreatedAt: "2026-04-17T10:01:00Z"},
+	}); err != nil {
+		t.Fatalf("save loop filter events failed: %v", err)
+	}
+
+	result, err := service.TaskEventsList(map[string]any{"task_id": "task_loop_filter_001", "run_id": "run_loop_filter_b", "type": "loop.failed", "limit": 20, "offset": 0})
+	if err != nil {
+		t.Fatalf("task events list with filters failed: %v", err)
+	}
+	items := result["items"].([]map[string]any)
+	if len(items) != 1 || items[0]["run_id"] != "run_loop_filter_b" || items[0]["type"] != "loop.failed" {
+		t.Fatalf("expected filtered loop event, got %+v", items)
+	}
+}
+
 func TestServiceTaskSteerPersistsFollowUpMessage(t *testing.T) {
 	service, _ := newTestServiceWithExecution(t, "task steer")
 	startResult, err := service.StartTask(map[string]any{

--- a/services/local-service/internal/rpc/server_test.go
+++ b/services/local-service/internal/rpc/server_test.go
@@ -1510,6 +1510,8 @@ func TestDispatchTaskEventsListReturnsLoopEvents(t *testing.T) {
 		Method:  "agent.task.events.list",
 		Params: mustMarshal(t, map[string]any{
 			"task_id": "task_rpc_loop_001",
+			"run_id":  "run_rpc_loop_001",
+			"type":    "loop.completed",
 			"limit":   20,
 			"offset":  0,
 		}),

--- a/services/local-service/internal/storage/loop_runtime_store.go
+++ b/services/local-service/internal/storage/loop_runtime_store.go
@@ -113,14 +113,21 @@ func (s *inMemoryLoopRuntimeStore) SaveDeliveryResult(_ context.Context, record 
 	return nil
 }
 
-func (s *inMemoryLoopRuntimeStore) ListEvents(_ context.Context, taskID string, limit, offset int) ([]EventRecord, int, error) {
+func (s *inMemoryLoopRuntimeStore) ListEvents(_ context.Context, taskID, runID, eventType string, limit, offset int) ([]EventRecord, int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	filtered := make([]EventRecord, 0, len(s.events))
 	for _, record := range s.events {
-		if taskID == "" || record.TaskID == taskID {
-			filtered = append(filtered, record)
+		if taskID != "" && record.TaskID != taskID {
+			continue
 		}
+		if runID != "" && record.RunID != runID {
+			continue
+		}
+		if eventType != "" && record.Type != eventType {
+			continue
+		}
+		filtered = append(filtered, record)
 	}
 	sort.SliceStable(filtered, func(i, j int) bool {
 		return parseGovernanceTime(filtered[i].CreatedAt).After(parseGovernanceTime(filtered[j].CreatedAt))
@@ -200,22 +207,36 @@ func (s *SQLiteLoopRuntimeStore) SaveDeliveryResult(ctx context.Context, record 
 	return nil
 }
 
-func (s *SQLiteLoopRuntimeStore) ListEvents(ctx context.Context, taskID string, limit, offset int) ([]EventRecord, int, error) {
+func (s *SQLiteLoopRuntimeStore) ListEvents(ctx context.Context, taskID, runID, eventType string, limit, offset int) ([]EventRecord, int, error) {
+	filters := make([]string, 0, 3)
+	filterArgs := make([]any, 0, 3)
+	if strings.TrimSpace(taskID) != "" {
+		filters = append(filters, `task_id = ?`)
+		filterArgs = append(filterArgs, taskID)
+	}
+	if strings.TrimSpace(runID) != "" {
+		filters = append(filters, `run_id = ?`)
+		filterArgs = append(filterArgs, runID)
+	}
+	if strings.TrimSpace(eventType) != "" {
+		filters = append(filters, `type = ?`)
+		filterArgs = append(filterArgs, eventType)
+	}
 	countQuery := `SELECT COUNT(1) FROM events`
 	query := `SELECT event_id, run_id, task_id, step_id, type, level, payload_json, created_at FROM events`
-	args := []any{}
-	if strings.TrimSpace(taskID) != "" {
-		countQuery += ` WHERE task_id = ?`
-		query += ` WHERE task_id = ?`
-		args = append(args, taskID)
+	if len(filters) > 0 {
+		whereClause := ` WHERE ` + strings.Join(filters, ` AND `)
+		countQuery += whereClause
+		query += whereClause
 	}
 	query += ` ORDER BY created_at DESC, event_id DESC`
+	args := append([]any(nil), filterArgs...)
 	if limit > 0 {
 		query += ` LIMIT ? OFFSET ?`
 		args = append(args, limit, offset)
 	}
 	var total int
-	if err := s.db.QueryRowContext(ctx, countQuery, firstArg(taskID)...).Scan(&total); err != nil {
+	if err := s.db.QueryRowContext(ctx, countQuery, filterArgs...).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("count events: %w", err)
 	}
 	rows, err := s.db.QueryContext(ctx, query, args...)

--- a/services/local-service/internal/storage/service_test.go
+++ b/services/local-service/internal/storage/service_test.go
@@ -342,7 +342,7 @@ func TestLoopRuntimeStorePersistsNormalizedRecords(t *testing.T) {
 	assertTableCount(t, sqliteStore.db, "events", 1)
 	assertTableCount(t, sqliteStore.db, "delivery_results", 1)
 
-	events, total, err := store.ListEvents(context.Background(), "task_loop_001", 20, 0)
+	events, total, err := store.ListEvents(context.Background(), "task_loop_001", "", "", 20, 0)
 	if err != nil {
 		t.Fatalf("ListEvents returned error: %v", err)
 	}
@@ -380,12 +380,28 @@ func TestLoopRuntimeStoreKeepsAppendOnlyEventsAcrossRuns(t *testing.T) {
 	}}); err != nil {
 		t.Fatalf("save second event failed: %v", err)
 	}
-	events, total, err := store.ListEvents(context.Background(), "task_001", 20, 0)
+	events, total, err := store.ListEvents(context.Background(), "task_001", "", "", 20, 0)
 	if err != nil {
 		t.Fatalf("list append-only events failed: %v", err)
 	}
 	if total != 2 || len(events) != 2 {
 		t.Fatalf("expected append-only events from multiple runs, got total=%d items=%+v", total, events)
+	}
+
+	filteredByRun, totalByRun, err := store.ListEvents(context.Background(), "task_001", "run_002", "", 20, 0)
+	if err != nil {
+		t.Fatalf("list events by run failed: %v", err)
+	}
+	if totalByRun != 1 || len(filteredByRun) != 1 || filteredByRun[0].RunID != "run_002" {
+		t.Fatalf("expected one run-scoped event, got total=%d items=%+v", totalByRun, filteredByRun)
+	}
+
+	filteredByType, totalByType, err := store.ListEvents(context.Background(), "task_001", "", "loop.round.completed", 20, 0)
+	if err != nil {
+		t.Fatalf("list events by type failed: %v", err)
+	}
+	if totalByType != 2 || len(filteredByType) != 2 {
+		t.Fatalf("expected two type-scoped events, got total=%d items=%+v", totalByType, filteredByType)
 	}
 }
 

--- a/services/local-service/internal/storage/types.go
+++ b/services/local-service/internal/storage/types.go
@@ -263,7 +263,7 @@ type LoopRuntimeStore interface {
 	SaveSteps(ctx context.Context, records []StepRecord) error
 	SaveEvents(ctx context.Context, records []EventRecord) error
 	SaveDeliveryResult(ctx context.Context, record DeliveryResultRecord) error
-	ListEvents(ctx context.Context, taskID string, limit, offset int) ([]EventRecord, int, error)
+	ListEvents(ctx context.Context, taskID, runID, eventType string, limit, offset int) ([]EventRecord, int, error)
 }
 
 // ToolCallStore 定义 tool_call 持久化契约。


### PR DESCRIPTION
## Summary
- extend `agent.task.events.list` so task event queries can filter by `run_id` and event `type`
- update loop runtime event storage queries in both in-memory and SQLite implementations
- align orchestrator and RPC behavior with the richer task event query contract
- add storage, orchestrator, and RPC coverage for filtered task event queries
- document the new filter parameters in the protocol design and shared RPC types

## Why
- task-centric event queries were too coarse for task detail and debug views that need to focus on one run or one event category
- frontend task detail and runtime inspection flows need more precise event filtering than `task_id` alone
- publishing the filter contract in the protocol keeps the backend implementation and frontend consumers aligned

## Files Changed
- `services/local-service/internal/storage/types.go`
- `services/local-service/internal/storage/loop_runtime_store.go`
- `services/local-service/internal/orchestrator/service.go`
- `services/local-service/internal/storage/service_test.go`
- `services/local-service/internal/orchestrator/service_test.go`
- `services/local-service/internal/rpc/server_test.go`
- `packages/protocol/rpc/methods.ts`
- `docs/protocol-design.md`

## Testing
- `go test ./internal/storage -run "LoopRuntimeStore|AppendOnly"`
- `go test ./internal/orchestrator -run "TaskEventsList"`
- `go test ./internal/rpc -run "TaskEventsList"`