### PR TITLE
refactor(desktop): lazy-load dashboard module routes

### DIFF
--- a/apps/desktop/src/app/dashboard/DashboardRoot.tsx
+++ b/apps/desktop/src/app/dashboard/DashboardRoot.tsx
@@ -1,18 +1,23 @@
-import { useEffect, useRef, useState } from "react";
+import { Suspense, lazy, useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { HashRouter, Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { DashboardVoiceField } from "@/features/dashboard/home/components/DashboardVoiceField";
 import { getDashboardHomeFallbackData, loadDashboardHomeData, submitDashboardHomeRecommendationFeedback } from "@/features/dashboard/home/dashboardHome.service";
-import { MemoryPage } from "@/features/dashboard/memory/MemoryPage";
-import { NotesPage } from "@/features/dashboard/notes/NotesPage";
-import { SafetyPage } from "@/features/dashboard/safety/SafetyPage";
 import { resolveDashboardModuleRoutePath, resolveDashboardRoutePath } from "@/features/dashboard/shared/dashboardRouteTargets";
-import { TasksPage } from "@/features/dashboard/tasks/TasksPage";
 import { cn } from "@/utils/cn";
 import { DashboardHome } from "./DashboardHome";
 import { subscribeApprovalPending, subscribeDeliveryReady, subscribeTaskUpdated } from "@/rpc/subscriptions";
 import "./dashboard.css";
+
+const TasksPage = lazy(() => import("@/features/dashboard/tasks/TasksPage").then((module) => ({ default: module.TasksPage })));
+const NotesPage = lazy(() => import("@/features/dashboard/notes/NotesPage").then((module) => ({ default: module.NotesPage })));
+const MemoryPage = lazy(() => import("@/features/dashboard/memory/MemoryPage").then((module) => ({ default: module.MemoryPage })));
+const SafetyPage = lazy(() => import("@/features/dashboard/safety/SafetyPage").then((module) => ({ default: module.SafetyPage })));
+
+function DashboardRouteFallback() {
+  return <div className="dashboard-route-layer" aria-live="polite">Loading module…</div>;
+}
 
 function useDashboardDomainExpansion() {
   const [isOpening, setIsOpening] = useState(true);
@@ -191,10 +196,10 @@ function DashboardRoutes() {
               }
               path={resolveDashboardRoutePath("home")}
             />
-            <Route element={<TasksPage />} path={`${resolveDashboardModuleRoutePath("tasks")}/*`} />
-            <Route element={<NotesPage />} path={`${resolveDashboardModuleRoutePath("notes")}/*`} />
-            <Route element={<MemoryPage />} path={`${resolveDashboardModuleRoutePath("memory")}/*`} />
-            <Route element={<SafetyPage />} path={`${resolveDashboardModuleRoutePath("safety")}/*`} />
+            <Route element={<Suspense fallback={<DashboardRouteFallback />}><TasksPage /></Suspense>} path={`${resolveDashboardModuleRoutePath("tasks")}/*`} />
+            <Route element={<Suspense fallback={<DashboardRouteFallback />}><NotesPage /></Suspense>} path={`${resolveDashboardModuleRoutePath("notes")}/*`} />
+            <Route element={<Suspense fallback={<DashboardRouteFallback />}><MemoryPage /></Suspense>} path={`${resolveDashboardModuleRoutePath("memory")}/*`} />
+            <Route element={<Suspense fallback={<DashboardRouteFallback />}><SafetyPage /></Suspense>} path={`${resolveDashboardModuleRoutePath("safety")}/*`} />
             <Route element={<Navigate replace to={resolveDashboardRoutePath("home")} />} path="*" />
           </Routes>
         </motion.div>


### PR DESCRIPTION
## Summary
- Add route-level lazy loading for the dashboard module pages in `apps/desktop/src/app/dashboard/DashboardRoot.tsx:1`
- Keep `DashboardHome` eagerly loaded and wrap `TasksPage`, `NotesPage`, `MemoryPage`, and `SafetyPage` in `Suspense`
- Reduce initial dashboard load cost without changing route structure or backend behavior
## Scope
- Desktop only
- Single-file change in `apps/desktop/src/app/dashboard/DashboardRoot.tsx:1`
- No backend, protocol, or task-flow changes
## Validation
- `pnpm --dir apps/desktop build` ✅
## Notes
- `pnpm --dir apps/desktop typecheck` and `pnpm --dir apps/desktop lint` still report existing baseline issues from `main`, unrelated to this lazy-load change
- This PR intentionally keeps the change narrow and does not include the broader desktop mock/runtime refactors