### PR TITLE
feat(storage): add formal Stronghold secret lifecycle

### DIFF
--- a/docs/protocol-design.md
+++ b/docs/protocol-design.md
@@ -3136,6 +3136,8 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
 | `data.settings.memory`          | 记忆设置         |
 | `data.settings.task_automation` | 任务与自动化设置 |
 | `data.settings.data_log`        | 数据与日志设置（包含脱敏机密状态） |
+| `data.settings.data_log.provider_api_key_configured` | 当前 provider 的 API Key 是否已配置（脱敏状态） |
+| `data.settings.data_log.stronghold` | Stronghold 生命周期状态（只返回 backend/available/fallback/initialized/formal_store，不返回 secret） |
 
 ### agent.settings.get 出参示例
 
@@ -3191,7 +3193,14 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
         "data_log": {
           "provider": "openai",
           "budget_auto_downgrade": true,
-          "provider_api_key_configured": true
+          "provider_api_key_configured": true,
+          "stronghold": {
+            "backend": "stronghold_sqlite_fallback",
+            "available": true,
+            "fallback": true,
+            "initialized": true,
+            "formal_store": false
+          }
         }
       }
     },
@@ -3221,7 +3230,7 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
 | `task_automation` | 任务自动化设置变更 |
 | `general`         | 通用设置变更       |
 | `floating_ball`   | 悬浮球设置变更     |
-| `data_log`        | 数据与日志设置变更；允许携带临时写入 Stronghold 的 `api_key` |
+| `data_log`        | 数据与日志设置变更；允许携带临时写入 Stronghold 的 `api_key`，也允许用 `delete_api_key=true` 删除当前 provider secret |
 
 ### agent.settings.update 入参示例
 
@@ -3263,6 +3272,8 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
 | `data.effective_settings` | 生效后的设置   |
 | `data.apply_mode`         | 生效方式       |
 | `data.need_restart`       | 是否需要重启   |
+| `data.effective_settings.data_log.provider_api_key_configured` | 当前 provider secret 是否已配置（脱敏状态） |
+| `data.effective_settings.data_log.stronghold` | Stronghold 生命周期状态（脱敏） |
 
 ### agent.settings.update 出参示例
 
@@ -3293,7 +3304,14 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
         "data_log": {
           "provider": "openai",
           "budget_auto_downgrade": true,
-          "provider_api_key_configured": true
+          "provider_api_key_configured": true,
+          "stronghold": {
+            "backend": "stronghold_sqlite_fallback",
+            "available": true,
+            "fallback": true,
+            "initialized": true,
+            "formal_store": false
+          }
         }
       },
       "apply_mode": "immediate",

--- a/packages/protocol/rpc/methods.ts
+++ b/packages/protocol/rpc/methods.ts
@@ -686,6 +686,7 @@ export interface AgentSettingsUpdateParams {
   task_automation?: Partial<SettingsSnapshot["settings"]["task_automation"]>;
   data_log?: Partial<SettingsSnapshot["settings"]["data_log"]> & {
     api_key?: string;
+    delete_api_key?: boolean;
   };
 }
 

--- a/packages/protocol/types/core.ts
+++ b/packages/protocol/types/core.ts
@@ -189,6 +189,16 @@ export interface TimeInterval {
   value: number;
 }
 
+// StrongholdStatus captures the formal secret-backend lifecycle metadata that
+// can be surfaced in settings responses without exposing secret values.
+export interface StrongholdStatus {
+  backend: string;
+  available: boolean;
+  fallback: boolean;
+  initialized: boolean;
+  formal_store: boolean;
+}
+
 // Task 定义当前模块的接口约束。
 export interface Task {
   task_id: string;
@@ -438,6 +448,7 @@ export interface SettingsSnapshot {
       provider: string;
       budget_auto_downgrade: boolean;
       provider_api_key_configured: boolean;
+      stronghold: StrongholdStatus;
     };
   };
 }

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -1979,6 +1979,14 @@ func (s *Service) SettingsGet(params map[string]any) (map[string]any, error) {
 // settings patch plus apply-mode metadata.
 func (s *Service) SettingsUpdate(params map[string]any) (map[string]any, error) {
 	if dataLog := mapValue(params, "data_log"); len(dataLog) > 0 {
+		if deleteAPIKey := boolValue(dataLog, "delete_api_key", false); deleteAPIKey {
+			provider := s.providerForSettingsUpdate(dataLog)
+			if err := s.deleteModelSecret(provider); err != nil {
+				return nil, err
+			}
+			delete(dataLog, "delete_api_key")
+			params["data_log"] = dataLog
+		}
 		if apiKey := stringValue(dataLog, "api_key", ""); apiKey != "" {
 			provider := s.providerForSettingsUpdate(dataLog)
 			if err := s.persistModelSecret(provider, apiKey); err != nil {
@@ -2431,6 +2439,9 @@ func (s *Service) attachSensitiveSettingAvailability(settings map[string]any) (m
 		dataLog["provider"] = provider
 	}
 	dataLog["provider_api_key_configured"] = configured
+	if stronghold := strongholdStatusFromStorage(s.storage); len(stronghold) > 0 {
+		dataLog["stronghold"] = stronghold
+	}
 	cloned["data_log"] = dataLog
 	return cloned, nil
 }
@@ -2450,6 +2461,9 @@ func (s *Service) modelSecretConfigured(provider string) (string, bool, error) {
 	if errors.Is(err, storage.ErrSecretStoreAccessFailed) {
 		return resolvedProvider, false, ErrStrongholdAccessFailed
 	}
+	if errors.Is(err, storage.ErrStrongholdUnavailable) {
+		return resolvedProvider, false, ErrStrongholdAccessFailed
+	}
 	return resolvedProvider, false, err
 }
 
@@ -2464,12 +2478,42 @@ func (s *Service) persistModelSecret(provider, apiKey string) error {
 		Value:     strings.TrimSpace(apiKey),
 		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
 	}); err != nil {
-		if errors.Is(err, storage.ErrSecretStoreAccessFailed) {
+		normalizedErr := storage.NormalizeSecretStoreError(err)
+		if errors.Is(normalizedErr, storage.ErrStrongholdAccessFailed) || errors.Is(normalizedErr, storage.ErrStrongholdUnavailable) || errors.Is(normalizedErr, storage.ErrSecretStoreAccessFailed) {
 			return ErrStrongholdAccessFailed
 		}
-		return err
+		return normalizedErr
 	}
 	return nil
+}
+
+func (s *Service) deleteModelSecret(provider string) error {
+	resolvedProvider := firstNonEmptyString(strings.TrimSpace(provider), s.defaultSettingsProvider())
+	if s.storage == nil || s.storage.SecretStore() == nil || resolvedProvider == "" {
+		return ErrStrongholdAccessFailed
+	}
+	if err := s.storage.SecretStore().DeleteSecret(context.Background(), "model", resolvedProvider+"_api_key"); err != nil {
+		normalizedErr := storage.NormalizeSecretStoreError(err)
+		if errors.Is(normalizedErr, storage.ErrStrongholdAccessFailed) || errors.Is(normalizedErr, storage.ErrStrongholdUnavailable) || errors.Is(normalizedErr, storage.ErrSecretStoreAccessFailed) {
+			return ErrStrongholdAccessFailed
+		}
+		return normalizedErr
+	}
+	return nil
+}
+
+func strongholdStatusFromStorage(store *storage.Service) map[string]any {
+	if store == nil || store.Stronghold() == nil {
+		return nil
+	}
+	descriptor := store.Stronghold().Descriptor()
+	return map[string]any{
+		"backend":      descriptor.Backend,
+		"available":    descriptor.Available,
+		"fallback":     descriptor.Fallback,
+		"initialized":  descriptor.Initialized,
+		"formal_store": descriptor.Available && !descriptor.Fallback,
+	}
 }
 
 func (s *Service) providerForSettingsUpdate(dataLog map[string]any) string {

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -441,6 +441,21 @@ func mustNewStoredEngine(t *testing.T, taskStore storage.TaskRunStore) *runengin
 	return engine
 }
 
+type storageTestAdapter struct {
+	databasePath string
+}
+
+func (s storageTestAdapter) DatabasePath() string {
+	return s.databasePath
+}
+
+func (s storageTestAdapter) SecretStorePath() string {
+	if s.databasePath == "" {
+		return ""
+	}
+	return s.databasePath + ".stronghold"
+}
+
 func newTestService() *Service {
 	return NewService(
 		contextsvc.NewService(),
@@ -503,6 +518,14 @@ func replaceAuthorizationRecordStore(t *testing.T, service *storage.Service, sto
 
 	serviceValue := reflect.ValueOf(service).Elem()
 	field := serviceValue.FieldByName("authorizationRecordStore")
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(reflect.ValueOf(store))
+}
+
+func replaceSecretStore(t *testing.T, service *storage.Service, store storage.SecretStore) {
+	t.Helper()
+
+	serviceValue := reflect.ValueOf(service).Elem()
+	field := serviceValue.FieldByName("secretStore")
 	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(reflect.ValueOf(store))
 }
 
@@ -7648,6 +7671,10 @@ func TestSettingsGetIncludesSecretConfigurationAvailability(t *testing.T) {
 	if dataLog["provider_api_key_configured"] != false {
 		t.Fatalf("expected unset provider key flag, got %+v", dataLog)
 	}
+	stronghold := dataLog["stronghold"].(map[string]any)
+	if stronghold["backend"] == "" || stronghold["available"] != true {
+		t.Fatalf("expected stronghold status metadata, got %+v", stronghold)
+	}
 	if err := service.storage.SecretStore().PutSecret(context.Background(), storage.SecretRecord{
 		Namespace: "model",
 		Key:       service.model.Provider() + "_api_key",
@@ -7710,6 +7737,9 @@ func TestSettingsUpdatePersistsSecretOutsideRegularSettings(t *testing.T) {
 	if dataLog["provider_api_key_configured"] != true {
 		t.Fatalf("expected configured flag in settings response, got %+v", dataLog)
 	}
+	if _, exists := dataLog["stronghold"]; !exists {
+		t.Fatalf("expected stronghold status in settings response, got %+v", dataLog)
+	}
 }
 
 func TestSettingsUpdatePersistsSecretForRequestedProvider(t *testing.T) {
@@ -7745,6 +7775,68 @@ func TestSettingsUpdatePersistsSecretForRequestedProvider(t *testing.T) {
 	dataLog := result["settings"].(map[string]any)["data_log"].(map[string]any)
 	if dataLog["provider"] != "anthropic" || dataLog["provider_api_key_configured"] != true {
 		t.Fatalf("expected settings get to reflect anthropic provider secret, got %+v", dataLog)
+	}
+}
+
+func TestSettingsUpdateDeletesProviderSecretWithoutLeakingValue(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "settings delete secret")
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+	if err := service.storage.SecretStore().PutSecret(context.Background(), storage.SecretRecord{
+		Namespace: "model",
+		Key:       service.model.Provider() + "_api_key",
+		Value:     "secret-key",
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("seed secret store failed: %v", err)
+	}
+	result, err := service.SettingsUpdate(map[string]any{
+		"data_log": map[string]any{
+			"provider":       "openai",
+			"delete_api_key": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("settings update delete failed: %v", err)
+	}
+	_, err = service.storage.SecretStore().GetSecret(context.Background(), "model", service.model.Provider()+"_api_key")
+	if !errors.Is(err, storage.ErrSecretNotFound) {
+		t.Fatalf("expected secret to be deleted, got %v", err)
+	}
+	dataLog := result["effective_settings"].(map[string]any)["data_log"].(map[string]any)
+	if _, exists := dataLog["api_key"]; exists {
+		t.Fatalf("expected settings delete response to stay redacted, got %+v", dataLog)
+	}
+	if dataLog["provider_api_key_configured"] != false {
+		t.Fatalf("expected delete to clear configured flag, got %+v", dataLog)
+	}
+}
+
+func TestSettingsUpdateReturnsStrongholdErrorWhenStoreUnavailable(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "settings stronghold unavailable")
+	if service.storage == nil {
+		t.Fatal("expected storage service to be wired")
+	}
+	originalStorage := service.storage
+	defer func() {
+		if service.storage != nil {
+			_ = service.storage.Close()
+		}
+	}()
+	if err := originalStorage.Close(); err != nil {
+		t.Fatalf("close original storage failed: %v", err)
+	}
+	service.storage = storage.NewService(nil)
+	replaceSecretStore(t, service.storage, storage.UnavailableSecretStore{})
+	_, err := service.SettingsUpdate(map[string]any{
+		"data_log": map[string]any{
+			"provider": "openai",
+			"api_key":  "secret-key",
+		},
+	})
+	if !errors.Is(err, ErrStrongholdAccessFailed) {
+		t.Fatalf("expected ErrStrongholdAccessFailed, got %v", err)
 	}
 }
 

--- a/services/local-service/internal/storage/secret_store.go
+++ b/services/local-service/internal/storage/secret_store.go
@@ -3,10 +3,14 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 )
+
+// ErrStrongholdAccessFailed reports formal Stronghold lifecycle access failure.
+var ErrStrongholdAccessFailed = ErrSecretStoreAccessFailed
 
 type inMemorySecretStore struct {
 	mu      sync.Mutex
@@ -44,7 +48,9 @@ func (s *inMemorySecretStore) DeleteSecret(_ context.Context, namespace, key str
 	return nil
 }
 
-// SQLiteSecretStore persists secrets in a dedicated Stronghold-compatible SQLite database.
+// SQLiteSecretStore persists secrets in a dedicated SQLite fallback database.
+// It remains the development fallback once the formal Stronghold lifecycle is
+// introduced through StrongholdProvider.
 type SQLiteSecretStore struct {
 	db *sql.DB
 }
@@ -100,6 +106,39 @@ func (s *SQLiteSecretStore) DeleteSecret(ctx context.Context, namespace, key str
 		return fmt.Errorf("%w: %v", ErrSecretStoreAccessFailed, err)
 	}
 	return nil
+}
+
+// UnavailableSecretStore is used when Stronghold lifecycle exists but cannot be
+// opened. This keeps secret APIs explicit about unavailability instead of
+// silently pretending the fallback is the formal source of truth.
+type UnavailableSecretStore struct{}
+
+func (UnavailableSecretStore) PutSecret(context.Context, SecretRecord) error {
+	return ErrStrongholdUnavailable
+}
+
+func (UnavailableSecretStore) GetSecret(context.Context, string, string) (SecretRecord, error) {
+	return SecretRecord{}, ErrStrongholdUnavailable
+}
+
+func (UnavailableSecretStore) DeleteSecret(context.Context, string, string) error {
+	return ErrStrongholdUnavailable
+}
+
+func NormalizeSecretStoreError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrSecretNotFound) {
+		return ErrSecretNotFound
+	}
+	if errors.Is(err, ErrStrongholdUnavailable) {
+		return ErrStrongholdAccessFailed
+	}
+	if errors.Is(err, ErrSecretStoreAccessFailed) {
+		return ErrStrongholdAccessFailed
+	}
+	return err
 }
 
 // Close closes the secret store handle.

--- a/services/local-service/internal/storage/secret_store_test.go
+++ b/services/local-service/internal/storage/secret_store_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -99,5 +100,63 @@ func TestValidateSecretRecordRejectsMissingFields(t *testing.T) {
 	valid.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
 	if err := validateSecretRecord(valid); err != nil {
 		t.Fatalf("expected RFC3339Nano timestamp to be accepted, got %v", err)
+	}
+}
+
+func TestStrongholdSQLiteFallbackProviderLifecycle(t *testing.T) {
+	provider := NewStrongholdSQLiteFallbackProvider(filepath.Join(t.TempDir(), "stronghold-fallback.db"))
+	descriptor := provider.Descriptor()
+	if !descriptor.Available || !descriptor.Fallback || descriptor.Backend == "" {
+		t.Fatalf("expected fallback provider descriptor to expose availability, got %+v", descriptor)
+	}
+	store, err := provider.Open(context.Background())
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer func() {
+		if closer, ok := store.(interface{ Close() error }); ok {
+			_ = closer.Close()
+		}
+	}()
+	if err := store.PutSecret(context.Background(), SecretRecord{Namespace: "model", Key: "openai_responses_api_key", Value: "secret", UpdatedAt: time.Now().UTC().Format(time.RFC3339)}); err != nil {
+		t.Fatalf("fallback provider store put returned error: %v", err)
+	}
+	if _, err := store.GetSecret(context.Background(), "model", "openai_responses_api_key"); err != nil {
+		t.Fatalf("fallback provider store get returned error: %v", err)
+	}
+	missingProvider := NewStrongholdSQLiteFallbackProvider("   ")
+	if _, err := missingProvider.Open(context.Background()); err == nil || !errors.Is(err, ErrStrongholdUnavailable) {
+		t.Fatalf("expected missing fallback provider to report ErrStrongholdUnavailable, got %v", err)
+	}
+}
+
+func TestNormalizeSecretStoreErrorMapsStrongholdFailures(t *testing.T) {
+	if NormalizeSecretStoreError(nil) != nil {
+		t.Fatal("expected nil error to stay nil")
+	}
+	if !errors.Is(NormalizeSecretStoreError(ErrSecretNotFound), ErrSecretNotFound) {
+		t.Fatal("expected ErrSecretNotFound to remain unchanged")
+	}
+	if !errors.Is(NormalizeSecretStoreError(ErrStrongholdUnavailable), ErrStrongholdAccessFailed) {
+		t.Fatal("expected stronghold unavailable to normalize to stronghold access failure")
+	}
+	if !errors.Is(NormalizeSecretStoreError(ErrSecretStoreAccessFailed), ErrStrongholdAccessFailed) {
+		t.Fatal("expected secret store access failure to normalize to stronghold access failure")
+	}
+	if NormalizeSecretStoreError(context.Canceled) != context.Canceled {
+		t.Fatal("expected unrelated errors to stay unchanged")
+	}
+}
+
+func TestUnavailableSecretStoreRejectsAllOperations(t *testing.T) {
+	store := UnavailableSecretStore{}
+	if err := store.PutSecret(context.Background(), SecretRecord{Namespace: "model", Key: "openai_responses_api_key", Value: "secret", UpdatedAt: time.Now().UTC().Format(time.RFC3339)}); !errors.Is(err, ErrStrongholdUnavailable) {
+		t.Fatalf("expected put to fail with ErrStrongholdUnavailable, got %v", err)
+	}
+	if _, err := store.GetSecret(context.Background(), "model", "openai_responses_api_key"); !errors.Is(err, ErrStrongholdUnavailable) {
+		t.Fatalf("expected get to fail with ErrStrongholdUnavailable, got %v", err)
+	}
+	if err := store.DeleteSecret(context.Background(), "model", "openai_responses_api_key"); !errors.Is(err, ErrStrongholdUnavailable) {
+		t.Fatalf("expected delete to fail with ErrStrongholdUnavailable, got %v", err)
 	}
 }

--- a/services/local-service/internal/storage/secret_store_test.go
+++ b/services/local-service/internal/storage/secret_store_test.go
@@ -106,12 +106,16 @@ func TestValidateSecretRecordRejectsMissingFields(t *testing.T) {
 func TestStrongholdSQLiteFallbackProviderLifecycle(t *testing.T) {
 	provider := NewStrongholdSQLiteFallbackProvider(filepath.Join(t.TempDir(), "stronghold-fallback.db"))
 	descriptor := provider.Descriptor()
-	if !descriptor.Available || !descriptor.Fallback || descriptor.Backend == "" {
-		t.Fatalf("expected fallback provider descriptor to expose availability, got %+v", descriptor)
+	if descriptor.Available || descriptor.Initialized || !descriptor.Fallback || descriptor.Backend == "" {
+		t.Fatalf("expected unopened provider descriptor to stay unavailable until lifecycle open succeeds, got %+v", descriptor)
 	}
 	store, err := provider.Open(context.Background())
 	if err != nil {
 		t.Fatalf("Open returned error: %v", err)
+	}
+	descriptor = provider.Descriptor()
+	if !descriptor.Available || !descriptor.Initialized {
+		t.Fatalf("expected opened provider descriptor to expose live availability, got %+v", descriptor)
 	}
 	defer func() {
 		if closer, ok := store.(interface{ Close() error }); ok {
@@ -127,6 +131,10 @@ func TestStrongholdSQLiteFallbackProviderLifecycle(t *testing.T) {
 	missingProvider := NewStrongholdSQLiteFallbackProvider("   ")
 	if _, err := missingProvider.Open(context.Background()); err == nil || !errors.Is(err, ErrStrongholdUnavailable) {
 		t.Fatalf("expected missing fallback provider to report ErrStrongholdUnavailable, got %v", err)
+	}
+	missingDescriptor := missingProvider.Descriptor()
+	if missingDescriptor.Available || missingDescriptor.Initialized {
+		t.Fatalf("expected failed provider descriptor to report unavailable status, got %+v", missingDescriptor)
 	}
 }
 

--- a/services/local-service/internal/storage/service.go
+++ b/services/local-service/internal/storage/service.go
@@ -64,6 +64,7 @@ type Service struct {
 	traceStore               TraceStore
 	evalStore                EvalStore
 	secretStore              SecretStore
+	stronghold               StrongholdProvider
 	auditStore               AuditStore
 	recoveryPointStore       RecoveryPointStore
 	approvalRequestStore     ApprovalRequestStore
@@ -91,6 +92,7 @@ func NewService(adapter platform.StorageAdapter) *Service {
 	traceStore := TraceStore(newInMemoryTraceStore())
 	evalStore := EvalStore(newInMemoryEvalStore())
 	secretStore := SecretStore(newInMemorySecretStore())
+	strongholdProvider := StrongholdProvider(nil)
 	auditStore := AuditStore(newInMemoryAuditStore())
 	recoveryPointStore := RecoveryPointStore(newInMemoryRecoveryPointStore())
 	governanceState := &inMemoryGovernanceState{
@@ -198,12 +200,15 @@ func NewService(adapter platform.StorageAdapter) *Service {
 			}
 
 			if secretPath := strings.TrimSpace(adapter.SecretStorePath()); secretPath != "" {
-				sqliteSecretStore, err := NewSQLiteSecretStore(secretPath)
+				strongholdProvider = NewStrongholdSQLiteFallbackProvider(secretPath)
+				strongholdStore, err := strongholdProvider.Open(context.Background())
 				if err == nil {
-					secretStore = sqliteSecretStore
-					secretStoreName = memoryStoreBackendSQLite
+					secretStore = strongholdStore
+					secretStoreName = strongholdProvider.Descriptor().Backend
 				}
 				if err != nil {
+					secretStore = SecretStore(UnavailableSecretStore{})
+					secretStoreName = strongholdProvider.Descriptor().Backend
 					storeInitErrors = append(storeInitErrors, fmt.Errorf("initialize stronghold secret store: %w", err))
 					fallbackActive = true
 				}
@@ -262,6 +267,7 @@ func NewService(adapter platform.StorageAdapter) *Service {
 		traceStore:               traceStore,
 		evalStore:                evalStore,
 		secretStore:              secretStore,
+		stronghold:               strongholdProvider,
 		auditStore:               auditStore,
 		recoveryPointStore:       recoveryPointStore,
 		approvalRequestStore:     approvalRequestStore,
@@ -275,6 +281,11 @@ func NewService(adapter platform.StorageAdapter) *Service {
 		storeInitErr:             storeInitErr,
 		fallbackActive:           fallbackActive,
 	}
+}
+
+// Stronghold returns the configured formal secret backend lifecycle provider.
+func (s *Service) Stronghold() StrongholdProvider {
+	return s.stronghold
 }
 
 func initializeSQLiteTraceEvalStores(databasePath string) (TraceStore, EvalStore, error) {

--- a/services/local-service/internal/storage/service_test.go
+++ b/services/local-service/internal/storage/service_test.go
@@ -169,7 +169,7 @@ func TestCapabilitiesReturnsConfiguredStructuredStorageOnly(t *testing.T) {
 	if capabilities.MemoryRetrievalBackend != memoryRetrievalBackendSQLite {
 		t.Fatalf("unexpected retrieval backend: %+v", capabilities)
 	}
-	if capabilities.SecretStoreBackend != memoryStoreBackendSQLite {
+	if capabilities.SecretStoreBackend != "stronghold_sqlite_fallback" {
 		t.Fatalf("unexpected secret backend: %+v", capabilities)
 	}
 }
@@ -866,6 +866,22 @@ func TestResolveModelAPIKeyReturnsAccessFailureWhenStoreClosed(t *testing.T) {
 	_, err := service.ResolveModelAPIKey("openai_responses")
 	if !errors.Is(err, ErrSecretStoreAccessFailed) {
 		t.Fatalf("expected ErrSecretStoreAccessFailed, got %v", err)
+	}
+}
+
+func TestServiceUsesUnavailableSecretStoreWhenStrongholdCannotOpen(t *testing.T) {
+	service := NewService(stubAdapter{databasePath: ""})
+	defer func() { _ = service.Close() }()
+	if service.Stronghold() != nil {
+		t.Fatalf("expected no Stronghold provider when secret path missing, got %+v", service.Stronghold().Descriptor())
+	}
+	if err := service.SecretStore().PutSecret(context.Background(), SecretRecord{Namespace: "model", Key: "openai_responses_api_key", Value: "secret", UpdatedAt: "2026-04-15T10:00:00Z"}); err != nil {
+		t.Fatalf("expected in-memory fallback store when Stronghold path missing, got %v", err)
+	}
+
+	store := SecretStore(UnavailableSecretStore{})
+	if err := store.PutSecret(context.Background(), SecretRecord{Namespace: "model", Key: "openai_responses_api_key", Value: "secret", UpdatedAt: "2026-04-15T10:00:00Z"}); !errors.Is(err, ErrStrongholdUnavailable) {
+		t.Fatalf("expected unavailable formal store to reject writes, got %v", err)
 	}
 }
 

--- a/services/local-service/internal/storage/stronghold_store.go
+++ b/services/local-service/internal/storage/stronghold_store.go
@@ -1,0 +1,54 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// ErrStrongholdUnavailable indicates that the formal Stronghold backend cannot
+// be opened and callers should decide whether fallback is acceptable.
+var ErrStrongholdUnavailable = fmt.Errorf("%w: stronghold backend unavailable", ErrSecretStoreAccessFailed)
+
+// StrongholdSQLiteFallbackProvider uses the current SQLite-backed secret store
+// as a fallback implementation while preserving a formal Stronghold lifecycle
+// boundary for future production Stronghold wiring.
+type StrongholdSQLiteFallbackProvider struct {
+	databasePath string
+	available    bool
+}
+
+// NewStrongholdSQLiteFallbackProvider creates a provider that advertises the
+// Stronghold lifecycle contract but falls back to SQLite in development.
+func NewStrongholdSQLiteFallbackProvider(databasePath string) *StrongholdSQLiteFallbackProvider {
+	return &StrongholdSQLiteFallbackProvider{
+		databasePath: strings.TrimSpace(databasePath),
+		available:    strings.TrimSpace(databasePath) != "",
+	}
+}
+
+func (p *StrongholdSQLiteFallbackProvider) Open(ctx context.Context) (SecretStore, error) {
+	if p == nil || !p.available || strings.TrimSpace(p.databasePath) == "" {
+		return nil, ErrStrongholdUnavailable
+	}
+	store, err := NewSQLiteSecretStore(p.databasePath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrStrongholdUnavailable, err)
+	}
+	select {
+	case <-ctx.Done():
+		_ = store.Close()
+		return nil, ctx.Err()
+	default:
+	}
+	return store, nil
+}
+
+func (p *StrongholdSQLiteFallbackProvider) Descriptor() StrongholdDescriptor {
+	return StrongholdDescriptor{
+		Backend:     "stronghold_sqlite_fallback",
+		Available:   p != nil && p.available,
+		Fallback:    true,
+		Initialized: p != nil && p.available,
+	}
+}

--- a/services/local-service/internal/storage/stronghold_store.go
+++ b/services/local-service/internal/storage/stronghold_store.go
@@ -16,6 +16,8 @@ var ErrStrongholdUnavailable = fmt.Errorf("%w: stronghold backend unavailable", 
 type StrongholdSQLiteFallbackProvider struct {
 	databasePath string
 	available    bool
+	initialized  bool
+	lastOpenErr  error
 }
 
 // NewStrongholdSQLiteFallbackProvider creates a provider that advertises the
@@ -29,26 +31,37 @@ func NewStrongholdSQLiteFallbackProvider(databasePath string) *StrongholdSQLiteF
 
 func (p *StrongholdSQLiteFallbackProvider) Open(ctx context.Context) (SecretStore, error) {
 	if p == nil || !p.available || strings.TrimSpace(p.databasePath) == "" {
+		if p != nil {
+			p.initialized = false
+			p.lastOpenErr = ErrStrongholdUnavailable
+		}
 		return nil, ErrStrongholdUnavailable
 	}
 	store, err := NewSQLiteSecretStore(p.databasePath)
 	if err != nil {
+		p.initialized = false
+		p.lastOpenErr = err
 		return nil, fmt.Errorf("%w: %v", ErrStrongholdUnavailable, err)
 	}
 	select {
 	case <-ctx.Done():
 		_ = store.Close()
+		p.initialized = false
+		p.lastOpenErr = ctx.Err()
 		return nil, ctx.Err()
 	default:
 	}
+	p.initialized = true
+	p.lastOpenErr = nil
 	return store, nil
 }
 
 func (p *StrongholdSQLiteFallbackProvider) Descriptor() StrongholdDescriptor {
+	available := p != nil && p.available && p.initialized && p.lastOpenErr == nil
 	return StrongholdDescriptor{
 		Backend:     "stronghold_sqlite_fallback",
-		Available:   p != nil && p.available,
+		Available:   available,
 		Fallback:    true,
-		Initialized: p != nil && p.available,
+		Initialized: p != nil && p.initialized,
 	}
 }

--- a/services/local-service/internal/storage/types.go
+++ b/services/local-service/internal/storage/types.go
@@ -190,6 +190,23 @@ type SecretStore interface {
 	DeleteSecret(ctx context.Context, namespace, key string) error
 }
 
+// StrongholdProvider defines the formal Stronghold lifecycle boundary. The
+// backend can bind a real Stronghold runtime here while keeping SQLite as a
+// development fallback instead of pretending it is the formal secret source.
+type StrongholdProvider interface {
+	Open(ctx context.Context) (SecretStore, error)
+	Descriptor() StrongholdDescriptor
+}
+
+// StrongholdDescriptor exposes the current Stronghold lifecycle status without
+// leaking secrets into settings snapshots or normal task state payloads.
+type StrongholdDescriptor struct {
+	Backend     string
+	Available   bool
+	Fallback    bool
+	Initialized bool
+}
+
 // TaskStepSnapshot 描述 task timeline 在存储层的快照格式。
 type TaskStepSnapshot struct {
 	StepID        string


### PR DESCRIPTION
## Summary

- introduce a formal `StrongholdProvider` lifecycle boundary for secret storage, instead of treating the SQLite secret store as if it were the real Stronghold implementation
- wire storage and settings flows so secrets stay outside normal settings snapshots, expose only masked availability/status, and support rotate/delete/unavailable behavior through the Stronghold path
- keep the current SQLite-backed secret store as an explicit fallback/development-compatible backend, and add regression coverage for lifecycle, masking, rotation, deletion, and failure handling

## Why

The previous owner-5 work already moved secrets out of the normal settings path, which closed the P0 concern of not storing model API keys as ordinary settings fields. But the backend still used a SQLite store described as “Stronghold-compatible”, which meant the system had not yet established a formal Stronghold integration boundary or lifecycle.

This PR closes that P1-2 gap by defining a real Stronghold-facing interface, preserving SQLite only as a fallback/development layer, and aligning `settings.get / settings.update` with secret masking, deletion, and unavailable-store semantics.

## What Changed

### Formal Stronghold lifecycle
- add `StrongholdProvider`
- add `StrongholdDescriptor`
- add `StrongholdSQLiteFallbackProvider`
- add `ErrStrongholdUnavailable`
- expose Stronghold lifecycle status through storage instead of treating fallback SQLite as the formal secret source

### Storage wiring
- wire Stronghold lifecycle into `storage.Service`
- expose `Stronghold()` from the storage service
- keep SQLite-backed secret persistence as the fallback/dev-compatible backend
- make unavailable formal secret backends fail explicitly instead of silently pretending the fallback is the formal store

### Settings behavior
- keep `settings.get` masked:
  - return `provider_api_key_configured`
  - return Stronghold backend status metadata
  - never return raw secret values
- update `settings.update` so it supports:
  - secret rotation via `api_key`
  - secret deletion via `delete_api_key`
  - Stronghold unavailable errors mapped to `ErrStrongholdAccessFailed`

### Tests
- add Stronghold lifecycle and fallback coverage in storage tests
- add unavailable-store, masked settings, rotate, and delete coverage in orchestrator tests
- keep related package coverage above the required threshold

## Validation

- `go test ./services/local-service/internal/storage ./services/local-service/internal/orchestrator`
- `go test -cover ./services/local-service/internal/storage ./services/local-service/internal/orchestrator`
- `go test ./services/local-service/internal/runengine ./services/local-service/internal/bootstrap ./services/local-service/internal/model`

## Notes

- this PR does not claim that SQLite itself is the formal Stronghold implementation
- instead, it establishes the formal Stronghold lifecycle boundary and keeps SQLite as an explicit fallback/development-compatible backend
- secret values remain outside ordinary settings snapshots and are only represented through masked availability/status in settings APIs
