### PR TITLE
fix(onboarding): keep desktop guide interactive across windows

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1108,10 +1108,13 @@ unsafe fn update_onboarding_native_tracking() {
     set_forward_mouse_messages(hwnd, should_track);
 
     if !should_track {
-        set_window_ignore_cursor_events(hwnd, false);
+        // The transparent onboarding host must stay click-through until React
+        // registers a real interactive card region. Otherwise a replayed guide
+        // can block the whole monitor before the overlay finishes mounting.
+        set_window_ignore_cursor_events(hwnd, true);
         if let Ok(mut state) = ONBOARDING_INTERACTIVE_STATE.lock() {
             if state.hwnd == Some(hwnd_value) {
-                state.current_ignore = Some(false);
+                state.current_ignore = Some(true);
             }
         }
     }
@@ -1127,39 +1130,55 @@ unsafe extern "system" fn mousemove_forward(
         return CallNextHookEx(None, n_code, w_param, l_param);
     }
 
-    if w_param.0 as u32 == WM_MOUSEMOVE {
+    let message = w_param.0 as u32;
+    let should_sync_hit_testing = matches!(
+        message,
+        WM_MOUSEMOVE
+            | WM_LBUTTONDOWN
+            | WM_LBUTTONUP
+            | WM_RBUTTONDOWN
+            | WM_RBUTTONUP
+            | WM_MBUTTONDOWN
+            | WM_MBUTTONUP
+            | WM_MOUSEWHEEL
+            | WM_MOUSEHWHEEL
+    );
+
+    if should_sync_hit_testing {
         let point = (*(l_param.0 as *const MSLLHOOKSTRUCT)).pt;
 
         sync_shell_ball_native_hit_testing(point);
         sync_onboarding_native_hit_testing(point);
 
-        let forwarding_windows = match FORWARDING_WINDOWS.lock() {
-            Ok(guard) => guard,
-            Err(_) => return CallNextHookEx(None, n_code, w_param, l_param),
-        };
-
-        for &hwnd in forwarding_windows.iter() {
-            let hwnd = HWND(hwnd as _);
-            let mut client_rect = RECT {
-                left: 0,
-                top: 0,
-                right: 0,
-                bottom: 0,
+        if message == WM_MOUSEMOVE {
+            let forwarding_windows = match FORWARDING_WINDOWS.lock() {
+                Ok(guard) => guard,
+                Err(_) => return CallNextHookEx(None, n_code, w_param, l_param),
             };
 
-            if GetClientRect(hwnd, &mut client_rect).is_err() {
-                continue;
-            }
+            for &hwnd in forwarding_windows.iter() {
+                let hwnd = HWND(hwnd as _);
+                let mut client_rect = RECT {
+                    left: 0,
+                    top: 0,
+                    right: 0,
+                    bottom: 0,
+                };
 
-            let mut client_point = point;
-            if !ScreenToClient(hwnd, &mut client_point).as_bool() {
-                continue;
-            }
+                if GetClientRect(hwnd, &mut client_rect).is_err() {
+                    continue;
+                }
 
-            if PtInRect(&client_rect, client_point).as_bool() {
-                let w = Some(WPARAM(1));
-                let l = Some(LPARAM(makelparam!(client_point.x, client_point.y)));
-                SendMessageW(hwnd, WM_MOUSEMOVE, w, l);
+                let mut client_point = point;
+                if !ScreenToClient(hwnd, &mut client_point).as_bool() {
+                    continue;
+                }
+
+                if PtInRect(&client_rect, client_point).as_bool() {
+                    let w = Some(WPARAM(1));
+                    let l = Some(LPARAM(makelparam!(client_point.x, client_point.y)));
+                    SendMessageW(hwnd, WM_MOUSEMOVE, w, l);
+                }
             }
         }
     }

--- a/apps/desktop/src/features/onboarding/OnboardingWindow.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWindow.tsx
@@ -98,6 +98,7 @@ export function OnboardingWindow() {
   const presentation = useDesktopOnboardingPresentation();
   const [stagedPresentation, setStagedPresentation] = useState<DesktopOnboardingPresentation | null>(null);
   const copy = useMemo(() => (session ? getOnboardingCopy(session.step) : null), [session]);
+  const hasSettledPresentation = session !== null && presentation?.step === session.step;
 
   useEffect(() => {
     if (presentation !== null) {
@@ -136,7 +137,10 @@ export function OnboardingWindow() {
   }, [presentation, session, stagedPresentation]);
 
   useLayoutEffect(() => {
-    if (!cardRef.current || !session || !activePresentation) {
+    if (!cardRef.current || !session || !activePresentation || !hasSettledPresentation) {
+      // Cross-window steps can briefly reuse stale staged geometry while the next
+      // business window is still opening. Keep the overlay fully click-through
+      // until the current step has published a fresh presentation payload.
       void setOnboardingInteractiveRegions([]);
       return;
     }
@@ -162,7 +166,7 @@ export function OnboardingWindow() {
     return () => {
       void setOnboardingInteractiveRegions([]);
     };
-  }, [activePresentation, session]);
+  }, [activePresentation, hasSettledPresentation, session]);
 
   if (!session || !copy || !activePresentation) {
     return <main className="desktop-onboarding-window" />;

--- a/apps/desktop/src/features/onboarding/onboardingService.ts
+++ b/apps/desktop/src/features/onboarding/onboardingService.ts
@@ -220,6 +220,19 @@ export function shouldAutoStartDesktopOnboarding() {
   return !status.completed && !status.skipped;
 }
 
+/**
+ * Clears the transient onboarding session/presentation cache without touching
+ * the durable completed/skipped status. This is used on a cold desktop boot so
+ * the app never resumes an old mid-guide step from a previous process.
+ */
+export async function resetDesktopOnboardingRuntimeState() {
+  removeStoredValue(DESKTOP_ONBOARDING_SESSION_KEY);
+  removeStoredValue(DESKTOP_ONBOARDING_PRESENTATION_KEY);
+  await hideOnboardingWindow();
+  await broadcastSession(null);
+  await broadcastPresentation(null);
+}
+
 export async function setDesktopOnboardingSession(session: DesktopOnboardingSession | null) {
   if (session === null) {
     removeStoredValue(DESKTOP_ONBOARDING_SESSION_KEY);

--- a/apps/desktop/src/features/onboarding/onboardingService.ts
+++ b/apps/desktop/src/features/onboarding/onboardingService.ts
@@ -26,6 +26,7 @@ export type DesktopOnboardingStatus = {
 
 export type DesktopOnboardingSession = {
   isOpen: boolean;
+  runtime_boot_id?: string;
   source: DesktopOnboardingSource;
   step: DesktopOnboardingStep;
   started_at: string;
@@ -56,6 +57,7 @@ export type DesktopOnboardingActionRequest = {
 const DESKTOP_ONBOARDING_STATUS_KEY = "cialloclaw.desktop.onboarding.status";
 const DESKTOP_ONBOARDING_SESSION_KEY = "cialloclaw.desktop.onboarding.session";
 const DESKTOP_ONBOARDING_PRESENTATION_KEY = "cialloclaw.desktop.onboarding.presentation";
+const DESKTOP_ONBOARDING_RUNTIME_BOOT_ID_KEY = "cialloclaw.desktop.onboarding.runtime_boot_id";
 
 const DESKTOP_ONBOARDING_WINDOW_LABELS = [
   shellBallWindowLabels.ball,
@@ -215,6 +217,22 @@ export function loadDesktopOnboardingPresentation() {
   return loadStoredValue<DesktopOnboardingPresentation>(DESKTOP_ONBOARDING_PRESENTATION_KEY);
 }
 
+export function loadDesktopOnboardingRuntimeBootId() {
+  return loadStoredValue<string>(DESKTOP_ONBOARDING_RUNTIME_BOOT_ID_KEY);
+}
+
+/**
+ * Rotates the shared desktop-process runtime marker so persisted onboarding
+ * sessions can be recognized as stale after a cold restart.
+ *
+ * @returns The runtime marker for the current desktop process.
+ */
+export function refreshDesktopOnboardingRuntimeBootId() {
+  const runtimeBootId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  saveStoredValue(DESKTOP_ONBOARDING_RUNTIME_BOOT_ID_KEY, runtimeBootId);
+  return runtimeBootId;
+}
+
 export function shouldAutoStartDesktopOnboarding() {
   const status = loadDesktopOnboardingStatus();
   return !status.completed && !status.skipped;
@@ -264,6 +282,7 @@ export async function startDesktopOnboarding(
 ) {
   const now = new Date().toISOString();
   const status = loadDesktopOnboardingStatus();
+  const runtimeBootId = loadDesktopOnboardingRuntimeBootId() ?? refreshDesktopOnboardingRuntimeBootId();
 
   saveDesktopOnboardingStatus({
     ...status,
@@ -272,6 +291,7 @@ export async function startDesktopOnboarding(
 
   const session: DesktopOnboardingSession = {
     isOpen: true,
+    runtime_boot_id: runtimeBootId,
     source,
     step: "welcome",
     started_at: now,

--- a/apps/desktop/src/features/shell-ball/ShellBallApp.tsx
+++ b/apps/desktop/src/features/shell-ball/ShellBallApp.tsx
@@ -42,6 +42,8 @@ import { openOrFocusDesktopWindow } from "../../platform/windowController";
 import { buildDesktopOnboardingPresentation } from "@/features/onboarding/onboardingGeometry";
 import {
   advanceDesktopOnboarding,
+  loadDesktopOnboardingSession,
+  resetDesktopOnboardingRuntimeState,
   setDesktopOnboardingPresentation,
   shouldAutoStartDesktopOnboarding,
   startDesktopOnboarding,
@@ -231,6 +233,7 @@ async function animateShellBallDashboardWindow(input: {
 export function ShellBallApp({ isDev = false }: ShellBallAppProps) {
   void isDev;
   const onboardingSession = useDesktopOnboardingSession();
+  const [onboardingRuntimeReady, setOnboardingRuntimeReady] = useState(() => getCurrentWindow().label !== shellBallWindowLabels.ball);
   const {
     visualState,
     inputValue,
@@ -455,6 +458,39 @@ export function ShellBallApp({ isDev = false }: ShellBallAppProps) {
       return;
     }
 
+    let cancelled = false;
+
+    const storedSession = loadDesktopOnboardingSession();
+
+    // Cold starts should not resume a stale cross-window onboarding step from a
+    // previous desktop process, but manual replays still need the fresh welcome
+    // session to survive when shell-ball is created on demand.
+    const initializeOnboardingRuntime = async () => {
+      if (storedSession?.isOpen === true && storedSession.step !== "welcome") {
+        await resetDesktopOnboardingRuntimeState();
+      }
+
+      if (!cancelled) {
+        setOnboardingRuntimeReady(true);
+      }
+    };
+
+    void initializeOnboardingRuntime();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (getCurrentWindow().label !== shellBallWindowLabels.ball) {
+      return;
+    }
+
+    if (!onboardingRuntimeReady) {
+      return;
+    }
+
     if (!shouldAutoStartDesktopOnboarding()) {
       return;
     }
@@ -464,7 +500,7 @@ export function ShellBallApp({ isDev = false }: ShellBallAppProps) {
     }
 
     void startDesktopOnboarding("first_launch");
-  }, [onboardingSession]);
+  }, [onboardingRuntimeReady, onboardingSession]);
 
   useDesktopOnboardingActions(
     "shell-ball",

--- a/apps/desktop/src/features/shell-ball/ShellBallApp.tsx
+++ b/apps/desktop/src/features/shell-ball/ShellBallApp.tsx
@@ -43,6 +43,7 @@ import { buildDesktopOnboardingPresentation } from "@/features/onboarding/onboar
 import {
   advanceDesktopOnboarding,
   loadDesktopOnboardingSession,
+  refreshDesktopOnboardingRuntimeBootId,
   resetDesktopOnboardingRuntimeState,
   setDesktopOnboardingPresentation,
   shouldAutoStartDesktopOnboarding,
@@ -460,13 +461,14 @@ export function ShellBallApp({ isDev = false }: ShellBallAppProps) {
 
     let cancelled = false;
 
+    const runtimeBootId = refreshDesktopOnboardingRuntimeBootId();
     const storedSession = loadDesktopOnboardingSession();
 
-    // Cold starts should not resume a stale cross-window onboarding step from a
-    // previous desktop process, but manual replays still need the fresh welcome
-    // session to survive when shell-ball is created on demand.
+    // Cold starts must drop any persisted onboarding session that was created by
+    // an older desktop process. Manual replays in the current process inherit
+    // the fresh runtime marker and remain eligible across window opens.
     const initializeOnboardingRuntime = async () => {
-      if (storedSession?.isOpen === true && storedSession.step !== "welcome") {
+      if (storedSession?.isOpen === true && storedSession.runtime_boot_id !== runtimeBootId) {
         await resetDesktopOnboardingRuntimeState();
       }
 

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -6833,6 +6833,32 @@ test("desktop tauri setup enables mouse activity tracking for dwell context", ()
   assert.doesNotMatch(activitySource, /println!\("mouse activity at /);
 });
 
+test("desktop onboarding replay keeps the transparent host click-through until card regions load", () => {
+  const mainSource = readFileSync(resolve(desktopRoot, "src-tauri/src/main.rs"), "utf8");
+  const controllerSource = readFileSync(resolve(desktopRoot, "src/platform/onboardingWindowController.ts"), "utf8");
+  const onboardingWindowSource = readFileSync(resolve(desktopRoot, "src/features/onboarding/OnboardingWindow.tsx"), "utf8");
+  const onboardingServiceSource = readFileSync(resolve(desktopRoot, "src/features/onboarding/onboardingService.ts"), "utf8");
+  const shellBallAppSource = readFileSync(resolve(desktopRoot, "src/features/shell-ball/ShellBallApp.tsx"), "utf8");
+
+  assert.match(controllerSource, /setIgnoreCursorEvents\(true\);[\s\S]*setFocusable\(true\);[\s\S]*show\(\);/);
+  assert.match(
+    mainSource,
+    /if !should_track \{[\s\S]*set_window_ignore_cursor_events\(hwnd, true\);[\s\S]*state\.current_ignore = Some\(true\);/,
+  );
+  assert.match(mainSource, /let should_sync_hit_testing = matches!\([\s\S]*WM_LBUTTONDOWN[\s\S]*WM_RBUTTONDOWN[\s\S]*WM_MOUSEWHEEL/);
+  assert.match(onboardingWindowSource, /const hasSettledPresentation = session !== null && presentation\?\.step === session\.step;/);
+  assert.match(onboardingWindowSource, /!cardRef\.current \|\| !session \|\| !activePresentation \|\| !hasSettledPresentation/);
+  assert.match(onboardingWindowSource, /void setOnboardingInteractiveRegions\(\[\]\);/);
+  assert.match(onboardingServiceSource, /export async function resetDesktopOnboardingRuntimeState\(\) \{/);
+  assert.match(onboardingServiceSource, /removeStoredValue\(DESKTOP_ONBOARDING_SESSION_KEY\);/);
+  assert.match(onboardingServiceSource, /removeStoredValue\(DESKTOP_ONBOARDING_PRESENTATION_KEY\);/);
+  assert.match(shellBallAppSource, /const storedSession = loadDesktopOnboardingSession\(\);/);
+  assert.match(shellBallAppSource, /if \(storedSession\?\.isOpen === true && storedSession\.step !== "welcome"\) \{/);
+  assert.match(shellBallAppSource, /resetDesktopOnboardingRuntimeState/);
+  assert.match(shellBallAppSource, /const \[onboardingRuntimeReady, setOnboardingRuntimeReady\] = useState/);
+  assert.match(shellBallAppSource, /if \(!onboardingRuntimeReady\) \{/);
+});
+
 test("shell-ball file drops queue pending attachments instead of starting a task immediately", () => {
   const coordinatorSource = readFileSync(resolve(desktopRoot, "src/features/shell-ball/useShellBallCoordinator.ts"), "utf8");
   const interactionSource = readFileSync(resolve(desktopRoot, "src/features/shell-ball/useShellBallInteraction.ts"), "utf8");

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -6850,10 +6850,14 @@ test("desktop onboarding replay keeps the transparent host click-through until c
   assert.match(onboardingWindowSource, /!cardRef\.current \|\| !session \|\| !activePresentation \|\| !hasSettledPresentation/);
   assert.match(onboardingWindowSource, /void setOnboardingInteractiveRegions\(\[\]\);/);
   assert.match(onboardingServiceSource, /export async function resetDesktopOnboardingRuntimeState\(\) \{/);
+  assert.match(onboardingServiceSource, /const DESKTOP_ONBOARDING_RUNTIME_BOOT_ID_KEY = "cialloclaw\.desktop\.onboarding\.runtime_boot_id";/);
+  assert.match(onboardingServiceSource, /export function refreshDesktopOnboardingRuntimeBootId\(\) \{/);
   assert.match(onboardingServiceSource, /removeStoredValue\(DESKTOP_ONBOARDING_SESSION_KEY\);/);
   assert.match(onboardingServiceSource, /removeStoredValue\(DESKTOP_ONBOARDING_PRESENTATION_KEY\);/);
+  assert.match(onboardingServiceSource, /runtime_boot_id: runtimeBootId,/);
+  assert.match(shellBallAppSource, /const runtimeBootId = refreshDesktopOnboardingRuntimeBootId\(\);/);
   assert.match(shellBallAppSource, /const storedSession = loadDesktopOnboardingSession\(\);/);
-  assert.match(shellBallAppSource, /if \(storedSession\?\.isOpen === true && storedSession\.step !== "welcome"\) \{/);
+  assert.match(shellBallAppSource, /if \(storedSession\?\.isOpen === true && storedSession\.runtime_boot_id !== runtimeBootId\) \{/);
   assert.match(shellBallAppSource, /resetDesktopOnboardingRuntimeState/);
   assert.match(shellBallAppSource, /const \[onboardingRuntimeReady, setOnboardingRuntimeReady\] = useState/);
   assert.match(shellBallAppSource, /if \(!onboardingRuntimeReady\) \{/);

--- a/apps/desktop/src/platform/onboardingWindowController.ts
+++ b/apps/desktop/src/platform/onboardingWindowController.ts
@@ -52,6 +52,13 @@ export async function syncOnboardingWindowFrame(
   const onboardingWindow = await getOrCreateOnboardingWindow();
   await onboardingWindow.setPosition(new LogicalPosition(frame.x, frame.y));
   await onboardingWindow.setSize(new LogicalSize(frame.width, frame.height));
+  // Keep the transparent onboarding host click-through until the overlay webview
+  // reports its real card hotspot regions. This prevents replaying onboarding
+  // from briefly blocking the whole monitor while the window boots.
+  await onboardingWindow.setIgnoreCursorEvents(true);
+  // The overlay must stay focusable so its own buttons remain clickable once the
+  // native hotspot regions are restored. We avoid explicit focusing here, so the
+  // business window still keeps control until the user interacts with the guide.
   await onboardingWindow.setFocusable(true);
   await onboardingWindow.setAlwaysOnTop(options.alwaysOnTop ?? true);
   await onboardingWindow.show();


### PR DESCRIPTION
Prevent replayed onboarding from blocking desktop windows by keeping the transparent host click-through until fresh interactive regions are ready. Clear stale runtime guide state on cold starts without deleting new welcome sessions so manual replays still open correctly.
修用户引导，卡在第四步了，打开仪表盘之后onboarding就点不了。不打算合，想让bot看看能不能发现出问题。