### PR TITLE
fix(dashboard): harden long-idle window recovery

### DIFF
--- a/apps/desktop/src/app/dashboard/DashboardRoot.tsx
+++ b/apps/desktop/src/app/dashboard/DashboardRoot.tsx
@@ -43,6 +43,7 @@ function useDashboardOpeningTransitionState() {
     const openingTransitionController = createDashboardOpeningTransitionController({
       cancelAnimationFrame: (handle) => window.cancelAnimationFrame(handle),
       clearTimeout: (handle) => window.clearTimeout(handle),
+      hasFocus: () => document.hasFocus(),
       getVisibilityState: () => document.visibilityState,
       requestAnimationFrame: (callback) => window.requestAnimationFrame(callback),
       setIsOpening,

--- a/apps/desktop/src/app/dashboard/DashboardRoot.tsx
+++ b/apps/desktop/src/app/dashboard/DashboardRoot.tsx
@@ -28,13 +28,19 @@ import "./dashboard.css";
 
 const DASHBOARD_TASK_DETAIL_REQUEST_MEMORY_MS = 5_000;
 
-function useDashboardDomainExpansion() {
+/**
+ * Replays the dashboard opening mask after a hidden desktop window becomes
+ * visible again so long-idle sessions do not stay visually clipped.
+ */
+function useDashboardOpeningTransitionState() {
   const [isOpening, setIsOpening] = useState(true);
 
   useEffect(() => {
     let disposed = false;
     let clearWindowFocusListener: (() => void) | null = null;
-    const controller = createDashboardOpeningTransitionController({
+    // Keep the visibility/focus recovery state machine outside the hook so the
+    // long-idle window path stays contract-testable without mounting Tauri.
+    const openingTransitionController = createDashboardOpeningTransitionController({
       cancelAnimationFrame: (handle) => window.cancelAnimationFrame(handle),
       clearTimeout: (handle) => window.clearTimeout(handle),
       getVisibilityState: () => document.visibilityState,
@@ -44,14 +50,14 @@ function useDashboardDomainExpansion() {
     });
 
     const handleVisibilityChange = () => {
-      controller.handleVisibilityChange();
+      openingTransitionController.handleVisibilityChange();
     };
 
-    controller.trigger();
+    openingTransitionController.trigger();
     document.addEventListener("visibilitychange", handleVisibilityChange);
     void getCurrentWindow()
       .onFocusChanged(({ payload: focused }) => {
-        controller.handleWindowFocusChanged(focused);
+        openingTransitionController.handleWindowFocusChanged(focused);
       })
       .then((unlisten) => {
         if (disposed) {
@@ -67,7 +73,7 @@ function useDashboardDomainExpansion() {
 
     return () => {
       disposed = true;
-      controller.dispose();
+      openingTransitionController.dispose();
       clearWindowFocusListener?.();
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
@@ -80,7 +86,7 @@ function DashboardRoutes() {
   const location = useLocation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const isOpening = useDashboardDomainExpansion();
+  const isOpening = useDashboardOpeningTransitionState();
   const [voiceOpen, setVoiceOpen] = useState(false);
   const handledTaskDetailRequestIdsRef = useRef<Map<string, number>>(new Map());
   const dashboardHomeQuery = useQuery({
@@ -283,6 +289,9 @@ function DashboardRoutes() {
   );
 }
 
+/**
+ * Mounts the dashboard router tree for the dedicated desktop window.
+ */
 export function DashboardRoot() {
   return (
     <HashRouter>

--- a/apps/desktop/src/app/dashboard/DashboardRoot.tsx
+++ b/apps/desktop/src/app/dashboard/DashboardRoot.tsx
@@ -34,10 +34,16 @@ function useDashboardDomainExpansion() {
   useEffect(() => {
     let frame = 0;
     let timeout = 0;
+    let disposed = false;
+    let clearWindowFocusListener: (() => void) | null = null;
 
-    const trigger = () => {
+    const clearPendingRelease = () => {
       window.cancelAnimationFrame(frame);
       window.clearTimeout(timeout);
+    };
+
+    const trigger = () => {
+      clearPendingRelease();
       setIsOpening(true);
       frame = window.requestAnimationFrame(() => {
         setIsOpening(false);
@@ -48,13 +54,13 @@ function useDashboardDomainExpansion() {
       }, 720);
     };
 
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "hidden") {
-        hiddenRef.current = true;
-        return;
-      }
+    const markHidden = () => {
+      hiddenRef.current = true;
+      clearPendingRelease();
+    };
 
-      if (!hiddenRef.current) {
+    const restoreIfNeeded = () => {
+      if (!hiddenRef.current || document.visibilityState === "hidden") {
         return;
       }
 
@@ -62,12 +68,42 @@ function useDashboardDomainExpansion() {
       trigger();
     };
 
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        markHidden();
+        return;
+      }
+
+      restoreIfNeeded();
+    };
+
     trigger();
     document.addEventListener("visibilitychange", handleVisibilityChange);
+    void getCurrentWindow()
+      .onFocusChanged(({ payload: focused }) => {
+        if (!focused) {
+          markHidden();
+          return;
+        }
+
+        restoreIfNeeded();
+      })
+      .then((unlisten) => {
+        if (disposed) {
+          unlisten();
+          return;
+        }
+
+        clearWindowFocusListener = unlisten;
+      })
+      .catch((error) => {
+        console.warn("dashboard focus listener failed", error);
+      });
 
     return () => {
-      window.cancelAnimationFrame(frame);
-      window.clearTimeout(timeout);
+      disposed = true;
+      clearPendingRelease();
+      clearWindowFocusListener?.();
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, []);

--- a/apps/desktop/src/app/dashboard/DashboardRoot.tsx
+++ b/apps/desktop/src/app/dashboard/DashboardRoot.tsx
@@ -23,70 +23,35 @@ import { subscribeApprovalPending, subscribeDeliveryReady, subscribeTaskUpdated 
 import { rememberConversationSessionFromTaskUpdated } from "@/services/conversationSessionService";
 import { cn } from "@/utils/cn";
 import { DashboardHome } from "./DashboardHome";
+import { createDashboardOpeningTransitionController } from "./dashboardOpeningTransition";
 import "./dashboard.css";
 
 const DASHBOARD_TASK_DETAIL_REQUEST_MEMORY_MS = 5_000;
 
 function useDashboardDomainExpansion() {
   const [isOpening, setIsOpening] = useState(true);
-  const hiddenRef = useRef(false);
 
   useEffect(() => {
-    let frame = 0;
-    let timeout = 0;
     let disposed = false;
     let clearWindowFocusListener: (() => void) | null = null;
-
-    const clearPendingRelease = () => {
-      window.cancelAnimationFrame(frame);
-      window.clearTimeout(timeout);
-    };
-
-    const trigger = () => {
-      clearPendingRelease();
-      setIsOpening(true);
-      frame = window.requestAnimationFrame(() => {
-        setIsOpening(false);
-      });
-      // Hidden/background Tauri windows can miss the RAF edge and stay clipped.
-      timeout = window.setTimeout(() => {
-        setIsOpening(false);
-      }, 720);
-    };
-
-    const markHidden = () => {
-      hiddenRef.current = true;
-      clearPendingRelease();
-    };
-
-    const restoreIfNeeded = () => {
-      if (!hiddenRef.current || document.visibilityState === "hidden") {
-        return;
-      }
-
-      hiddenRef.current = false;
-      trigger();
-    };
+    const controller = createDashboardOpeningTransitionController({
+      cancelAnimationFrame: (handle) => window.cancelAnimationFrame(handle),
+      clearTimeout: (handle) => window.clearTimeout(handle),
+      getVisibilityState: () => document.visibilityState,
+      requestAnimationFrame: (callback) => window.requestAnimationFrame(callback),
+      setIsOpening,
+      setTimeout: (callback, timeoutMs) => window.setTimeout(callback, timeoutMs),
+    });
 
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "hidden") {
-        markHidden();
-        return;
-      }
-
-      restoreIfNeeded();
+      controller.handleVisibilityChange();
     };
 
-    trigger();
+    controller.trigger();
     document.addEventListener("visibilitychange", handleVisibilityChange);
     void getCurrentWindow()
       .onFocusChanged(({ payload: focused }) => {
-        if (!focused) {
-          markHidden();
-          return;
-        }
-
-        restoreIfNeeded();
+        controller.handleWindowFocusChanged(focused);
       })
       .then((unlisten) => {
         if (disposed) {
@@ -102,7 +67,7 @@ function useDashboardDomainExpansion() {
 
     return () => {
       disposed = true;
-      clearPendingRelease();
+      controller.dispose();
       clearWindowFocusListener?.();
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };

--- a/apps/desktop/src/app/dashboard/DashboardWindowErrorBoundary.tsx
+++ b/apps/desktop/src/app/dashboard/DashboardWindowErrorBoundary.tsx
@@ -1,0 +1,73 @@
+import { AlertTriangle, RefreshCcw } from "lucide-react";
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+type DashboardWindowErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type DashboardWindowErrorBoundaryState = {
+  hasError: boolean;
+};
+
+/**
+ * Keeps the dashboard window recoverable when long-lived desktop sessions hit
+ * an unexpected render-time exception. Without a window-level boundary the
+ * whole React tree disappears and the user only sees the background shell.
+ */
+export class DashboardWindowErrorBoundary extends Component<
+  DashboardWindowErrorBoundaryProps,
+  DashboardWindowErrorBoundaryState
+> {
+  state: DashboardWindowErrorBoundaryState = {
+    hasError: false,
+  };
+
+  static getDerivedStateFromError() {
+    return {
+      hasError: true,
+    } satisfies DashboardWindowErrorBoundaryState;
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("dashboard window render failed", error, errorInfo);
+  }
+
+  private handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <main className="dashboard-page">
+        <section className="dashboard-page__hero">
+          <div className="dashboard-page__hero-copy">
+            <p className="dashboard-page__eyebrow">dashboard recovery</p>
+            <div className="dashboard-page__title-row">
+              <AlertTriangle className="dashboard-page__title-icon" />
+              <h1>仪表盘需要恢复</h1>
+            </div>
+            <p className="dashboard-page__description">
+              这个窗口在驻留期间遇到了未处理的前端异常。重新加载后会重新挂载 dashboard
+              路由树，并恢复到当前窗口会话。
+            </p>
+          </div>
+
+          <div className="dashboard-card dashboard-card--status">
+            <p className="dashboard-card__kicker">恢复操作</p>
+            <div className="dashboard-card__list">
+              <Button className="dashboard-orbit-panel__primary-button" onClick={this.handleReload} type="button">
+                重新加载仪表盘
+                <RefreshCcw className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </section>
+      </main>
+    );
+  }
+}

--- a/apps/desktop/src/app/dashboard/DashboardWindowErrorBoundary.tsx
+++ b/apps/desktop/src/app/dashboard/DashboardWindowErrorBoundary.tsx
@@ -11,11 +11,20 @@ type DashboardWindowErrorBoundaryState = {
 };
 
 /**
+ * React 18 still requires a class component to catch render-phase errors.
+ * Keep that legacy API isolated behind a small wrapper so the rest of the
+ * dashboard tree can stay on hooks and function components.
+ */
+export function DashboardWindowErrorBoundary(props: DashboardWindowErrorBoundaryProps) {
+  return <DashboardWindowErrorBoundaryImpl {...props} />;
+}
+
+/**
  * Keeps the dashboard window recoverable when long-lived desktop sessions hit
  * an unexpected render-time exception. Without a window-level boundary the
  * whole React tree disappears and the user only sees the background shell.
  */
-export class DashboardWindowErrorBoundary extends Component<
+class DashboardWindowErrorBoundaryImpl extends Component<
   DashboardWindowErrorBoundaryProps,
   DashboardWindowErrorBoundaryState
 > {

--- a/apps/desktop/src/app/dashboard/dashboardOpeningTransition.ts
+++ b/apps/desktop/src/app/dashboard/dashboardOpeningTransition.ts
@@ -18,7 +18,9 @@ type DashboardOpeningTransitionEnvironment = {
 export function createDashboardOpeningTransitionController(environment: DashboardOpeningTransitionEnvironment) {
   let frame = 0;
   let timeout = 0;
-  let hidden = false;
+  // Seed the hidden flag from the mount-time visibility so windows restored
+  // off-screen still replay the opening mask on their first real reveal.
+  let hidden = environment.getVisibilityState() === "hidden";
 
   const clearPendingRelease = () => {
     environment.cancelAnimationFrame(frame);

--- a/apps/desktop/src/app/dashboard/dashboardOpeningTransition.ts
+++ b/apps/desktop/src/app/dashboard/dashboardOpeningTransition.ts
@@ -1,0 +1,84 @@
+export const DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS = 720;
+
+type DashboardOpeningTransitionEnvironment = {
+  cancelAnimationFrame: (handle: number) => void;
+  clearTimeout: (handle: number) => void;
+  getVisibilityState: () => DocumentVisibilityState;
+  requestAnimationFrame: (callback: FrameRequestCallback) => number;
+  setIsOpening: (value: boolean) => void;
+  setTimeout: (callback: () => void, timeoutMs: number) => number;
+};
+
+/**
+ * Coordinates the dashboard opening mask so hidden or unfocused desktop
+ * windows can replay their reveal transition once they become visible again.
+ */
+export function createDashboardOpeningTransitionController(environment: DashboardOpeningTransitionEnvironment) {
+  let frame = 0;
+  let timeout = 0;
+  let hidden = false;
+
+  const clearPendingRelease = () => {
+    environment.cancelAnimationFrame(frame);
+    environment.clearTimeout(timeout);
+    frame = 0;
+    timeout = 0;
+  };
+
+  const trigger = () => {
+    clearPendingRelease();
+    environment.setIsOpening(true);
+    frame = environment.requestAnimationFrame(() => {
+      environment.setIsOpening(false);
+    });
+    // Hidden/background Tauri windows can miss the RAF edge and stay clipped.
+    timeout = environment.setTimeout(() => {
+      environment.setIsOpening(false);
+    }, DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS);
+  };
+
+  const markHidden = () => {
+    hidden = true;
+    clearPendingRelease();
+  };
+
+  const restoreIfNeeded = () => {
+    if (!hidden || environment.getVisibilityState() === "hidden") {
+      return false;
+    }
+
+    hidden = false;
+    trigger();
+    return true;
+  };
+
+  const handleVisibilityChange = () => {
+    if (environment.getVisibilityState() === "hidden") {
+      markHidden();
+      return false;
+    }
+
+    return restoreIfNeeded();
+  };
+
+  const handleWindowFocusChanged = (focused: boolean) => {
+    if (!focused) {
+      markHidden();
+      return false;
+    }
+
+    return restoreIfNeeded();
+  };
+
+  const dispose = () => {
+    clearPendingRelease();
+  };
+
+  return {
+    dispose,
+    handleVisibilityChange,
+    handleWindowFocusChanged,
+    restoreIfNeeded,
+    trigger,
+  };
+}

--- a/apps/desktop/src/app/dashboard/dashboardOpeningTransition.ts
+++ b/apps/desktop/src/app/dashboard/dashboardOpeningTransition.ts
@@ -3,6 +3,7 @@ export const DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS = 720;
 type DashboardOpeningTransitionEnvironment = {
   cancelAnimationFrame: (handle: number) => void;
   clearTimeout: (handle: number) => void;
+  hasFocus: () => boolean;
   getVisibilityState: () => DocumentVisibilityState;
   requestAnimationFrame: (callback: FrameRequestCallback) => number;
   setIsOpening: (value: boolean) => void;
@@ -18,9 +19,10 @@ type DashboardOpeningTransitionEnvironment = {
 export function createDashboardOpeningTransitionController(environment: DashboardOpeningTransitionEnvironment) {
   let frame = 0;
   let timeout = 0;
-  // Seed the hidden flag from the mount-time visibility so windows restored
-  // off-screen still replay the opening mask on their first real reveal.
-  let hidden = environment.getVisibilityState() === "hidden";
+  // Seed the hidden flag from mount-time visibility and focus so windows that
+  // start hidden or backgrounded can still replay the opening mask when they
+  // first become meaningfully visible to the user.
+  let hidden = environment.getVisibilityState() === "hidden" || !environment.hasFocus();
 
   const clearPendingRelease = () => {
     environment.cancelAnimationFrame(frame);

--- a/apps/desktop/src/app/dashboard/dashboardOpeningTransition.ts
+++ b/apps/desktop/src/app/dashboard/dashboardOpeningTransition.ts
@@ -10,8 +10,10 @@ type DashboardOpeningTransitionEnvironment = {
 };
 
 /**
- * Coordinates the dashboard opening mask so hidden or unfocused desktop
- * windows can replay their reveal transition once they become visible again.
+ * Isolates the dashboard opening-mask recovery state machine from the React
+ * hook that wires it to Tauri window events. Keeping this in a small
+ * controller makes the long-idle recovery path readable in the app code and
+ * directly testable without mounting a desktop window.
  */
 export function createDashboardOpeningTransitionController(environment: DashboardOpeningTransitionEnvironment) {
   let frame = 0;

--- a/apps/desktop/src/app/dashboard/main.tsx
+++ b/apps/desktop/src/app/dashboard/main.tsx
@@ -1,9 +1,10 @@
-// 该入口负责挂载仪表盘窗口。
+// This entrypoint mounts the dashboard desktop window.
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import ReactDOM from "react-dom/client";
 import { AppProviders } from "@/features/shared/AppProviders";
 import { installHideOnCloseRequest } from "@/platform/hideOnCloseRequest";
 import { DashboardRoot } from "./DashboardRoot";
+import { DashboardWindowErrorBoundary } from "./DashboardWindowErrorBoundary";
 
 function installDashboardEscapeClose(windowHandle = getCurrentWindow()) {
   let closing = false;
@@ -41,6 +42,8 @@ installDashboardEscapeClose();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <AppProviders>
-    <DashboardRoot />
+    <DashboardWindowErrorBoundary>
+      <DashboardRoot />
+    </DashboardWindowErrorBoundary>
   </AppProviders>,
 );

--- a/apps/desktop/src/app/dashboard/main.tsx
+++ b/apps/desktop/src/app/dashboard/main.tsx
@@ -41,6 +41,8 @@ void installHideOnCloseRequest();
 installDashboardEscapeClose();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
+  // Keep the recovery boundary above AppProviders so provider init failures
+  // still land on the dashboard fallback instead of collapsing the window.
   <DashboardWindowErrorBoundary>
     <AppProviders>
       <DashboardRoot />

--- a/apps/desktop/src/app/dashboard/main.tsx
+++ b/apps/desktop/src/app/dashboard/main.tsx
@@ -41,9 +41,9 @@ void installHideOnCloseRequest();
 installDashboardEscapeClose();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <AppProviders>
-    <DashboardWindowErrorBoundary>
+  <DashboardWindowErrorBoundary>
+    <AppProviders>
       <DashboardRoot />
-    </DashboardWindowErrorBoundary>
-  </AppProviders>,
+    </AppProviders>
+  </DashboardWindowErrorBoundary>,
 );

--- a/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
+++ b/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
@@ -3524,7 +3524,10 @@ test("dashboard entry keeps a window-level error boundary so runtime faults do n
   );
 
   assert.match(dashboardMainSource, /DashboardWindowErrorBoundary/);
-  assert.match(dashboardMainSource, /<DashboardWindowErrorBoundary>[\s\S]*<DashboardRoot \/>[\s\S]*<\/DashboardWindowErrorBoundary>/);
+  assert.match(
+    dashboardMainSource,
+    /<DashboardWindowErrorBoundary>[\s\S]*<AppProviders>[\s\S]*<DashboardRoot \/>[\s\S]*<\/AppProviders>[\s\S]*<\/DashboardWindowErrorBoundary>/,
+  );
   assert.match(dashboardErrorBoundarySource, /static getDerivedStateFromError/);
   assert.match(dashboardErrorBoundarySource, /window\.location\.reload\(\)/);
   assert.match(dashboardErrorBoundarySource, /dashboard window render failed/);

--- a/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
+++ b/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
@@ -90,6 +90,7 @@ function loadDashboardOpeningTransitionModule() {
       createDashboardOpeningTransitionController: (environment: {
         cancelAnimationFrame: (handle: number) => void;
         clearTimeout: (handle: number) => void;
+        hasFocus: () => boolean;
         getVisibilityState: () => DocumentVisibilityState;
         requestAnimationFrame: (callback: FrameRequestCallback) => number;
         setIsOpening: (value: boolean) => void;
@@ -3628,6 +3629,7 @@ test("dashboard opening transition controller replays focus and visibility recov
   const timeoutCallbacks = new Map<number, () => void>();
   let nextHandle = 1;
   let visibilityState: DocumentVisibilityState = "visible";
+  let hasFocus = true;
 
   const controller = createDashboardOpeningTransitionController({
     cancelAnimationFrame: (handle) => {
@@ -3642,6 +3644,7 @@ test("dashboard opening transition controller replays focus and visibility recov
         timeoutCallbacks.delete(handle);
       }
     },
+    hasFocus: () => hasFocus,
     getVisibilityState: () => visibilityState,
     requestAnimationFrame: (callback) => {
       const handle = nextHandle++;
@@ -3708,12 +3711,14 @@ test("dashboard opening transition controller replays the opening mask for windo
   const frameCallbacks = new Map<number, FrameRequestCallback>();
   let nextHandle = 1;
   let visibilityState: DocumentVisibilityState = "hidden";
+  let hasFocus = false;
 
   const controller = createDashboardOpeningTransitionController({
     cancelAnimationFrame: (handle) => {
       frameCallbacks.delete(handle);
     },
     clearTimeout: () => {},
+    hasFocus: () => hasFocus,
     getVisibilityState: () => visibilityState,
     requestAnimationFrame: (callback) => {
       const handle = nextHandle++;
@@ -3735,6 +3740,45 @@ test("dashboard opening transition controller replays the opening mask for windo
 
   visibilityState = "visible";
   assert.equal(controller.handleVisibilityChange(), true);
+  assert.deepEqual(openingStates, [true, true]);
+  assert.deepEqual(timeoutDurations, [
+    DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS,
+    DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS,
+  ]);
+});
+
+test("dashboard opening transition controller replays the opening mask for windows mounted while unfocused", () => {
+  const {
+    DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS,
+    createDashboardOpeningTransitionController,
+  } = loadDashboardOpeningTransitionModule();
+  const openingStates: boolean[] = [];
+  const timeoutDurations: number[] = [];
+  let nextHandle = 1;
+  let visibilityState: DocumentVisibilityState = "visible";
+  let hasFocus = false;
+
+  const controller = createDashboardOpeningTransitionController({
+    cancelAnimationFrame: () => {},
+    clearTimeout: () => {},
+    hasFocus: () => hasFocus,
+    getVisibilityState: () => visibilityState,
+    requestAnimationFrame: () => nextHandle++,
+    setIsOpening: (value) => {
+      openingStates.push(value);
+    },
+    setTimeout: (_callback, timeoutMs) => {
+      timeoutDurations.push(timeoutMs);
+      return nextHandle++;
+    },
+  });
+
+  controller.trigger();
+  assert.deepEqual(openingStates, [true]);
+  assert.deepEqual(timeoutDurations, [DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS]);
+
+  hasFocus = true;
+  assert.equal(controller.handleWindowFocusChanged(true), true);
   assert.deepEqual(openingStates, [true, true]);
   assert.deepEqual(timeoutDurations, [
     DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS,

--- a/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
+++ b/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
@@ -83,6 +83,44 @@ function loadDashboardTaskDetailNavigationSource() {
   return readFileSync(resolve(desktopRoot, "src/features/dashboard/shared/dashboardTaskDetailNavigation.ts"), "utf8");
 }
 
+function loadDashboardOpeningTransitionModule() {
+  return withDesktopAliasRuntime((requireFn) =>
+    requireFn(resolve(desktopRoot, ".cache/dashboard-tests/app/dashboard/dashboardOpeningTransition.js")) as {
+      DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS: number;
+      createDashboardOpeningTransitionController: (environment: {
+        cancelAnimationFrame: (handle: number) => void;
+        clearTimeout: (handle: number) => void;
+        getVisibilityState: () => DocumentVisibilityState;
+        requestAnimationFrame: (callback: FrameRequestCallback) => number;
+        setIsOpening: (value: boolean) => void;
+        setTimeout: (callback: () => void, timeoutMs: number) => number;
+      }) => {
+        dispose: () => void;
+        handleVisibilityChange: () => boolean;
+        handleWindowFocusChanged: (focused: boolean) => boolean;
+        restoreIfNeeded: () => boolean;
+        trigger: () => void;
+      };
+    },
+  );
+}
+
+function loadDashboardWindowErrorBoundaryModule() {
+  return withDesktopAliasRuntime((requireFn) =>
+    requireFn(resolve(desktopRoot, ".cache/dashboard-tests/app/dashboard/DashboardWindowErrorBoundary.js")) as {
+      DashboardWindowErrorBoundary: {
+        new (props: { children: unknown }): {
+          componentDidCatch: (error: Error, errorInfo: { componentStack: string }) => void;
+          props: { children: unknown };
+          render: () => unknown;
+          state: { hasError: boolean };
+        };
+        getDerivedStateFromError: () => { hasError: boolean };
+      };
+    },
+  );
+}
+
 function loadConversationSessionServiceModule() {
   return withDesktopAliasRuntime((requireFn) => {
     const modulePath = resolve(desktopRoot, "src/services/conversationSessionService.ts");
@@ -583,6 +621,40 @@ function loadMirrorServiceModule() {
       };
     };
   });
+}
+
+function findRenderedElement(
+  node: unknown,
+  predicate: (element: { props: Record<string, unknown>; type: unknown }) => boolean,
+): { props: Record<string, unknown>; type: unknown } | null {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      const match = findRenderedElement(item, predicate);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }
+
+  if (!node || typeof node !== "object") {
+    return null;
+  }
+
+  const maybeElement = node as { props?: Record<string, unknown>; type?: unknown };
+  if (!maybeElement.props || !("type" in maybeElement)) {
+    return null;
+  }
+
+  const element = {
+    props: maybeElement.props,
+    type: maybeElement.type,
+  };
+  if (predicate(element)) {
+    return element;
+  }
+
+  return findRenderedElement(element.props.children, predicate);
 }
 
 type DashboardContractRpcMethodOverrides = {
@@ -3508,12 +3580,93 @@ test("dashboard task-detail routing deduplicates retry request ids and accepts t
 test("dashboard opening mask replays after Tauri window focus returns from hidden desktop sessions", () => {
   const dashboardRootSource = readFileSync(resolve(desktopRoot, "src/app/dashboard/DashboardRoot.tsx"), "utf8");
 
-  assert.match(dashboardRootSource, /const markHidden = \(\) => \{/);
-  assert.match(dashboardRootSource, /const restoreIfNeeded = \(\) => \{/);
-  assert.match(dashboardRootSource, /document\.visibilityState === "hidden"/);
+  assert.match(dashboardRootSource, /createDashboardOpeningTransitionController/);
+  assert.match(dashboardRootSource, /const handleVisibilityChange = \(\) => \{/);
   assert.match(dashboardRootSource, /\.onFocusChanged\(\(\{ payload: focused \}\) => \{/);
-  assert.match(dashboardRootSource, /if \(!focused\) \{\s*markHidden\(\);/);
-  assert.match(dashboardRootSource, /restoreIfNeeded\(\);/);
+  assert.match(dashboardRootSource, /controller\.handleWindowFocusChanged\(focused\);/);
+});
+
+test("dashboard opening transition controller replays focus and visibility recovery at runtime", () => {
+  const {
+    DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS,
+    createDashboardOpeningTransitionController,
+  } = loadDashboardOpeningTransitionModule();
+  const openingStates: boolean[] = [];
+  const timeoutDurations: number[] = [];
+  const cancelledFrames: number[] = [];
+  const clearedTimeouts: number[] = [];
+  const frameCallbacks = new Map<number, FrameRequestCallback>();
+  const timeoutCallbacks = new Map<number, () => void>();
+  let nextHandle = 1;
+  let visibilityState: DocumentVisibilityState = "visible";
+
+  const controller = createDashboardOpeningTransitionController({
+    cancelAnimationFrame: (handle) => {
+      if (handle > 0) {
+        cancelledFrames.push(handle);
+        frameCallbacks.delete(handle);
+      }
+    },
+    clearTimeout: (handle) => {
+      if (handle > 0) {
+        clearedTimeouts.push(handle);
+        timeoutCallbacks.delete(handle);
+      }
+    },
+    getVisibilityState: () => visibilityState,
+    requestAnimationFrame: (callback) => {
+      const handle = nextHandle++;
+      frameCallbacks.set(handle, callback);
+      return handle;
+    },
+    setIsOpening: (value) => {
+      openingStates.push(value);
+    },
+    setTimeout: (callback, timeoutMs) => {
+      const handle = nextHandle++;
+      timeoutDurations.push(timeoutMs);
+      timeoutCallbacks.set(handle, callback);
+      return handle;
+    },
+  });
+
+  controller.trigger();
+  assert.deepEqual(openingStates, [true]);
+  assert.deepEqual(timeoutDurations, [DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS]);
+
+  controller.handleWindowFocusChanged(false);
+  assert.equal(cancelledFrames.length, 1);
+  assert.equal(clearedTimeouts.length, 1);
+
+  controller.handleWindowFocusChanged(true);
+  assert.deepEqual(openingStates, [true, true]);
+  assert.deepEqual(timeoutDurations, [
+    DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS,
+    DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS,
+  ]);
+  assert.equal(frameCallbacks.size, 1);
+  Array.from(frameCallbacks.values()).at(-1)?.(16.7);
+  assert.deepEqual(openingStates, [true, true, false]);
+
+  controller.handleWindowFocusChanged(false);
+  visibilityState = "hidden";
+  controller.handleWindowFocusChanged(true);
+  assert.deepEqual(openingStates, [true, true, false]);
+
+  visibilityState = "visible";
+  controller.handleVisibilityChange();
+  assert.deepEqual(openingStates, [true, true, false, true]);
+  assert.deepEqual(timeoutDurations, [
+    DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS,
+    DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS,
+    DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS,
+  ]);
+  Array.from(timeoutCallbacks.values()).at(-1)?.();
+  assert.deepEqual(openingStates, [true, true, false, true, false]);
+
+  controller.dispose();
+  assert.equal(cancelledFrames.length, 3);
+  assert.equal(clearedTimeouts.length, 3);
 });
 
 test("dashboard entry keeps a window-level error boundary so runtime faults do not collapse into a blank shell", () => {
@@ -3531,6 +3684,68 @@ test("dashboard entry keeps a window-level error boundary so runtime faults do n
   assert.match(dashboardErrorBoundarySource, /static getDerivedStateFromError/);
   assert.match(dashboardErrorBoundarySource, /window\.location\.reload\(\)/);
   assert.match(dashboardErrorBoundarySource, /dashboard window render failed/);
+});
+
+test("dashboard window error boundary renders a recovery fallback and reload action after runtime faults", () => {
+  const { DashboardWindowErrorBoundary } = loadDashboardWindowErrorBoundaryModule();
+  const child = { props: { id: "child" }, type: "mock-child" };
+  const boundary = new DashboardWindowErrorBoundary({ children: child });
+  const originalConsoleError = console.error;
+  const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const consoleMessages: unknown[][] = [];
+  let reloadCalls = 0;
+
+  try {
+    console.error = (...args: unknown[]) => {
+      consoleMessages.push(args);
+    };
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        location: {
+          reload: () => {
+            reloadCalls += 1;
+          },
+        },
+      },
+      writable: true,
+    });
+
+    assert.equal(boundary.render(), child);
+
+    boundary.componentDidCatch(new Error("dashboard exploded"), {
+      componentStack: "\n    at DashboardRoot",
+    });
+    assert.equal(consoleMessages.length, 1);
+    assert.match(String(consoleMessages[0][0]), /dashboard window render failed/);
+
+    boundary.state = {
+      ...boundary.state,
+      ...DashboardWindowErrorBoundary.getDerivedStateFromError(),
+    };
+
+    const fallbackTree = boundary.render();
+    const title = findRenderedElement(
+      fallbackTree,
+      (element) => element.type === "h1" && element.props.children === "仪表盘需要恢复",
+    );
+    const reloadButton = findRenderedElement(
+      fallbackTree,
+      (element) => element.props.type === "button" && typeof element.props.onClick === "function",
+    );
+
+    assert.ok(title);
+    assert.ok(reloadButton);
+    (reloadButton.props.onClick as () => void)();
+    assert.equal(reloadCalls, 1);
+  } finally {
+    console.error = originalConsoleError;
+    if (originalWindowDescriptor) {
+      Object.defineProperty(globalThis, "window", originalWindowDescriptor);
+    } else {
+      delete (globalThis as { window?: unknown }).window;
+    }
+  }
 });
 
 test("conversation session reuse expires after the backend freshness window", () => {

--- a/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
+++ b/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
@@ -3698,6 +3698,50 @@ test("dashboard opening transition controller replays focus and visibility recov
   assert.equal(clearedTimeouts.length, 3);
 });
 
+test("dashboard opening transition controller replays the opening mask for windows mounted while hidden", () => {
+  const {
+    DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS,
+    createDashboardOpeningTransitionController,
+  } = loadDashboardOpeningTransitionModule();
+  const openingStates: boolean[] = [];
+  const timeoutDurations: number[] = [];
+  const frameCallbacks = new Map<number, FrameRequestCallback>();
+  let nextHandle = 1;
+  let visibilityState: DocumentVisibilityState = "hidden";
+
+  const controller = createDashboardOpeningTransitionController({
+    cancelAnimationFrame: (handle) => {
+      frameCallbacks.delete(handle);
+    },
+    clearTimeout: () => {},
+    getVisibilityState: () => visibilityState,
+    requestAnimationFrame: (callback) => {
+      const handle = nextHandle++;
+      frameCallbacks.set(handle, callback);
+      return handle;
+    },
+    setIsOpening: (value) => {
+      openingStates.push(value);
+    },
+    setTimeout: (_callback, timeoutMs) => {
+      timeoutDurations.push(timeoutMs);
+      return nextHandle++;
+    },
+  });
+
+  controller.trigger();
+  assert.deepEqual(openingStates, [true]);
+  assert.deepEqual(timeoutDurations, [DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS]);
+
+  visibilityState = "visible";
+  assert.equal(controller.handleVisibilityChange(), true);
+  assert.deepEqual(openingStates, [true, true]);
+  assert.deepEqual(timeoutDurations, [
+    DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS,
+    DASHBOARD_OPENING_RECOVERY_TIMEOUT_MS,
+  ]);
+});
+
 test("dashboard entry keeps a window-level error boundary so runtime faults do not collapse into a blank shell", () => {
   const dashboardMainSource = readFileSync(resolve(desktopRoot, "src/app/dashboard/main.tsx"), "utf8");
   const dashboardErrorBoundarySource = readFileSync(

--- a/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
+++ b/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
@@ -108,8 +108,27 @@ function loadDashboardOpeningTransitionModule() {
 function loadDashboardWindowErrorBoundaryModule() {
   return withDesktopAliasRuntime((requireFn) =>
     requireFn(resolve(desktopRoot, ".cache/dashboard-tests/app/dashboard/DashboardWindowErrorBoundary.js")) as {
-      DashboardWindowErrorBoundary: {
-        new (props: { children: unknown }): {
+      DashboardWindowErrorBoundary: (props: { children: unknown }) => {
+        props: { children: unknown };
+        type: {
+          new (props: { children: unknown }): {
+            componentDidCatch: (error: Error, errorInfo: { componentStack: string }) => void;
+            props: { children: unknown };
+            render: () => unknown;
+            state: { hasError: boolean };
+          };
+          getDerivedStateFromError: () => { hasError: boolean };
+        };
+      };
+    },
+  );
+}
+
+function instantiateDashboardWindowErrorBoundary(
+  DashboardWindowErrorBoundary: (props: { children: unknown }) => {
+    props: { children: unknown };
+    type: {
+      new (props: { children: unknown }): {
           componentDidCatch: (error: Error, errorInfo: { componentStack: string }) => void;
           props: { children: unknown };
           render: () => unknown;
@@ -117,8 +136,18 @@ function loadDashboardWindowErrorBoundaryModule() {
         };
         getDerivedStateFromError: () => { hasError: boolean };
       };
+  },
+) {
+  const renderedBoundary = DashboardWindowErrorBoundary({ children: null });
+  const BoundaryImplementation = renderedBoundary.type;
+
+  return {
+    BoundaryImplementation,
+    create(props: { children: unknown }) {
+      const element = DashboardWindowErrorBoundary(props);
+      return new BoundaryImplementation(element.props);
     },
-  );
+  };
 }
 
 function loadConversationSessionServiceModule() {
@@ -3583,7 +3612,7 @@ test("dashboard opening mask replays after Tauri window focus returns from hidde
   assert.match(dashboardRootSource, /createDashboardOpeningTransitionController/);
   assert.match(dashboardRootSource, /const handleVisibilityChange = \(\) => \{/);
   assert.match(dashboardRootSource, /\.onFocusChanged\(\(\{ payload: focused \}\) => \{/);
-  assert.match(dashboardRootSource, /controller\.handleWindowFocusChanged\(focused\);/);
+  assert.match(dashboardRootSource, /openingTransitionController\.handleWindowFocusChanged\(focused\);/);
 });
 
 test("dashboard opening transition controller replays focus and visibility recovery at runtime", () => {
@@ -3681,6 +3710,8 @@ test("dashboard entry keeps a window-level error boundary so runtime faults do n
     dashboardMainSource,
     /<DashboardWindowErrorBoundary>[\s\S]*<AppProviders>[\s\S]*<DashboardRoot \/>[\s\S]*<\/AppProviders>[\s\S]*<\/DashboardWindowErrorBoundary>/,
   );
+  assert.match(dashboardErrorBoundarySource, /export function DashboardWindowErrorBoundary/);
+  assert.match(dashboardErrorBoundarySource, /class DashboardWindowErrorBoundaryImpl extends Component/);
   assert.match(dashboardErrorBoundarySource, /static getDerivedStateFromError/);
   assert.match(dashboardErrorBoundarySource, /window\.location\.reload\(\)/);
   assert.match(dashboardErrorBoundarySource, /dashboard window render failed/);
@@ -3689,7 +3720,8 @@ test("dashboard entry keeps a window-level error boundary so runtime faults do n
 test("dashboard window error boundary renders a recovery fallback and reload action after runtime faults", () => {
   const { DashboardWindowErrorBoundary } = loadDashboardWindowErrorBoundaryModule();
   const child = { props: { id: "child" }, type: "mock-child" };
-  const boundary = new DashboardWindowErrorBoundary({ children: child });
+  const { BoundaryImplementation, create } = instantiateDashboardWindowErrorBoundary(DashboardWindowErrorBoundary);
+  const boundary = create({ children: child });
   const originalConsoleError = console.error;
   const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
   const consoleMessages: unknown[][] = [];
@@ -3721,7 +3753,7 @@ test("dashboard window error boundary renders a recovery fallback and reload act
 
     boundary.state = {
       ...boundary.state,
-      ...DashboardWindowErrorBoundary.getDerivedStateFromError(),
+      ...BoundaryImplementation.getDerivedStateFromError(),
     };
 
     const fallbackTree = boundary.render();

--- a/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
+++ b/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
@@ -3505,6 +3505,31 @@ test("dashboard task-detail routing deduplicates retry request ids and accepts t
   assert.match(taskPageSource, /if \(selectedTaskId && detailOpen\) \{/);
 });
 
+test("dashboard opening mask replays after Tauri window focus returns from hidden desktop sessions", () => {
+  const dashboardRootSource = readFileSync(resolve(desktopRoot, "src/app/dashboard/DashboardRoot.tsx"), "utf8");
+
+  assert.match(dashboardRootSource, /const markHidden = \(\) => \{/);
+  assert.match(dashboardRootSource, /const restoreIfNeeded = \(\) => \{/);
+  assert.match(dashboardRootSource, /document\.visibilityState === "hidden"/);
+  assert.match(dashboardRootSource, /\.onFocusChanged\(\(\{ payload: focused \}\) => \{/);
+  assert.match(dashboardRootSource, /if \(!focused\) \{\s*markHidden\(\);/);
+  assert.match(dashboardRootSource, /restoreIfNeeded\(\);/);
+});
+
+test("dashboard entry keeps a window-level error boundary so runtime faults do not collapse into a blank shell", () => {
+  const dashboardMainSource = readFileSync(resolve(desktopRoot, "src/app/dashboard/main.tsx"), "utf8");
+  const dashboardErrorBoundarySource = readFileSync(
+    resolve(desktopRoot, "src/app/dashboard/DashboardWindowErrorBoundary.tsx"),
+    "utf8",
+  );
+
+  assert.match(dashboardMainSource, /DashboardWindowErrorBoundary/);
+  assert.match(dashboardMainSource, /<DashboardWindowErrorBoundary>[\s\S]*<DashboardRoot \/>[\s\S]*<\/DashboardWindowErrorBoundary>/);
+  assert.match(dashboardErrorBoundarySource, /static getDerivedStateFromError/);
+  assert.match(dashboardErrorBoundarySource, /window\.location\.reload\(\)/);
+  assert.match(dashboardErrorBoundarySource, /dashboard window render failed/);
+});
+
 test("conversation session reuse expires after the backend freshness window", () => {
   const originalDate = globalThis.Date;
 

--- a/apps/desktop/tsconfig.dashboard-test.json
+++ b/apps/desktop/tsconfig.dashboard-test.json
@@ -13,6 +13,8 @@
     }
   },
   "include": [
+    "src/app/dashboard/DashboardWindowErrorBoundary.tsx",
+    "src/app/dashboard/dashboardOpeningTransition.ts",
     "src/features/dashboard/dashboard.contract.test.ts",
     "src/features/dashboard/shared/dashboardContractValidators.ts",
     "src/features/dashboard/shared/dashboardSafetyNavigation.ts",


### PR DESCRIPTION
## Summary

- fix the dashboard background-only / white-screen symptom after long idle desktop sessions
- replay dashboard opening-mask recovery when the Tauri window regains focus, not only on document visibility changes
- add a window-level error boundary so runtime render failures do not collapse the whole dashboard shell
- add dashboard contract coverage for focus-based recovery and error-boundary wiring

## Details

- track both window focus and document visibility in the dashboard opening transition
- clear pending animation and timeout work before replaying the recovery transition
- wrap the dashboard entry with a recoverable error boundary and reload action
- keep the fix scoped to desktop frontend behavior without changing backend or protocol semantics

## Verification

- pnpm --dir apps/desktop typecheck
- pnpm --dir apps/desktop lint
- pnpm --dir apps/desktop test:dashboard
- pnpm --dir apps/desktop build
