### PR TITLE
fix: stop forcing intent confirmation for actionable short text inputs

### DIFF
--- a/services/local-service/internal/execution/service.go
+++ b/services/local-service/internal/execution/service.go
@@ -132,6 +132,7 @@ type Result struct {
 	Artifacts       []map[string]any
 	ExtensionAssets []map[string]any
 	BubbleText      string
+	LoopStopReason  string
 	RecoveryPoint   map[string]any
 	ModelInvocation map[string]any
 	AuditRecord     map[string]any
@@ -165,6 +166,7 @@ type generationTrace struct {
 	AuditRecord      map[string]any
 	GenerationOutput map[string]any
 	BudgetFailure    map[string]any
+	LoopStopReason   string
 }
 
 // NewService builds the execution service.
@@ -323,6 +325,7 @@ func (s *Service) Execute(ctx context.Context, request Request) (Result, error) 
 		AuditRecord:     cloneMap(trace.AuditRecord),
 		ToolCalls:       append([]tools.ToolCallRecord(nil), trace.ToolCalls...),
 		BudgetFailure:   cloneMap(trace.BudgetFailure),
+		LoopStopReason:  trace.LoopStopReason,
 		ToolInput: map[string]any{
 			"intent_name":     effectiveIntentName(request.Intent),
 			"delivery_type":   deliveryType,
@@ -1976,6 +1979,7 @@ func (s *Service) generateOutputWithAgentLoop(ctx context.Context, request Reque
 		ToolCalls:       runtimeResult.ToolCalls,
 		ModelInvocation: cloneMap(runtimeResult.ModelInvocation),
 		AuditRecord:     cloneMap(runtimeResult.AuditRecord),
+		LoopStopReason:  string(runtimeResult.StopReason),
 	}, true, nil
 }
 
@@ -2276,11 +2280,7 @@ func fallbackOutput(request Request, inputText string) string {
 	case "":
 		return "我还不确定你希望我怎么处理这段内容，请补充你的目标，例如解释、翻译、改写或总结。"
 	case defaultAgentLoopIntentName:
-		highlights := extractHighlights(normalized, 3)
-		if len(highlights) == 0 {
-			return "我已经理解了当前输入，但还需要更多信息才能继续执行。"
-		}
-		return "初步处理结果：\n- " + strings.Join(highlights, "\n- ")
+		return "我还不确定你希望我怎么处理这段内容，请补充你的目标，例如解释、翻译、改写或总结。"
 	case "rewrite":
 		return "改写结果：\n" + normalized
 	case "translate":
@@ -2929,7 +2929,7 @@ func runStatusFromStopReason(reason agentloop.StopReason) string {
 	case agentloop.StopReasonNeedAuthorization:
 		return "waiting_auth"
 	case agentloop.StopReasonNeedUserInput:
-		return "confirming_intent"
+		return "waiting_input"
 	case agentloop.StopReasonPlannerError, agentloop.StopReasonRepeatedToolChoice, agentloop.StopReasonMaxIterations, agentloop.StopReasonToolRetryExhausted:
 		return "failed"
 	default:

--- a/services/local-service/internal/execution/service_test.go
+++ b/services/local-service/internal/execution/service_test.go
@@ -663,6 +663,40 @@ func TestExecuteAgentLoopPersistsRuntimeEventsAndStopReason(t *testing.T) {
 	}
 }
 
+func TestExecuteAgentLoopRequestsClarificationWhenPlannerReturnsEmptyOutput(t *testing.T) {
+	modelClient := &stubModelClient{
+		toolCalls: []model.ToolCallResult{{
+			RequestID:  "req_loop_need_input",
+			Provider:   "openai_responses",
+			ModelID:    "gpt-5.4",
+			OutputText: "",
+		}},
+	}
+	service, _ := newTestExecutionServiceWithModelClient(t, modelClient)
+
+	result, err := service.Execute(context.Background(), Request{
+		TaskID:       "task_loop_need_input",
+		RunID:        "run_loop_need_input",
+		Title:        "Loop need input",
+		Intent:       map[string]any{"name": defaultAgentLoopIntentName, "arguments": map[string]any{}},
+		Snapshot:     contextsvc.TaskContextSnapshot{InputType: "text", Text: "你好"},
+		DeliveryType: "bubble",
+		ResultTitle:  "Loop clarification",
+	})
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if result.LoopStopReason != string(agentloop.StopReasonNeedUserInput) {
+		t.Fatalf("expected need_user_input stop reason, got %+v", result)
+	}
+	if !strings.Contains(result.Content, "请补充你的目标") {
+		t.Fatalf("expected clarification fallback output, got %+v", result)
+	}
+	if !strings.Contains(result.BubbleText, "请补充你的目标") {
+		t.Fatalf("expected clarification bubble text, got %+v", result)
+	}
+}
+
 func TestPersistAgentLoopRuntimeKeepsResumeSegmentsAndEventsDistinct(t *testing.T) {
 	store := &recordingLoopRuntimeStore{}
 	service := (&Service{}).WithLoopRuntimeStore(store)
@@ -1405,6 +1439,12 @@ func TestExecuteAgentLoopDoesNotDuplicateQueuedSteeringOnFirstRound(t *testing.T
 func TestRunStatusFromStopReasonTreatsToolRetryExhaustedAsFailed(t *testing.T) {
 	if status := runStatusFromStopReason(agentloop.StopReasonToolRetryExhausted); status != "failed" {
 		t.Fatalf("expected tool retry exhausted to map to failed, got %q", status)
+	}
+}
+
+func TestRunStatusFromStopReasonTreatsNeedUserInputAsWaitingInput(t *testing.T) {
+	if status := runStatusFromStopReason(agentloop.StopReasonNeedUserInput); status != "waiting_input" {
+		t.Fatalf("expected need_user_input to map to waiting_input, got %q", status)
 	}
 }
 
@@ -2756,6 +2796,14 @@ func TestFallbackOutputRequestsClarificationWhenIntentMissing(t *testing.T) {
 	}
 	if strings.Contains(output, "总结结果") {
 		t.Fatalf("expected unknown intent fallback not to pretend summarize, got %s", output)
+	}
+}
+
+func TestFallbackOutputRequestsClarificationForAgentLoopWhenGoalIsUnderspecified(t *testing.T) {
+	output := fallbackOutput(Request{Intent: map[string]any{"name": defaultAgentLoopIntentName}}, "你好")
+
+	if !strings.Contains(output, "请补充你的目标") {
+		t.Fatalf("expected agent_loop fallback to request clarification, got %s", output)
 	}
 }
 

--- a/services/local-service/internal/intent/service.go
+++ b/services/local-service/internal/intent/service.go
@@ -4,7 +4,6 @@ package intent
 import (
 	"path/filepath"
 	"strings"
-	"unicode"
 	"unicode/utf8"
 
 	contextsvc "github.com/cialloclaw/cialloclaw/services/local-service/internal/context"
@@ -74,9 +73,6 @@ func (s *Service) Suggest(snapshot contextsvc.TaskContextSnapshot, explicitInten
 	if intentName == "screen_analyze" {
 		requiresConfirm = false
 	}
-	if !requiresConfirm && len(explicitIntent) == 0 {
-		requiresConfirm = requiresConfirmation(snapshot, intentName)
-	}
 
 	directDeliveryType := directDeliveryTypeForSnapshot(snapshot, intentName)
 	resultPreview := previewForDeliveryType(directDeliveryType)
@@ -95,15 +91,12 @@ func (s *Service) Suggest(snapshot contextsvc.TaskContextSnapshot, explicitInten
 }
 
 // defaultIntent chooses the minimum default route when the client does not provide
-// an explicit intent payload. The current correction path no longer classifies
-// free-form requests into summarize / translate / explain via keyword matching.
-// Instead, non-trivial inputs fall back to the generic agent loop path.
+// an explicit intent payload. Free-form requests always fall back to the
+// generic agent loop path so clarification stays in the main execution flow
+// instead of growing an intent-side phrase router.
 func (s *Service) defaultIntent(snapshot contextsvc.TaskContextSnapshot) map[string]any {
 	if screenIntent, ok := screenAnalyzeIntent(snapshot); ok {
 		return screenIntent
-	}
-	if shouldConfirmTextGoal(snapshot) {
-		return map[string]any{}
 	}
 
 	return intentPayload(defaultAgentLoopIntent)
@@ -209,100 +202,6 @@ func sourceTypeFromSnapshot(snapshot contextsvc.TaskContextSnapshot) string {
 		}
 		return "hover_input"
 	}
-}
-
-func requiresConfirmation(snapshot contextsvc.TaskContextSnapshot, intentName string) bool {
-	switch {
-	case intentName == "":
-		return true
-	case intentName == defaultAgentLoopIntent:
-		return false
-	case snapshot.InputType == "file":
-		return true
-	case snapshot.InputType == "text_selection":
-		return intentName != "translate"
-	case isLongContent(snapshot.Text):
-		return intentName == "summarize" || intentName == "rewrite"
-	default:
-		return false
-	}
-}
-
-func shouldConfirmTextGoal(snapshot contextsvc.TaskContextSnapshot) bool {
-	if snapshot.InputType != "text" {
-		return false
-	}
-	trimmed := strings.TrimSpace(snapshot.Text)
-	if trimmed == "" {
-		return false
-	}
-	if hasIntentContextAnchor(snapshot) {
-		return false
-	}
-	if isLongContent(trimmed) || isQuestionText(trimmed) {
-		return false
-	}
-	if utf8.RuneCountInString(trimmed) > 4 {
-		return false
-	}
-
-	// Short text should default to agent_loop. Only clearly non-goal inputs stay
-	// in confirmation so the gateway does not turn into a growing action lexicon.
-	return isClearlyAmbiguousShortText(trimmed)
-}
-
-func hasIntentContextAnchor(snapshot contextsvc.TaskContextSnapshot) bool {
-	return strings.TrimSpace(snapshot.SelectionText) != "" ||
-		strings.TrimSpace(snapshot.ErrorText) != "" ||
-		len(snapshot.Files) > 0 ||
-		strings.TrimSpace(snapshot.PageTitle) != "" ||
-		strings.TrimSpace(snapshot.WindowTitle) != "" ||
-		strings.TrimSpace(snapshot.VisibleText) != "" ||
-		strings.TrimSpace(snapshot.ScreenSummary) != ""
-}
-
-func isClearlyAmbiguousShortText(text string) bool {
-	if isPunctuationOrEmojiOnly(text) {
-		return true
-	}
-
-	normalized := normalizeAmbiguousShortText(text)
-	if normalized == "" {
-		return false
-	}
-
-	switch normalized {
-	case "hi", "hello", "hey", "ok", "okay",
-		"你好", "您好", "在吗", "在么",
-		"嗯", "嗯嗯", "哦", "哦哦", "啊", "啊啊",
-		"好的", "好", "行", "收到",
-		"这个", "那个", "这", "那":
-		return true
-	default:
-		return false
-	}
-}
-
-func normalizeAmbiguousShortText(text string) string {
-	normalized := strings.TrimSpace(strings.ToLower(text))
-	return strings.Trim(normalized, " \t\r\n.,!?;:~，。！？；：、…'\"`“”‘’()[]{}<>《》【】")
-}
-
-func isPunctuationOrEmojiOnly(text string) bool {
-	hasSymbol := false
-	for _, value := range strings.TrimSpace(text) {
-		switch {
-		case unicode.IsSpace(value):
-			continue
-		case unicode.IsLetter(value), unicode.IsNumber(value):
-			return false
-		case unicode.IsPunct(value), unicode.IsSymbol(value):
-			hasSymbol = true
-		default:
-			return false
-		}
-	}
-	return hasSymbol
 }
 
 func directDeliveryTypeForSnapshot(snapshot contextsvc.TaskContextSnapshot, intentName string) string {

--- a/services/local-service/internal/intent/service.go
+++ b/services/local-service/internal/intent/service.go
@@ -4,6 +4,7 @@ package intent
 import (
 	"path/filepath"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	contextsvc "github.com/cialloclaw/cialloclaw/services/local-service/internal/context"
@@ -235,6 +236,9 @@ func shouldConfirmTextGoal(snapshot contextsvc.TaskContextSnapshot) bool {
 	if trimmed == "" {
 		return false
 	}
+	if hasIntentContextAnchor(snapshot) {
+		return false
+	}
 	if isLongContent(trimmed) || isQuestionText(trimmed) {
 		return false
 	}
@@ -242,26 +246,63 @@ func shouldConfirmTextGoal(snapshot contextsvc.TaskContextSnapshot) bool {
 		return false
 	}
 
-	// Short text should only pause for intent confirmation when it does not
-	// contain any execution signal. This avoids hard-gating concise requests such
-	// as "解释下" while still keeping greeting-like inputs in the confirm flow.
-	return !hasShortTextExecutionSignal(trimmed)
+	// Short text should default to agent_loop. Only clearly non-goal inputs stay
+	// in confirmation so the gateway does not turn into a growing action lexicon.
+	return isClearlyAmbiguousShortText(trimmed)
 }
 
-func hasShortTextExecutionSignal(text string) bool {
-	normalized := strings.TrimSpace(strings.ToLower(text))
+func hasIntentContextAnchor(snapshot contextsvc.TaskContextSnapshot) bool {
+	return strings.TrimSpace(snapshot.SelectionText) != "" ||
+		strings.TrimSpace(snapshot.ErrorText) != "" ||
+		len(snapshot.Files) > 0 ||
+		strings.TrimSpace(snapshot.PageTitle) != "" ||
+		strings.TrimSpace(snapshot.WindowTitle) != "" ||
+		strings.TrimSpace(snapshot.VisibleText) != "" ||
+		strings.TrimSpace(snapshot.ScreenSummary) != ""
+}
+
+func isClearlyAmbiguousShortText(text string) bool {
+	if isPunctuationOrEmojiOnly(text) {
+		return true
+	}
+
+	normalized := normalizeAmbiguousShortText(text)
 	if normalized == "" {
 		return false
 	}
 
-	if containsAny(normalized,
-		"翻译", "解释", "总结", "概括", "改写", "润色", "分析", "检查", "查看", "看看",
-		"读取", "搜索", "整理", "提取", "定位", "修复", "查", "看", "写", "做",
-		"fix", "read", "scan", "grep") {
+	switch normalized {
+	case "hi", "hello", "hey", "ok", "okay",
+		"你好", "您好", "在吗", "在么",
+		"嗯", "嗯嗯", "哦", "哦哦", "啊", "啊啊",
+		"好的", "好", "行", "收到",
+		"这个", "那个", "这", "那":
 		return true
+	default:
+		return false
 	}
+}
 
-	return strings.ContainsAny(normalized, "/\\.:#@")
+func normalizeAmbiguousShortText(text string) string {
+	normalized := strings.TrimSpace(strings.ToLower(text))
+	return strings.Trim(normalized, " \t\r\n.,!?;:~，。！？；：、…'\"`“”‘’()[]{}<>《》【】")
+}
+
+func isPunctuationOrEmojiOnly(text string) bool {
+	hasSymbol := false
+	for _, value := range strings.TrimSpace(text) {
+		switch {
+		case unicode.IsSpace(value):
+			continue
+		case unicode.IsLetter(value), unicode.IsNumber(value):
+			return false
+		case unicode.IsPunct(value), unicode.IsSymbol(value):
+			hasSymbol = true
+		default:
+			return false
+		}
+	}
+	return hasSymbol
 }
 
 func directDeliveryTypeForSnapshot(snapshot contextsvc.TaskContextSnapshot, intentName string) string {

--- a/services/local-service/internal/intent/service.go
+++ b/services/local-service/internal/intent/service.go
@@ -238,7 +238,30 @@ func shouldConfirmTextGoal(snapshot contextsvc.TaskContextSnapshot) bool {
 	if isLongContent(trimmed) || isQuestionText(trimmed) {
 		return false
 	}
-	return utf8.RuneCountInString(trimmed) <= 4
+	if utf8.RuneCountInString(trimmed) > 4 {
+		return false
+	}
+
+	// Short text should only pause for intent confirmation when it does not
+	// contain any execution signal. This avoids hard-gating concise requests such
+	// as "解释下" while still keeping greeting-like inputs in the confirm flow.
+	return !hasShortTextExecutionSignal(trimmed)
+}
+
+func hasShortTextExecutionSignal(text string) bool {
+	normalized := strings.TrimSpace(strings.ToLower(text))
+	if normalized == "" {
+		return false
+	}
+
+	if containsAny(normalized,
+		"翻译", "解释", "总结", "概括", "改写", "润色", "分析", "检查", "查看", "看看",
+		"读取", "搜索", "整理", "提取", "定位", "修复", "查", "看", "写", "做",
+		"fix", "read", "scan", "grep") {
+		return true
+	}
+
+	return strings.ContainsAny(normalized, "/\\.:#@")
 }
 
 func directDeliveryTypeForSnapshot(snapshot contextsvc.TaskContextSnapshot, intentName string) string {

--- a/services/local-service/internal/intent/service_test.go
+++ b/services/local-service/internal/intent/service_test.go
@@ -52,10 +52,10 @@ func TestSuggestKeepsAgentLoopForPlainTextWithoutVisualSignals(t *testing.T) {
 	}
 }
 
-func TestSuggestRoutesNonAmbiguousShortTextToAgentLoopWithoutConfirmation(t *testing.T) {
+func TestSuggestRoutesShortFreeTextToAgentLoopWithoutConfirmation(t *testing.T) {
 	service := NewService()
 
-	testCases := []string{"解释下", "a.go", "v1.2", `C:\`, `@me`}
+	testCases := []string{"解释下", "你好", "这个", "🙂", "a.go", "v1.2", `C:\`, `@me`}
 	for _, testCase := range testCases {
 		t.Run(testCase, func(t *testing.T) {
 			suggestion := service.Suggest(contextsvc.TaskContextSnapshot{
@@ -73,43 +73,19 @@ func TestSuggestRoutesNonAmbiguousShortTextToAgentLoopWithoutConfirmation(t *tes
 	}
 }
 
-func TestSuggestKeepsAmbiguousShortTextInConfirmation(t *testing.T) {
-	service := NewService()
-
-	testCases := []string{"你好", "hi", "好的", "这个", "🙂"}
-	for _, testCase := range testCases {
-		t.Run(testCase, func(t *testing.T) {
-			suggestion := service.Suggest(contextsvc.TaskContextSnapshot{
-				InputType: "text",
-				Text:      testCase,
-			}, nil, false)
-
-			if len(suggestion.Intent) != 0 {
-				t.Fatalf("expected ambiguous short text to keep empty intent payload, got %+v", suggestion.Intent)
-			}
-			if !suggestion.RequiresConfirm {
-				t.Fatal("expected ambiguous short text to remain in confirmation flow")
-			}
-		})
-	}
-}
-
-func TestSuggestKeepsAnchoredShortTextOnAgentLoopWithoutConfirmation(t *testing.T) {
+func TestSuggestRespectsExplicitConfirmationRequestForFreeText(t *testing.T) {
 	service := NewService()
 
 	suggestion := service.Suggest(contextsvc.TaskContextSnapshot{
-		InputType:   "text",
-		Text:        "这个",
-		PageTitle:   "Build Dashboard",
-		WindowTitle: "Browser - Build Dashboard",
-		VisibleText: "release validation failed",
-	}, nil, false)
+		InputType: "text",
+		Text:      "你好",
+	}, nil, true)
 
 	if got := stringValue(suggestion.Intent, "name"); got != defaultAgentLoopIntent {
-		t.Fatalf("expected anchored short text to route through agent loop, got %q", got)
+		t.Fatalf("expected explicit confirmation request to keep agent_loop intent, got %q", got)
 	}
-	if suggestion.RequiresConfirm {
-		t.Fatal("expected anchored short text to skip forced confirmation")
+	if !suggestion.RequiresConfirm {
+		t.Fatal("expected explicit confirmation request to preserve confirming_intent entry")
 	}
 }
 

--- a/services/local-service/internal/intent/service_test.go
+++ b/services/local-service/internal/intent/service_test.go
@@ -52,6 +52,38 @@ func TestSuggestKeepsAgentLoopForPlainTextWithoutVisualSignals(t *testing.T) {
 	}
 }
 
+func TestSuggestRoutesShortActionTextToAgentLoopWithoutConfirmation(t *testing.T) {
+	service := NewService()
+
+	suggestion := service.Suggest(contextsvc.TaskContextSnapshot{
+		InputType: "text",
+		Text:      "解释下",
+	}, nil, false)
+
+	if got := stringValue(suggestion.Intent, "name"); got != defaultAgentLoopIntent {
+		t.Fatalf("expected short action text to route through agent loop, got %q", got)
+	}
+	if suggestion.RequiresConfirm {
+		t.Fatal("expected short action text to skip forced confirmation")
+	}
+}
+
+func TestSuggestKeepsAmbiguousShortTextInConfirmation(t *testing.T) {
+	service := NewService()
+
+	suggestion := service.Suggest(contextsvc.TaskContextSnapshot{
+		InputType: "text",
+		Text:      "你好",
+	}, nil, false)
+
+	if len(suggestion.Intent) != 0 {
+		t.Fatalf("expected ambiguous short text to keep empty intent payload, got %+v", suggestion.Intent)
+	}
+	if !suggestion.RequiresConfirm {
+		t.Fatal("expected ambiguous short text to remain in confirmation flow")
+	}
+}
+
 func TestSuggestKeepsPlainTextSubjectAheadOfPageContextForAgentLoop(t *testing.T) {
 	service := NewService()
 

--- a/services/local-service/internal/intent/service_test.go
+++ b/services/local-service/internal/intent/service_test.go
@@ -52,35 +52,64 @@ func TestSuggestKeepsAgentLoopForPlainTextWithoutVisualSignals(t *testing.T) {
 	}
 }
 
-func TestSuggestRoutesShortActionTextToAgentLoopWithoutConfirmation(t *testing.T) {
+func TestSuggestRoutesNonAmbiguousShortTextToAgentLoopWithoutConfirmation(t *testing.T) {
 	service := NewService()
 
-	suggestion := service.Suggest(contextsvc.TaskContextSnapshot{
-		InputType: "text",
-		Text:      "解释下",
-	}, nil, false)
+	testCases := []string{"解释下", "a.go", "v1.2", `C:\`, `@me`}
+	for _, testCase := range testCases {
+		t.Run(testCase, func(t *testing.T) {
+			suggestion := service.Suggest(contextsvc.TaskContextSnapshot{
+				InputType: "text",
+				Text:      testCase,
+			}, nil, false)
 
-	if got := stringValue(suggestion.Intent, "name"); got != defaultAgentLoopIntent {
-		t.Fatalf("expected short action text to route through agent loop, got %q", got)
-	}
-	if suggestion.RequiresConfirm {
-		t.Fatal("expected short action text to skip forced confirmation")
+			if got := stringValue(suggestion.Intent, "name"); got != defaultAgentLoopIntent {
+				t.Fatalf("expected short text to route through agent loop, got %q", got)
+			}
+			if suggestion.RequiresConfirm {
+				t.Fatal("expected non-ambiguous short text to skip forced confirmation")
+			}
+		})
 	}
 }
 
 func TestSuggestKeepsAmbiguousShortTextInConfirmation(t *testing.T) {
 	service := NewService()
 
+	testCases := []string{"你好", "hi", "好的", "这个", "🙂"}
+	for _, testCase := range testCases {
+		t.Run(testCase, func(t *testing.T) {
+			suggestion := service.Suggest(contextsvc.TaskContextSnapshot{
+				InputType: "text",
+				Text:      testCase,
+			}, nil, false)
+
+			if len(suggestion.Intent) != 0 {
+				t.Fatalf("expected ambiguous short text to keep empty intent payload, got %+v", suggestion.Intent)
+			}
+			if !suggestion.RequiresConfirm {
+				t.Fatal("expected ambiguous short text to remain in confirmation flow")
+			}
+		})
+	}
+}
+
+func TestSuggestKeepsAnchoredShortTextOnAgentLoopWithoutConfirmation(t *testing.T) {
+	service := NewService()
+
 	suggestion := service.Suggest(contextsvc.TaskContextSnapshot{
-		InputType: "text",
-		Text:      "你好",
+		InputType:   "text",
+		Text:        "这个",
+		PageTitle:   "Build Dashboard",
+		WindowTitle: "Browser - Build Dashboard",
+		VisibleText: "release validation failed",
 	}, nil, false)
 
-	if len(suggestion.Intent) != 0 {
-		t.Fatalf("expected ambiguous short text to keep empty intent payload, got %+v", suggestion.Intent)
+	if got := stringValue(suggestion.Intent, "name"); got != defaultAgentLoopIntent {
+		t.Fatalf("expected anchored short text to route through agent loop, got %q", got)
 	}
-	if !suggestion.RequiresConfirm {
-		t.Fatal("expected ambiguous short text to remain in confirmation flow")
+	if suggestion.RequiresConfirm {
+		t.Fatal("expected anchored short text to skip forced confirmation")
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/agentloop"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/audit"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/checkpoint"
 	contextsvc "github.com/cialloclaw/cialloclaw/services/local-service/internal/context"
@@ -487,7 +488,11 @@ func (s *Service) StartTask(params map[string]any) (map[string]any, error) {
 	}
 	response["task"] = taskMap(task)
 	response["bubble_message"] = bubble
-	response["delivery_result"] = deliveryResult
+	if len(deliveryResult) > 0 {
+		response["delivery_result"] = deliveryResult
+	} else {
+		response["delivery_result"] = nil
+	}
 	return response, nil
 }
 
@@ -938,7 +943,7 @@ func (s *Service) ConfirmTask(params map[string]any) (map[string]any, error) {
 	return map[string]any{
 		"task":            taskMap(updatedTask),
 		"bubble_message":  resultBubble,
-		"delivery_result": deliveryResult,
+		"delivery_result": optionalFormalDeliveryResult(deliveryResult),
 	}, nil
 }
 
@@ -6667,6 +6672,13 @@ func cloneMap(values map[string]any) map[string]any {
 	return result
 }
 
+func optionalFormalDeliveryResult(deliveryResult map[string]any) any {
+	if len(deliveryResult) == 0 {
+		return nil
+	}
+	return deliveryResult
+}
+
 // cloneMapSlice recursively copies a []map[string]any payload.
 func cloneMapSlice(values []map[string]any) []map[string]any {
 	if len(values) == 0 {
@@ -6876,6 +6888,13 @@ func (s *Service) executeTask(task runengine.TaskRecord, snapshot contextsvc.Tas
 		failedTask, failureBubble := s.failExecutionTask(processingTask, taskIntent, executionResult, err)
 		return failedTask, failureBubble, nil, nil, nil
 	}
+	if executionResult.LoopStopReason == string(agentloop.StopReasonNeedUserInput) {
+		waitingTask, waitingBubble, ok := s.reopenTaskForUserInput(processingTask, taskIntent, executionResult)
+		if !ok {
+			return runengine.TaskRecord{}, nil, nil, nil, ErrTaskNotFound
+		}
+		return waitingTask, waitingBubble, nil, nil, nil
+	}
 
 	resultBubble := s.delivery.BuildBubbleMessage(
 		processingTask.TaskID,
@@ -6892,6 +6911,20 @@ func (s *Service) executeTask(task runengine.TaskRecord, snapshot contextsvc.Tas
 	updatedTask = s.attachFormalCitations(processingTask, updatedTask, executionResult.ToolCalls, executionResult.ToolOutput, executionResult.DeliveryResult, executionArtifacts)
 	s.attachPostDeliveryHandoffs(updatedTask.TaskID, updatedTask.RunID, snapshot, taskIntent, executionResult.DeliveryResult, executionArtifacts)
 	return updatedTask, resultBubble, executionResult.DeliveryResult, executionArtifacts, nil
+}
+
+// reopenTaskForUserInput keeps the current task open when the agent loop stops
+// because the user's goal is still underspecified. The same task/session stays
+// alive so follow-up input can continue the mainline instead of creating a fake
+// completed delivery record.
+func (s *Service) reopenTaskForUserInput(task runengine.TaskRecord, taskIntent map[string]any, executionResult execution.Result) (runengine.TaskRecord, map[string]any, bool) {
+	clarificationText := firstNonEmptyString(
+		firstNonEmptyString(executionResult.BubbleText, stringValue(executionResult.DeliveryResult, "preview_text", "")),
+		"请补充你的目标。",
+	)
+	bubble := s.delivery.BuildBubbleMessage(task.TaskID, "status", clarificationText, task.UpdatedAt.Format(dateTimeLayout))
+	updatedTask, ok := s.runEngine.ReopenWaitingInput(task.TaskID, task.Title, taskIntent, bubble)
+	return updatedTask, bubble, ok
 }
 
 // attachFormalCitations upgrades execution-side citation seeds into protocol-facing

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -914,7 +914,7 @@ func TestServiceStartTaskAndConfirmFlow(t *testing.T) {
 	}
 }
 
-func TestServiceSubmitInputKeepsUnknownShortTextInIntentConfirmation(t *testing.T) {
+func TestServiceSubmitInputKeepsAmbiguousShortTextInIntentConfirmation(t *testing.T) {
 	service := newTestService()
 
 	result, err := service.SubmitInput(map[string]any{
@@ -932,11 +932,11 @@ func TestServiceSubmitInputKeepsUnknownShortTextInIntentConfirmation(t *testing.
 
 	task := result["task"].(map[string]any)
 	if task["status"] != "confirming_intent" {
-		t.Fatalf("expected unknown short text to remain in confirming_intent, got %v", task["status"])
+		t.Fatalf("expected ambiguous short text to remain in confirming_intent, got %v", task["status"])
 	}
 	intentValue, ok := task["intent"].(map[string]any)
 	if !ok || len(intentValue) != 0 {
-		t.Fatalf("expected unknown short text task to keep empty intent payload, got %+v", task["intent"])
+		t.Fatalf("expected ambiguous short text task to keep empty intent payload, got %+v", task["intent"])
 	}
 	bubble := result["bubble_message"].(map[string]any)
 	if bubble["text"] != "我还不确定你想如何处理这段内容，请确认目标。" {
@@ -947,6 +947,39 @@ func TestServiceSubmitInputKeepsUnknownShortTextInIntentConfirmation(t *testing.
 	}
 	if _, ok := service.runEngine.GetTask(task["task_id"].(string)); !ok {
 		t.Fatal("expected task to remain available in runtime")
+	}
+}
+
+func TestServiceSubmitInputRoutesShortActionTextToAgentLoopWithoutForcedConfirmation(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "Short action request completed.")
+
+	result, err := service.SubmitInput(map[string]any{
+		"session_id": "sess_short_action",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "解释下",
+		},
+	})
+	if err != nil {
+		t.Fatalf("submit input failed: %v", err)
+	}
+
+	task := result["task"].(map[string]any)
+	if task["status"] != "completed" {
+		t.Fatalf("expected short action text to execute directly, got %v", task["status"])
+	}
+	intentValue, ok := task["intent"].(map[string]any)
+	if !ok || intentValue["name"] != "agent_loop" {
+		t.Fatalf("expected short action text to route through agent_loop, got %+v", task["intent"])
+	}
+	deliveryResult, ok := result["delivery_result"].(map[string]any)
+	if !ok {
+		t.Fatal("expected short action text to return delivery_result")
+	}
+	if deliveryResult["type"] != "bubble" {
+		t.Fatalf("expected short action text to prefer bubble delivery, got %v", deliveryResult["type"])
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -47,6 +47,12 @@ type stubModelClient struct {
 	generateText func(request model.GenerateTextRequest) (model.GenerateTextResponse, error)
 }
 
+type stubToolCallingModelClient struct {
+	output                 string
+	toolCalls              []model.ToolCallResult
+	generateToolCallsCount int
+}
+
 type failingExecutionBackend struct {
 	err error
 }
@@ -492,6 +498,32 @@ func (s stubModelClient) GenerateText(_ context.Context, request model.GenerateT
 	}, nil
 }
 
+func (s *stubToolCallingModelClient) GenerateText(_ context.Context, request model.GenerateTextRequest) (model.GenerateTextResponse, error) {
+	return model.GenerateTextResponse{
+		TaskID:     request.TaskID,
+		RunID:      request.RunID,
+		RequestID:  "req_text_unused",
+		Provider:   "openai_responses",
+		ModelID:    "gpt-5.4",
+		OutputText: s.output,
+	}, nil
+}
+
+func (s *stubToolCallingModelClient) GenerateToolCalls(_ context.Context, request model.ToolCallRequest) (model.ToolCallResult, error) {
+	s.generateToolCallsCount++
+	if len(s.toolCalls) == 0 {
+		return model.ToolCallResult{
+			RequestID:  "req_tool_final",
+			Provider:   "openai_responses",
+			ModelID:    "gpt-5.4",
+			OutputText: s.output,
+		}, nil
+	}
+	result := s.toolCalls[0]
+	s.toolCalls = s.toolCalls[1:]
+	return result, nil
+}
+
 func timePointer(value time.Time) *time.Time {
 	return &value
 }
@@ -915,7 +947,7 @@ func TestServiceStartTaskAndConfirmFlow(t *testing.T) {
 }
 
 func TestServiceSubmitInputRoutesShortFreeTextToAgentLoopWithoutForcedConfirmation(t *testing.T) {
-	service, _ := newTestServiceWithExecution(t, "请补充你的目标。")
+	service, _ := newTestServiceWithModelClient(t, &stubToolCallingModelClient{})
 
 	testCases := []string{"解释下", "你好", "这个", "🙂", "a.go", "v1.2", `C:\`, `@me`}
 	for index, testCase := range testCases {
@@ -934,19 +966,19 @@ func TestServiceSubmitInputRoutesShortFreeTextToAgentLoopWithoutForcedConfirmati
 			}
 
 			task := result["task"].(map[string]any)
-			if task["status"] != "completed" {
-				t.Fatalf("expected short free text to execute directly through agent_loop, got %v", task["status"])
+			if task["status"] != "waiting_input" {
+				t.Fatalf("expected short free text clarification to keep task open, got %v", task["status"])
 			}
 			intentValue, ok := task["intent"].(map[string]any)
 			if !ok || intentValue["name"] != "agent_loop" {
 				t.Fatalf("expected short free text to route through agent_loop, got %+v", task["intent"])
 			}
-			deliveryResult, ok := result["delivery_result"].(map[string]any)
-			if !ok {
-				t.Fatal("expected short free text to return delivery_result")
+			if result["delivery_result"] != nil {
+				t.Fatalf("expected short free text clarification not to finalize delivery_result, got %+v", result["delivery_result"])
 			}
-			if deliveryResult["type"] != "bubble" {
-				t.Fatalf("expected short free text to prefer bubble delivery, got %v", deliveryResult["type"])
+			bubble := result["bubble_message"].(map[string]any)
+			if !strings.Contains(stringValue(bubble, "text", ""), "请补充你的目标") {
+				t.Fatalf("expected short free text clarification bubble, got %+v", bubble)
 			}
 		})
 	}
@@ -1562,7 +1594,7 @@ func TestServiceSecurityRespondResumesQueuedScreenAnalyzeTaskThroughApproval(t *
 }
 
 func TestServiceConfirmTaskRunsStoredAgentLoopIntentWithoutCorrection(t *testing.T) {
-	service, _ := newTestServiceWithExecution(t, "请补充你的目标。")
+	service, _ := newTestServiceWithModelClient(t, &stubToolCallingModelClient{})
 
 	startResult, err := service.SubmitInput(map[string]any{
 		"session_id": "sess_unknown_confirm",
@@ -1590,8 +1622,8 @@ func TestServiceConfirmTaskRunsStoredAgentLoopIntentWithoutCorrection(t *testing
 	}
 
 	task := confirmResult["task"].(map[string]any)
-	if task["status"] != "completed" {
-		t.Fatalf("expected confirmed task to execute stored agent_loop intent, got %v", task["status"])
+	if task["status"] != "waiting_input" {
+		t.Fatalf("expected confirmed task to stay open when agent_loop needs more input, got %v", task["status"])
 	}
 	intentValue, ok := task["intent"].(map[string]any)
 	if !ok || intentValue["name"] != "agent_loop" {
@@ -1601,12 +1633,15 @@ func TestServiceConfirmTaskRunsStoredAgentLoopIntentWithoutCorrection(t *testing
 	if !strings.Contains(stringValue(bubble, "text", ""), "请补充你的目标") {
 		t.Fatalf("expected agent_loop clarification bubble, got %v", bubble["text"])
 	}
-	deliveryResult, ok := confirmResult["delivery_result"].(map[string]any)
-	if !ok {
-		t.Fatal("expected confirmed agent_loop task to produce delivery_result")
+	if confirmResult["delivery_result"] != nil {
+		t.Fatalf("expected clarification flow not to finalize delivery_result, got %+v", confirmResult["delivery_result"])
 	}
-	if !strings.Contains(stringValue(deliveryResult, "preview_text", ""), "请补充你的目标") {
-		t.Fatalf("expected delivery_result preview to carry clarification text, got %+v", deliveryResult)
+	record, ok := service.runEngine.GetTask(task["task_id"].(string))
+	if !ok {
+		t.Fatal("expected reopened waiting_input task to remain in runtime")
+	}
+	if record.FinishedAt != nil {
+		t.Fatal("expected reopened waiting_input task to keep finished_at nil")
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -950,36 +950,41 @@ func TestServiceSubmitInputKeepsAmbiguousShortTextInIntentConfirmation(t *testin
 	}
 }
 
-func TestServiceSubmitInputRoutesShortActionTextToAgentLoopWithoutForcedConfirmation(t *testing.T) {
-	service, _ := newTestServiceWithExecution(t, "Short action request completed.")
+func TestServiceSubmitInputRoutesNonAmbiguousShortTextToAgentLoopWithoutForcedConfirmation(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "Short text request completed.")
 
-	result, err := service.SubmitInput(map[string]any{
-		"session_id": "sess_short_action",
-		"source":     "floating_ball",
-		"trigger":    "hover_text_input",
-		"input": map[string]any{
-			"type": "text",
-			"text": "解释下",
-		},
-	})
-	if err != nil {
-		t.Fatalf("submit input failed: %v", err)
-	}
+	testCases := []string{"解释下", "a.go", "v1.2", `C:\`, `@me`}
+	for index, testCase := range testCases {
+		t.Run(testCase, func(t *testing.T) {
+			result, err := service.SubmitInput(map[string]any{
+				"session_id": fmt.Sprintf("sess_short_text_%02d", index),
+				"source":     "floating_ball",
+				"trigger":    "hover_text_input",
+				"input": map[string]any{
+					"type": "text",
+					"text": testCase,
+				},
+			})
+			if err != nil {
+				t.Fatalf("submit input failed: %v", err)
+			}
 
-	task := result["task"].(map[string]any)
-	if task["status"] != "completed" {
-		t.Fatalf("expected short action text to execute directly, got %v", task["status"])
-	}
-	intentValue, ok := task["intent"].(map[string]any)
-	if !ok || intentValue["name"] != "agent_loop" {
-		t.Fatalf("expected short action text to route through agent_loop, got %+v", task["intent"])
-	}
-	deliveryResult, ok := result["delivery_result"].(map[string]any)
-	if !ok {
-		t.Fatal("expected short action text to return delivery_result")
-	}
-	if deliveryResult["type"] != "bubble" {
-		t.Fatalf("expected short action text to prefer bubble delivery, got %v", deliveryResult["type"])
+			task := result["task"].(map[string]any)
+			if task["status"] != "completed" {
+				t.Fatalf("expected non-ambiguous short text to execute directly, got %v", task["status"])
+			}
+			intentValue, ok := task["intent"].(map[string]any)
+			if !ok || intentValue["name"] != "agent_loop" {
+				t.Fatalf("expected non-ambiguous short text to route through agent_loop, got %+v", task["intent"])
+			}
+			deliveryResult, ok := result["delivery_result"].(map[string]any)
+			if !ok {
+				t.Fatal("expected non-ambiguous short text to return delivery_result")
+			}
+			if deliveryResult["type"] != "bubble" {
+				t.Fatalf("expected non-ambiguous short text to prefer bubble delivery, got %v", deliveryResult["type"])
+			}
+		})
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -914,46 +914,10 @@ func TestServiceStartTaskAndConfirmFlow(t *testing.T) {
 	}
 }
 
-func TestServiceSubmitInputKeepsAmbiguousShortTextInIntentConfirmation(t *testing.T) {
-	service := newTestService()
+func TestServiceSubmitInputRoutesShortFreeTextToAgentLoopWithoutForcedConfirmation(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "请补充你的目标。")
 
-	result, err := service.SubmitInput(map[string]any{
-		"session_id": "sess_unknown_text",
-		"source":     "floating_ball",
-		"trigger":    "hover_text_input",
-		"input": map[string]any{
-			"type": "text",
-			"text": "你好",
-		},
-	})
-	if err != nil {
-		t.Fatalf("submit input failed: %v", err)
-	}
-
-	task := result["task"].(map[string]any)
-	if task["status"] != "confirming_intent" {
-		t.Fatalf("expected ambiguous short text to remain in confirming_intent, got %v", task["status"])
-	}
-	intentValue, ok := task["intent"].(map[string]any)
-	if !ok || len(intentValue) != 0 {
-		t.Fatalf("expected ambiguous short text task to keep empty intent payload, got %+v", task["intent"])
-	}
-	bubble := result["bubble_message"].(map[string]any)
-	if bubble["text"] != "我还不确定你想如何处理这段内容，请确认目标。" {
-		t.Fatalf("expected neutral confirmation prompt, got %v", bubble["text"])
-	}
-	if result["delivery_result"] != nil {
-		t.Fatalf("expected no delivery result before intent is confirmed, got %+v", result["delivery_result"])
-	}
-	if _, ok := service.runEngine.GetTask(task["task_id"].(string)); !ok {
-		t.Fatal("expected task to remain available in runtime")
-	}
-}
-
-func TestServiceSubmitInputRoutesNonAmbiguousShortTextToAgentLoopWithoutForcedConfirmation(t *testing.T) {
-	service, _ := newTestServiceWithExecution(t, "Short text request completed.")
-
-	testCases := []string{"解释下", "a.go", "v1.2", `C:\`, `@me`}
+	testCases := []string{"解释下", "你好", "这个", "🙂", "a.go", "v1.2", `C:\`, `@me`}
 	for index, testCase := range testCases {
 		t.Run(testCase, func(t *testing.T) {
 			result, err := service.SubmitInput(map[string]any{
@@ -971,20 +935,52 @@ func TestServiceSubmitInputRoutesNonAmbiguousShortTextToAgentLoopWithoutForcedCo
 
 			task := result["task"].(map[string]any)
 			if task["status"] != "completed" {
-				t.Fatalf("expected non-ambiguous short text to execute directly, got %v", task["status"])
+				t.Fatalf("expected short free text to execute directly through agent_loop, got %v", task["status"])
 			}
 			intentValue, ok := task["intent"].(map[string]any)
 			if !ok || intentValue["name"] != "agent_loop" {
-				t.Fatalf("expected non-ambiguous short text to route through agent_loop, got %+v", task["intent"])
+				t.Fatalf("expected short free text to route through agent_loop, got %+v", task["intent"])
 			}
 			deliveryResult, ok := result["delivery_result"].(map[string]any)
 			if !ok {
-				t.Fatal("expected non-ambiguous short text to return delivery_result")
+				t.Fatal("expected short free text to return delivery_result")
 			}
 			if deliveryResult["type"] != "bubble" {
-				t.Fatalf("expected non-ambiguous short text to prefer bubble delivery, got %v", deliveryResult["type"])
+				t.Fatalf("expected short free text to prefer bubble delivery, got %v", deliveryResult["type"])
 			}
 		})
+	}
+}
+
+func TestServiceSubmitInputRespectsExplicitConfirmationForFreeText(t *testing.T) {
+	service := newTestService()
+
+	result, err := service.SubmitInput(map[string]any{
+		"session_id": "sess_confirm_free_text",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "你好",
+		},
+		"options": map[string]any{
+			"confirm_required": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("submit input failed: %v", err)
+	}
+
+	task := result["task"].(map[string]any)
+	if task["status"] != "confirming_intent" {
+		t.Fatalf("expected explicit confirm_required to preserve confirming_intent, got %v", task["status"])
+	}
+	intentValue, ok := task["intent"].(map[string]any)
+	if !ok || intentValue["name"] != "agent_loop" {
+		t.Fatalf("expected explicit confirm_required to keep agent_loop intent, got %+v", task["intent"])
+	}
+	if result["delivery_result"] != nil {
+		t.Fatalf("expected explicit confirmation flow to defer delivery_result, got %+v", result["delivery_result"])
 	}
 }
 
@@ -1209,6 +1205,9 @@ func TestServiceConfirmTaskQueuesCorrectedTaskBehindSameSessionWork(t *testing.T
 		"input": map[string]any{
 			"type": "text",
 			"text": "ok",
+		},
+		"options": map[string]any{
+			"confirm_required": true,
 		},
 	})
 	if err != nil {
@@ -1562,8 +1561,8 @@ func TestServiceSecurityRespondResumesQueuedScreenAnalyzeTaskThroughApproval(t *
 	}
 }
 
-func TestServiceConfirmTaskRejectsUnknownIntentWithoutCorrection(t *testing.T) {
-	service := newTestService()
+func TestServiceConfirmTaskRunsStoredAgentLoopIntentWithoutCorrection(t *testing.T) {
+	service, _ := newTestServiceWithExecution(t, "请补充你的目标。")
 
 	startResult, err := service.SubmitInput(map[string]any{
 		"session_id": "sess_unknown_confirm",
@@ -1572,6 +1571,9 @@ func TestServiceConfirmTaskRejectsUnknownIntentWithoutCorrection(t *testing.T) {
 		"input": map[string]any{
 			"type": "text",
 			"text": "你好",
+		},
+		"options": map[string]any{
+			"confirm_required": true,
 		},
 	})
 	if err != nil {
@@ -1588,15 +1590,23 @@ func TestServiceConfirmTaskRejectsUnknownIntentWithoutCorrection(t *testing.T) {
 	}
 
 	task := confirmResult["task"].(map[string]any)
-	if task["status"] != "confirming_intent" {
-		t.Fatalf("expected task to remain in confirming_intent when no corrected intent is provided, got %v", task["status"])
+	if task["status"] != "completed" {
+		t.Fatalf("expected confirmed task to execute stored agent_loop intent, got %v", task["status"])
+	}
+	intentValue, ok := task["intent"].(map[string]any)
+	if !ok || intentValue["name"] != "agent_loop" {
+		t.Fatalf("expected confirmed task to keep agent_loop intent, got %+v", task["intent"])
 	}
 	bubble := confirmResult["bubble_message"].(map[string]any)
-	if bubble["text"] != "请先明确告诉我你希望执行的处理方式。" {
-		t.Fatalf("expected clarification bubble, got %v", bubble["text"])
+	if !strings.Contains(stringValue(bubble, "text", ""), "请补充你的目标") {
+		t.Fatalf("expected agent_loop clarification bubble, got %v", bubble["text"])
 	}
-	if confirmResult["delivery_result"] != nil {
-		t.Fatalf("expected no delivery result while intent is still missing, got %+v", confirmResult["delivery_result"])
+	deliveryResult, ok := confirmResult["delivery_result"].(map[string]any)
+	if !ok {
+		t.Fatal("expected confirmed agent_loop task to produce delivery_result")
+	}
+	if !strings.Contains(stringValue(deliveryResult, "preview_text", ""), "请补充你的目标") {
+		t.Fatalf("expected delivery_result preview to carry clarification text, got %+v", deliveryResult)
 	}
 }
 
@@ -1610,6 +1620,9 @@ func TestServiceConfirmTaskKeepsUnknownIntentInConfirmationWhenRejected(t *testi
 		"input": map[string]any{
 			"type": "text",
 			"text": "你好",
+		},
+		"options": map[string]any{
+			"confirm_required": true,
 		},
 	})
 	if err != nil {
@@ -1654,6 +1667,9 @@ func TestServiceConfirmTaskRewritesPlaceholderTitleAfterCorrection(t *testing.T)
 		"input": map[string]any{
 			"type": "text",
 			"text": "你好",
+		},
+		"options": map[string]any{
+			"confirm_required": true,
 		},
 	})
 	if err != nil {

--- a/services/local-service/internal/runengine/engine.go
+++ b/services/local-service/internal/runengine/engine.go
@@ -594,6 +594,49 @@ func (e *Engine) ReopenIntentConfirmation(taskID, title string, intent map[strin
 	return record.clone(), true
 }
 
+// ReopenWaitingInput keeps a task open when execution determined that more user
+// input is required. The reset clears completed delivery state so follow-up
+// submissions continue the same task instead of creating a fake finished result.
+func (e *Engine) ReopenWaitingInput(taskID, title string, intent map[string]any, bubbleMessage map[string]any) (TaskRecord, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	record, ok := e.tasks[taskID]
+	if !ok {
+		return TaskRecord{}, false
+	}
+
+	record.Title = firstNonEmpty(title, record.Title)
+	record.Intent = cloneMap(intent)
+	record.Status = "waiting_input"
+	record.CurrentStep = "collect_input"
+	record.UpdatedAt = e.now()
+	record.FinishedAt = nil
+	record.DeliveryResult = nil
+	record.Artifacts = nil
+	record.BubbleMessage = cloneMap(bubbleMessage)
+	record.PendingExecution = nil
+	record.ApprovalRequest = nil
+	record.Authorization = nil
+	record.ImpactScope = nil
+	record.StorageWritePlan = nil
+	record.ArtifactPlans = nil
+	record.MemoryReadPlans = nil
+	record.MemoryWritePlans = nil
+	record.MirrorReferences = nil
+	record.SecuritySummary = mergePreservedSecuritySummary(
+		buildSecuritySummary(record.RiskLevel, latestRestorePointFromSummary(record.SecuritySummary)),
+		record.SecuritySummary,
+	)
+	record.Timeline = advanceTimeline(record.Timeline, "collect_input", "pending", "等待用户补充输入")
+	record.CurrentStepStatus = currentTimelineStatus(record.Timeline)
+	record.LatestEvent = e.buildEvent(record, "task.updated")
+	record.queueNotification("task.updated", taskUpdatedNotificationParams(record))
+	e.persistTaskLocked(record)
+
+	return record.clone(), true
+}
+
 // SetPresentation updates task-facing presentation fields without changing the
 // state-machine conclusion.
 func (e *Engine) SetPresentation(taskID string, bubbleMessage map[string]any, deliveryResult map[string]any, artifacts []map[string]any) (TaskRecord, bool) {


### PR DESCRIPTION
## Summary
- narrow short-text confirmation gating in the intent service
- route actionable short text requests into `agent_loop`
- keep ambiguous short text inputs in `confirming_intent`
- add intent and orchestrator regression coverage

## Testing
- go test ./services/local-service/internal/intent ./services/local-service/internal/orchestrator
