### PR TITLE
fix(onboarding): enhance hit-testing and reset functionality for onboarding overlay

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1108,10 +1108,13 @@ unsafe fn update_onboarding_native_tracking() {
     set_forward_mouse_messages(hwnd, should_track);
 
     if !should_track {
-        set_window_ignore_cursor_events(hwnd, false);
+        // Keep the onboarding window click-through until a concrete native
+        // interactive region is registered so replayed or still-initializing
+        // guide windows never trap pointer input on Windows.
+        set_window_ignore_cursor_events(hwnd, true);
         if let Ok(mut state) = ONBOARDING_INTERACTIVE_STATE.lock() {
             if state.hwnd == Some(hwnd_value) {
-                state.current_ignore = Some(false);
+                state.current_ignore = Some(true);
             }
         }
     }
@@ -1127,11 +1130,17 @@ unsafe extern "system" fn mousemove_forward(
         return CallNextHookEx(None, n_code, w_param, l_param);
     }
 
-    if w_param.0 as u32 == WM_MOUSEMOVE {
+    let message = w_param.0 as u32;
+
+    if matches!(message, WM_MOUSEMOVE | WM_LBUTTONDOWN | WM_LBUTTONUP) {
         let point = (*(l_param.0 as *const MSLLHOOKSTRUCT)).pt;
 
         sync_shell_ball_native_hit_testing(point);
         sync_onboarding_native_hit_testing(point);
+
+        if message != WM_MOUSEMOVE {
+            return CallNextHookEx(None, n_code, w_param, l_param);
+        }
 
         let forwarding_windows = match FORWARDING_WINDOWS.lock() {
             Ok(guard) => guard,
@@ -1207,6 +1216,38 @@ fn onboarding_set_interactive_regions(
     _window: tauri::Window,
     _regions: Vec<ShellBallInteractiveRect>,
 ) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(windows)]
+#[tauri::command]
+fn onboarding_reset_native_tracking() -> Result<(), String> {
+    let snapshot = ONBOARDING_INTERACTIVE_STATE
+        .lock()
+        .map_err(|_| "onboarding interactive state lock poisoned".to_string())?
+        .clone();
+
+    if let Some(hwnd_value) = snapshot.hwnd {
+        unsafe {
+            let hwnd = HWND(hwnd_value as _);
+            set_forward_mouse_messages(hwnd, false);
+            set_window_ignore_cursor_events(hwnd, true);
+        }
+    }
+
+    let mut state = ONBOARDING_INTERACTIVE_STATE
+        .lock()
+        .map_err(|_| "onboarding interactive state lock poisoned".to_string())?;
+    state.hwnd = None;
+    state.regions.clear();
+    state.current_ignore = None;
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+#[tauri::command]
+fn onboarding_reset_native_tracking() -> Result<(), String> {
     Ok(())
 }
 
@@ -1403,6 +1444,7 @@ fn main() {
             shell_ball_get_mouse_position,
             shell_ball_set_interactive_regions,
             onboarding_set_interactive_regions,
+            onboarding_reset_native_tracking,
             shell_ball_set_press_lock,
             desktop_get_mouse_activity_snapshot,
             desktop_capture_screenshot,

--- a/apps/desktop/src/features/control-panel/ControlPanelApp.tsx
+++ b/apps/desktop/src/features/control-panel/ControlPanelApp.tsx
@@ -758,9 +758,13 @@ export function ControlPanelApp() {
 
   const handleReplayOnboarding = () => {
     void (async () => {
-      await showShellBallWindow("ball");
-      await startDesktopOnboarding("manual", "control-panel");
-      await requestCurrentDesktopWindowClose();
+      try {
+        await showShellBallWindow("ball");
+        await startDesktopOnboarding("manual", "control-panel");
+        await requestCurrentDesktopWindowClose();
+      } catch (error) {
+        console.warn("control-panel onboarding replay failed", error);
+      }
     })();
   };
 

--- a/apps/desktop/src/features/onboarding/OnboardingWindow.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWindow.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Button, Heading, Text } from "@radix-ui/themes";
-import { cn } from "@/utils/cn";
-import { setOnboardingInteractiveRegions } from "@/platform/onboardingWindow";
 import {
   advanceDesktopOnboarding,
   completeDesktopOnboarding,
@@ -10,6 +8,8 @@ import {
   skipDesktopOnboarding,
   requestDesktopOnboardingAction,
 } from "./onboardingService";
+import { setOnboardingInteractiveRegions } from "@/platform/onboardingWindow";
+import { cn } from "@/utils/cn";
 import { useDesktopOnboardingPresentation } from "./useDesktopOnboardingPresentation";
 import { useDesktopOnboardingSession } from "./useDesktopOnboardingSession";
 import "./onboarding.css";

--- a/apps/desktop/src/features/onboarding/onboardingService.ts
+++ b/apps/desktop/src/features/onboarding/onboardingService.ts
@@ -270,9 +270,11 @@ export async function startDesktopOnboarding(
     preferredWindowLabel ??
     (currentWindowLabel === "dashboard" || currentWindowLabel === "control-panel" ? currentWindowLabel : "shell-ball");
   const welcomePresentation = await buildDefaultWelcomePresentation(windowLabel);
+
   if (welcomePresentation !== null) {
     await setDesktopOnboardingPresentation(welcomePresentation);
   }
+
   return session;
 }
 

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -6833,6 +6833,36 @@ test("desktop tauri setup enables mouse activity tracking for dwell context", ()
   assert.doesNotMatch(activitySource, /println!\("mouse activity at /);
 });
 
+test("desktop tauri mouse hook syncs hit-testing on move and click", () => {
+  const mainSource = readFileSync(resolve(desktopRoot, "src-tauri/src/main.rs"), "utf8");
+
+  assert.match(mainSource, /matches!\(message, WM_MOUSEMOVE \| WM_LBUTTONDOWN \| WM_LBUTTONUP\)/);
+  assert.match(mainSource, /sync_shell_ball_native_hit_testing\(point\);/);
+  assert.match(mainSource, /sync_onboarding_native_hit_testing\(point\);/);
+});
+
+test("onboarding controller keeps a destroy-on-close overlay window", () => {
+  const controllerSource = readFileSync(resolve(desktopRoot, "src/platform/onboardingWindowController.ts"), "utf8");
+  const onboardingServiceSource = readFileSync(resolve(desktopRoot, "src/features/onboarding/onboardingService.ts"), "utf8");
+  const onboardingWindowSource = readFileSync(resolve(desktopRoot, "src/features/onboarding/OnboardingWindow.tsx"), "utf8");
+  const onboardingPlatformSource = readFileSync(resolve(desktopRoot, "src/platform/onboardingWindow.ts"), "utf8");
+  const onboardingEventsSource = readFileSync(resolve(desktopRoot, "src/features/onboarding/onboarding.events.ts"), "utf8");
+
+  assert.match(controllerSource, /await onboardingWindow\.setIgnoreCursorEvents\(true\);/);
+  assert.match(controllerSource, /onboardingWindow\.once\("tauri:\/\/created"/);
+  assert.match(controllerSource, /onboardingWindow\.once\("tauri:\/\/error"/);
+  assert.match(controllerSource, /setSize\(new LogicalSize\(frame\.width, frame\.height\)\)/);
+  assert.match(controllerSource, /await resetOnboardingNativeTracking\(\);/);
+  assert.match(controllerSource, /await onboardingWindow\.destroy\(\);/);
+  assert.doesNotMatch(controllerSource, /resolveOnboardingCardWindowFrame/);
+  assert.match(onboardingServiceSource, /await syncOnboardingWindowFrame\(presentation\.monitorFrame, \{/);
+  assert.doesNotMatch(onboardingServiceSource, /windowReady/);
+  assert.match(onboardingWindowSource, /setOnboardingInteractiveRegions\(/);
+  assert.match(onboardingWindowSource, /desktop-onboarding-window__card--\$\{activePresentation\.placement\}/);
+  assert.match(onboardingPlatformSource, /export async function resetOnboardingNativeTracking\(\)/);
+  assert.doesNotMatch(onboardingEventsSource, /windowReady/);
+});
+
 test("shell-ball file drops queue pending attachments instead of starting a task immediately", () => {
   const coordinatorSource = readFileSync(resolve(desktopRoot, "src/features/shell-ball/useShellBallCoordinator.ts"), "utf8");
   const interactionSource = readFileSync(resolve(desktopRoot, "src/features/shell-ball/useShellBallInteraction.ts"), "utf8");

--- a/apps/desktop/src/platform/onboardingWindow.ts
+++ b/apps/desktop/src/platform/onboardingWindow.ts
@@ -19,3 +19,11 @@ export async function setOnboardingInteractiveRegions(regions: OnboardingInterac
     regions,
   });
 }
+
+/**
+ * Clears native onboarding hit-testing state before the dedicated overlay
+ * window is destroyed so replay sessions always boot from a clean cursor map.
+ */
+export async function resetOnboardingNativeTracking() {
+  await invoke("onboarding_reset_native_tracking");
+}

--- a/apps/desktop/src/platform/onboardingWindowController.ts
+++ b/apps/desktop/src/platform/onboardingWindowController.ts
@@ -1,4 +1,5 @@
 import { LogicalPosition, LogicalSize, Window } from "@tauri-apps/api/window";
+import { resetOnboardingNativeTracking } from "./onboardingWindow";
 
 export const ONBOARDING_WINDOW_LABEL = "onboarding";
 
@@ -35,7 +36,31 @@ async function getOrCreateOnboardingWindow() {
     height: 720,
   } as const;
 
-  return new Window(ONBOARDING_WINDOW_LABEL, onboardingWindowOptions);
+  const onboardingWindow = new Window(ONBOARDING_WINDOW_LABEL, onboardingWindowOptions);
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+
+    const settle = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      callback();
+    };
+
+    onboardingWindow.once("tauri://created", () => {
+      settle(resolve);
+    });
+
+    onboardingWindow.once("tauri://error", (event) => {
+      const payload = typeof event.payload === "string" ? event.payload : "failed to create onboarding window";
+      settle(() => reject(new Error(payload)));
+    });
+  });
+
+  return onboardingWindow;
 }
 
 /**
@@ -50,6 +75,10 @@ export async function syncOnboardingWindowFrame(
   options: SyncOnboardingWindowFrameOptions = {},
 ) {
   const onboardingWindow = await getOrCreateOnboardingWindow();
+  // The fullscreen onboarding host must start in native click-through mode so a
+  // freshly created replay window never blocks the monitor before React reports
+  // the card hotspot rectangles.
+  await onboardingWindow.setIgnoreCursorEvents(true);
   await onboardingWindow.setPosition(new LogicalPosition(frame.x, frame.y));
   await onboardingWindow.setSize(new LogicalSize(frame.width, frame.height));
   await onboardingWindow.setFocusable(true);
@@ -67,5 +96,8 @@ export async function hideOnboardingWindow() {
     return;
   }
 
+  // Clear the native forwarding hook and stale hotspot cache before destroying
+  // the overlay window so later replay sessions recreate a clean host state.
+  await resetOnboardingNativeTracking();
   await onboardingWindow.destroy();
 }


### PR DESCRIPTION
修新手引导，卡在第四步了，打开仪表盘之后onboarding就点不了。不打算合，想让bot看看能不能发现出问题。