### PR TITLE
feat(worker): add CDP attach support for real Chromium pages

### DIFF
--- a/docs/module-design.md
+++ b/docs/module-design.md
@@ -1734,7 +1734,7 @@ flowchart TB
 #### worker 契约补充
 - attached 模式结果可追加 `attached / browser_kind / browser_transport / endpoint_url / source` 元信息，供后续 Go sidecar、引用映射与前端承接复用；
 - `browser_attach_current`、`browser_snapshot`、`browser_navigate`、`browser_tab_focus` 结果至少需要稳定回写 `page_index / url / title`，`browser_tabs_list` 需要回写 `tabs[]` 与 `tab_count`；
-- worker 至少需要把 `browser_attach_failed`、`page_target_not_found`、`unsupported_browser_kind`、`invalid_input` 作为结构化错误语义稳定返回，而不是只抛原始运行时异常。
+- worker 至少需要把 `browser_attach_failed`、`browser_kind_mismatch`、`page_target_not_found`、`unsupported_browser_kind`、`invalid_input` 作为结构化错误语义稳定返回，而不是只抛原始运行时异常。
 
 #### 处理主线
 1. 先确认 sidecar 健康状态与浏览器能力可用。

--- a/docs/module-design.md
+++ b/docs/module-design.md
@@ -1722,10 +1722,17 @@ flowchart TB
 
 #### 实现约束
 - Playwright sidecar 至少支持 `page_read`、`page_search`、`page_interact`、`structured_dom` 四类正式能力；
+- sidecar 可在保持既有 launch 路径兼容的前提下附加 `attach.mode = cdp` 请求形状，用于附着已开启调试端口的本地 Chromium 浏览器；
+- `attach.target.url / title_contains / page_index` 仅在显式提供时才参与附着页缩小；顶层 `url` 继续保留给 launch 路径与展示 fallback，不得隐式升级成 attach 过滤条件；
+- `attach.endpoint_url` 仅允许 loopback 目标（`localhost`、`127.0.0.0/8`、`::1`），避免 sidecar 退化为通用 outbound CDP dialer；
 - sidecar 启动前必须通过健康检查，避免把未就绪 worker 暴露给主执行链；
 - 传输层失败要清空 ready 状态并触发回收，普通请求失败则保留 ready 状态；
 - 页面交互与结构化 DOM 结果必须通过 `tool_call -> event -> delivery_result` 链回写，而不是前端直连 sidecar；
 - `tool_call.completed` 事件需要回写 worker/source/output 元信息，便于任务详情、通知订阅和后续审计复用。
+
+#### worker 契约补充
+- attached 模式结果可追加 `attached / browser_kind / browser_transport / endpoint_url / source` 元信息，供后续 Go sidecar、引用映射与前端承接复用；
+- worker 至少需要把 `browser_attach_failed`、`page_target_not_found`、`unsupported_browser_kind`、`invalid_input` 作为结构化错误语义稳定返回，而不是只抛原始运行时异常。
 
 #### 处理主线
 1. 先确认 sidecar 健康状态与浏览器能力可用。

--- a/docs/module-design.md
+++ b/docs/module-design.md
@@ -1721,10 +1721,11 @@ flowchart TB
 - 结构化 DOM/页面结果回传。
 
 #### 实现约束
-- Playwright sidecar 至少支持 `page_read`、`page_search`、`page_interact`、`structured_dom` 四类正式能力；
+- Playwright sidecar 至少支持 `page_read`、`page_search`、`page_interact`、`structured_dom` 四类兼容能力，以及 `browser_attach_current`、`browser_snapshot`、`browser_navigate`、`browser_tabs_list`、`browser_tab_focus`、`browser_interact` 六类真实浏览器动作；
 - sidecar 可在保持既有 launch 路径兼容的前提下附加 `attach.mode = cdp` 请求形状，用于附着已开启调试端口的本地 Chromium 浏览器；
 - `attach.target.url / title_contains / page_index` 仅在显式提供时才参与附着页缩小；顶层 `url` 继续保留给 launch 路径与展示 fallback，不得隐式升级成 attach 过滤条件；
 - `attach.endpoint_url` 仅允许 loopback 目标（`localhost`、`127.0.0.0/8`、`::1`），避免 sidecar 退化为通用 outbound CDP dialer；
+- `browser_*` 动作必须显式提供 `attach`，不得偷偷回退到 launch 路径；其中 `browser_navigate` 的顶层 `url` 仅表示导航目标，不参与附着页筛选；
 - sidecar 启动前必须通过健康检查，避免把未就绪 worker 暴露给主执行链；
 - 传输层失败要清空 ready 状态并触发回收，普通请求失败则保留 ready 状态；
 - 页面交互与结构化 DOM 结果必须通过 `tool_call -> event -> delivery_result` 链回写，而不是前端直连 sidecar；
@@ -1732,12 +1733,13 @@ flowchart TB
 
 #### worker 契约补充
 - attached 模式结果可追加 `attached / browser_kind / browser_transport / endpoint_url / source` 元信息，供后续 Go sidecar、引用映射与前端承接复用；
+- `browser_attach_current`、`browser_snapshot`、`browser_navigate`、`browser_tab_focus` 结果至少需要稳定回写 `page_index / url / title`，`browser_tabs_list` 需要回写 `tabs[]` 与 `tab_count`；
 - worker 至少需要把 `browser_attach_failed`、`page_target_not_found`、`unsupported_browser_kind`、`invalid_input` 作为结构化错误语义稳定返回，而不是只抛原始运行时异常。
 
 #### 处理主线
 1. 先确认 sidecar 健康状态与浏览器能力可用。
-2. 接收标准页面能力请求，路由到 `page_read / page_search / page_interact / structured_dom`。
-3. 把页面结果、结构化 DOM、截图或 URL 元数据组装成标准工具输出。
+2. 接收标准页面能力请求，路由到 `page_read / page_search / page_interact / structured_dom` 与 `browser_*` 动作。
+3. 把页面结果、结构化 DOM、页签列表、导航结果或 URL 元数据组装成标准工具输出。
 4. 为需要证据链的场景生成 `citation_seed` 与 artifact 候选。
 5. 通过 `tool_call.completed` 和正式交付链回流，而不是独立暴露页面结果。
 

--- a/workers/playwright-worker/src/index.js
+++ b/workers/playwright-worker/src/index.js
@@ -9,9 +9,12 @@ export const manifest = {
 };
 
 const browserTimeoutMS = 15000;
+const defaultCDPEndpointURL = "http://127.0.0.1:9222";
+const supportedCDPBrowserKinds = new Set(["chrome", "edge"]);
 const workerUserAgent = "CialloClawPlaywrightWorker/0.1";
 
 const defaultDependencies = {
+  connectToBrowser,
   launchBrowser,
 };
 
@@ -59,6 +62,11 @@ async function launchBrowser() {
   return chromium.launch({ headless: true });
 }
 
+async function connectToBrowser(endpointURL) {
+  const { chromium } = await import("playwright");
+  return chromium.connectOverCDP(endpointURL);
+}
+
 async function closeIfPossible(target, methodName) {
   if (target && typeof target[methodName] === "function") {
     await target[methodName]();
@@ -89,10 +97,174 @@ async function openBrowserPage(url, deps, callback) {
     if (!response.ok()) {
       throw new Error(`http_${response.status()}`);
     }
-    return await callback(page, response);
+    return await callback(page, response, {
+      attached: false,
+      browserKind: undefined,
+      browserTransport: "launch",
+      endpointURL: undefined,
+      source: "playwright_worker_browser",
+    });
   } finally {
     await closeResources(context, browser);
   }
+}
+
+function createStructuredWorkerError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function structuredWorkerErrorResponse(error) {
+  if (!error || typeof error.code !== "string") {
+    return null;
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: error.code,
+      message: error.message,
+    },
+  };
+}
+
+function normalizeOptionalString(value) {
+  const normalized = String(value ?? "").trim();
+  return normalized === "" ? undefined : normalized;
+}
+
+function normalizeComparableURL(url) {
+  const normalized = normalizeOptionalString(url);
+  if (!normalized) {
+    return undefined;
+  }
+
+  try {
+    return new URL(normalized).toString();
+  } catch {
+    return normalized;
+  }
+}
+
+// resolveAttachConfig keeps the worker-side attach contract additive so the Go
+// runtime can keep using the legacy launch flow until issue-3 wiring lands.
+function resolveAttachConfig(request) {
+  const attach = request?.attach;
+  if (!attach) {
+    return null;
+  }
+
+  const mode = normalizeOptionalString(attach.mode) ?? "cdp";
+  if (mode !== "cdp") {
+    throw createStructuredWorkerError("invalid_input", "attach.mode must be 'cdp'");
+  }
+
+  const browserKind = normalizeOptionalString(attach.browser_kind)?.toLowerCase();
+  if (browserKind && !supportedCDPBrowserKinds.has(browserKind)) {
+    throw createStructuredWorkerError("unsupported_browser_kind", `unsupported browser kind '${browserKind}'`);
+  }
+
+  const target = typeof attach.target === "object" && attach.target !== null ? attach.target : {};
+  const rawPageIndex = target.page_index;
+  const pageIndex = rawPageIndex === undefined ? undefined : Number(rawPageIndex);
+  if (rawPageIndex !== undefined && (!Number.isInteger(pageIndex) || pageIndex < 0)) {
+    throw createStructuredWorkerError("invalid_input", "attach.target.page_index must be a non-negative integer");
+  }
+
+  return {
+    browserKind,
+    endpointURL: normalizeOptionalString(attach.endpoint_url) ?? defaultCDPEndpointURL,
+    pageIndex,
+    targetTitleContains: normalizeOptionalString(target.title_contains)?.toLowerCase(),
+    targetURL: normalizeComparableURL(target.url ?? request?.url),
+  };
+}
+
+async function describeAttachedPages(browser) {
+  const contexts = typeof browser?.contexts === "function" ? browser.contexts() : [];
+  const pages = contexts.flatMap((context) => {
+    if (!context || typeof context.pages !== "function") {
+      return [];
+    }
+    return context.pages();
+  });
+
+  return Promise.all(pages.map(async (page, index) => ({
+    index,
+    page,
+    title: normalizeOptionalString(await page.title().catch(() => "")) ?? "",
+    url: normalizeComparableURL(typeof page.url === "function" ? page.url() : "") ?? "",
+  })));
+}
+
+// selectAttachedPage avoids blind tab selection by progressively narrowing the
+// candidate set and only falling back when the connected browser exposes a
+// single usable page.
+function selectAttachedPage(pageDescriptors, attachConfig) {
+  if (pageDescriptors.length === 0) {
+    throw createStructuredWorkerError("page_target_not_found", "no attached browser pages are available");
+  }
+
+  let candidates = pageDescriptors;
+  if (attachConfig.targetURL) {
+    const exactURLMatches = pageDescriptors.filter((descriptor) => descriptor.url === attachConfig.targetURL);
+    if (exactURLMatches.length > 0) {
+      candidates = exactURLMatches;
+    }
+  }
+
+  if (attachConfig.targetTitleContains) {
+    const titleMatches = candidates.filter((descriptor) => descriptor.title.toLowerCase().includes(attachConfig.targetTitleContains));
+    if (titleMatches.length > 0) {
+      candidates = titleMatches;
+    }
+  }
+
+  if (attachConfig.pageIndex !== undefined) {
+    if (attachConfig.pageIndex >= candidates.length) {
+      throw createStructuredWorkerError("page_target_not_found", `attach.target.page_index ${attachConfig.pageIndex} is out of range`);
+    }
+    return candidates[attachConfig.pageIndex].page;
+  }
+
+  if (candidates.length === 1) {
+    return candidates[0].page;
+  }
+
+  throw createStructuredWorkerError(
+    "page_target_not_found",
+    "could not resolve a unique attached browser page; provide a stricter url, title_contains, or page_index",
+  );
+}
+
+async function openAttachedPage(request, deps, callback) {
+  const attachConfig = resolveAttachConfig(request);
+  if (!attachConfig) {
+    return openBrowserPage(String(request.url ?? ""), deps, callback);
+  }
+
+  let browser;
+  try {
+    browser = await deps.connectToBrowser(attachConfig.endpointURL);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw createStructuredWorkerError("browser_attach_failed", message);
+  }
+
+  const pageDescriptors = await describeAttachedPages(browser);
+  const page = selectAttachedPage(pageDescriptors, attachConfig);
+
+  // The real browser is user-owned; the short-lived worker process exits after
+  // one request, so we intentionally leave the remote browser running and let
+  // process teardown release the CDP connection.
+  return callback(page, undefined, {
+    attached: true,
+    browserKind: attachConfig.browserKind,
+    browserTransport: "cdp",
+    endpointURL: attachConfig.endpointURL,
+    source: "playwright_worker_cdp",
+  });
 }
 
 // healthResponse validates that the worker can load Playwright, start a browser,
@@ -116,14 +288,20 @@ export async function healthResponse(deps = defaultDependencies) {
   }
 }
 
-async function fetchPage(url, deps) {
-  return openBrowserPage(url, deps, async (page, response) => {
+async function fetchPage(request, deps) {
+  return openAttachedPage(request, deps, async (page, response, execution) => {
+    const fallbackURL = String(request?.url ?? "");
     const html = await page.content();
     const bodyText = await page.locator("body").innerText().catch(() => html);
-    const contentType = response.headers()["content-type"] ?? "text/html";
+    const contentType = response?.headers?.()["content-type"] ?? "text/html";
     return {
-      url: page.url() || url,
+      attached: execution.attached,
+      browserKind: execution.browserKind,
+      browserTransport: execution.browserTransport,
+      endpointURL: execution.endpointURL,
+      url: page.url() || fallbackURL,
       html,
+      source: execution.source,
       title: (await page.title()) || extractTitle(html, page.url()),
       textContent: normalizeText(bodyText),
       contentType,
@@ -131,8 +309,9 @@ async function fetchPage(url, deps) {
   });
 }
 
-async function buildStructuredDOM(url, deps) {
-  return openBrowserPage(url, deps, async (page) => {
+async function buildStructuredDOM(request, deps) {
+  return openAttachedPage(request, deps, async (page, _response, execution) => {
+    const fallbackURL = String(request?.url ?? "");
     const snapshot = await page.evaluate(() => ({
       headings: Array.from(document.querySelectorAll("h1, h2, h3")).map((node) => node.textContent?.trim()).filter(Boolean).slice(0, 20),
       links: Array.from(document.querySelectorAll("a[href]")).map((node) => node.textContent?.trim() || node.getAttribute("href") || "").filter(Boolean).slice(0, 20),
@@ -140,9 +319,13 @@ async function buildStructuredDOM(url, deps) {
       inputs: Array.from(document.querySelectorAll("input, textarea, select")).map((node) => node.getAttribute("name") || node.getAttribute("aria-label") || node.getAttribute("placeholder") || node.tagName.toLowerCase()).filter(Boolean).slice(0, 20),
     }));
     return {
-      url: page.url() || url,
+      attached: execution.attached,
+      browserKind: execution.browserKind,
+      browserTransport: execution.browserTransport,
+      endpointURL: execution.endpointURL,
+      url: page.url() || fallbackURL,
       title: (await page.title()) || extractTitle(await page.content(), page.url()),
-      source: "playwright_worker_browser",
+      source: execution.source,
       ...snapshot,
     };
   });
@@ -183,8 +366,9 @@ function validatePageActions(actions) {
   return null;
 }
 
-async function interactWithPage(url, actions, deps) {
-  return openBrowserPage(url, deps, async (page) => {
+async function interactWithPage(request, actions, deps) {
+  return openAttachedPage(request, deps, async (page, _response, execution) => {
+    const fallbackURL = String(request?.url ?? "");
     let applied = 0;
     for (const action of actions) {
       const type = String(action?.type ?? "").trim().toLowerCase();
@@ -225,13 +409,32 @@ async function interactWithPage(url, actions, deps) {
     const html = await page.content();
     const bodyText = await page.locator("body").innerText().catch(() => html);
     return {
-      url: page.url() || url,
+      attached: execution.attached,
+      browserKind: execution.browserKind,
+      browserTransport: execution.browserTransport,
+      endpointURL: execution.endpointURL,
+      url: page.url() || fallbackURL,
       title: (await page.title()) || extractTitle(html, page.url()),
       text_content: normalizeText(bodyText),
       actions_applied: applied,
-      source: "playwright_worker_browser",
+      source: execution.source,
     };
   });
+}
+
+async function executeBrowserRequest(request, deps, callback) {
+  try {
+    return {
+      ok: true,
+      result: await callback(),
+    };
+  } catch (error) {
+    const structured = structuredWorkerErrorResponse(error);
+    if (structured) {
+      return structured;
+    }
+    throw error;
+  }
 }
 
 // handleRequest keeps the worker protocol stable for the Go sidecar runtime and
@@ -241,46 +444,49 @@ export async function handleRequest(request, deps = defaultDependencies) {
     case "health":
       return healthResponse(deps);
     case "page_read": {
-      const page = await fetchPage(String(request.url ?? ""), deps);
-      return {
-        ok: true,
-        result: {
+      return executeBrowserRequest(request, deps, async () => {
+        const page = await fetchPage(request, deps);
+        return {
+          attached: page.attached,
+          browser_kind: page.browserKind,
+          browser_transport: page.browserTransport,
+          endpoint_url: page.endpointURL,
           url: page.url,
           title: page.title,
           text_content: page.textContent,
           mime_type: page.contentType,
           text_type: page.contentType,
-          source: "playwright_worker_browser",
-        },
-      };
+          source: page.source,
+        };
+      });
     }
     case "page_search": {
-      const page = await fetchPage(String(request.url ?? ""), deps);
-      const normalizedQuery = String(request.query ?? "").trim().toLowerCase();
-      const rawLimit = Number(request.limit ?? 0);
-      const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.floor(rawLimit) : 5;
-      const segments = page.textContent
-        .split(/[.!?。！？]\s*/)
-        .map((segment) => segment.trim())
-        .filter(Boolean);
-      const allMatches = normalizedQuery === "" ? [] : segments.filter((segment) => segment.toLowerCase().includes(normalizedQuery));
-      const matches = allMatches.slice(0, limit);
-      return {
-        ok: true,
-        result: {
+      return executeBrowserRequest(request, deps, async () => {
+        const page = await fetchPage(request, deps);
+        const normalizedQuery = String(request.query ?? "").trim().toLowerCase();
+        const rawLimit = Number(request.limit ?? 0);
+        const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.floor(rawLimit) : 5;
+        const segments = page.textContent
+          .split(/[.!?。！？]\s*/)
+          .map((segment) => segment.trim())
+          .filter(Boolean);
+        const allMatches = normalizedQuery === "" ? [] : segments.filter((segment) => segment.toLowerCase().includes(normalizedQuery));
+        const matches = allMatches.slice(0, limit);
+        return {
+          attached: page.attached,
+          browser_kind: page.browserKind,
+          browser_transport: page.browserTransport,
+          endpoint_url: page.endpointURL,
           url: page.url,
           query: String(request.query ?? ""),
           match_count: allMatches.length,
           matches,
-          source: "playwright_worker_browser",
-        },
-      };
+          source: page.source,
+        };
+      });
     }
     case "structured_dom": {
-      return {
-        ok: true,
-        result: await buildStructuredDOM(String(request.url ?? ""), deps),
-      };
+      return executeBrowserRequest(request, deps, async () => buildStructuredDOM(request, deps));
     }
     case "page_interact": {
       const actions = Array.isArray(request.actions) ? request.actions : [];
@@ -288,14 +494,7 @@ export async function handleRequest(request, deps = defaultDependencies) {
       if (validationError) {
         return validationError;
       }
-      return {
-        ok: true,
-        result: await interactWithPage(
-          String(request.url ?? ""),
-          actions,
-          deps,
-        ),
-      };
+      return executeBrowserRequest(request, deps, async () => interactWithPage(request, actions, deps));
     }
     default:
       return {

--- a/workers/playwright-worker/src/index.js
+++ b/workers/playwright-worker/src/index.js
@@ -192,6 +192,20 @@ function serializeExecutionMetadata(execution) {
   };
 }
 
+function detectConnectedBrowserKind(versionString) {
+  const normalized = normalizeOptionalString(versionString)?.toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized.includes("edge")) {
+    return "edge";
+  }
+  if (normalized.includes("chrome")) {
+    return "chrome";
+  }
+  return undefined;
+}
+
 function isLoopbackHostname(hostname) {
   const normalized = String(hostname ?? "").trim().toLowerCase().replace(/^\[/u, "").replace(/\]$/u, "");
   if (normalized === "localhost" || normalized === "::1") {
@@ -325,6 +339,14 @@ async function connectAttachedBrowser(request, deps) {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw createStructuredWorkerError("browser_attach_failed", message);
+  }
+
+  const connectedBrowserKind = detectConnectedBrowserKind(await browser?.version?.().catch(() => ""));
+  if (attachConfig.browserKind && connectedBrowserKind && attachConfig.browserKind !== connectedBrowserKind) {
+    throw createStructuredWorkerError(
+      "browser_kind_mismatch",
+      `attach.browser_kind '${attachConfig.browserKind}' did not match connected browser '${connectedBrowserKind}'`,
+    );
   }
 
   return {

--- a/workers/playwright-worker/src/index.js
+++ b/workers/playwright-worker/src/index.js
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 import path from "node:path";
 import { stdin as input, stdout as output, stderr as errorOutput } from "node:process";
 import { fileURLToPath } from "node:url";
@@ -147,6 +148,34 @@ function normalizeComparableURL(url) {
   }
 }
 
+function isLoopbackHostname(hostname) {
+  const normalized = String(hostname ?? "").trim().toLowerCase().replace(/^\[/u, "").replace(/\]$/u, "");
+  if (normalized === "localhost" || normalized === "::1") {
+    return true;
+  }
+  return isIP(normalized) === 4 && normalized.startsWith("127.");
+}
+
+// normalizeAttachEndpointURL keeps the real-browser attach path bound to local
+// debugging targets, so issue-2 does not become a generic outbound CDP dialer.
+function normalizeAttachEndpointURL(rawEndpointURL) {
+  const endpointURL = normalizeOptionalString(rawEndpointURL) ?? defaultCDPEndpointURL;
+  let parsedURL;
+  try {
+    parsedURL = new URL(endpointURL);
+  } catch {
+    throw createStructuredWorkerError("invalid_input", "attach.endpoint_url must be a valid URL");
+  }
+
+  if (!["http:", "https:", "ws:", "wss:"].includes(parsedURL.protocol)) {
+    throw createStructuredWorkerError("invalid_input", "attach.endpoint_url must use http, https, ws, or wss");
+  }
+  if (!isLoopbackHostname(parsedURL.hostname)) {
+    throw createStructuredWorkerError("invalid_input", "attach.endpoint_url must target a loopback host");
+  }
+  return endpointURL;
+}
+
 // resolveAttachConfig keeps the worker-side attach contract additive so the Go
 // runtime can keep using the legacy launch flow until issue-3 wiring lands.
 function resolveAttachConfig(request) {
@@ -174,7 +203,7 @@ function resolveAttachConfig(request) {
 
   return {
     browserKind,
-    endpointURL: normalizeOptionalString(attach.endpoint_url) ?? defaultCDPEndpointURL,
+    endpointURL: normalizeAttachEndpointURL(attach.endpoint_url),
     pageIndex,
     targetTitleContains: normalizeOptionalString(target.title_contains)?.toLowerCase(),
     targetURL: normalizeComparableURL(target.url ?? request?.url),

--- a/workers/playwright-worker/src/index.js
+++ b/workers/playwright-worker/src/index.js
@@ -6,7 +6,18 @@ import { fileURLToPath } from "node:url";
 export const manifest = {
   worker_name: "playwright_worker",
   transport: ["stdio", "jsonrpc"],
-  capabilities: ["page_read", "page_search", "page_interact", "structured_dom"],
+  capabilities: [
+    "page_read",
+    "page_search",
+    "page_interact",
+    "structured_dom",
+    "browser_attach_current",
+    "browser_snapshot",
+    "browser_navigate",
+    "browser_tabs_list",
+    "browser_tab_focus",
+    "browser_interact",
+  ],
 };
 
 const browserTimeoutMS = 15000;
@@ -148,6 +159,34 @@ function normalizeComparableURL(url) {
   }
 }
 
+function createAttachedExecution(attachConfig) {
+  return {
+    attached: true,
+    browserKind: attachConfig.browserKind,
+    browserTransport: "cdp",
+    endpointURL: attachConfig.endpointURL,
+    source: "playwright_worker_cdp",
+  };
+}
+
+function requireAttachConfig(request) {
+  const attachConfig = resolveAttachConfig(request);
+  if (!attachConfig) {
+    throw createStructuredWorkerError("invalid_input", "attach is required for browser_* actions");
+  }
+  return attachConfig;
+}
+
+function serializeExecutionMetadata(execution) {
+  return {
+    attached: execution.attached,
+    browser_kind: execution.browserKind,
+    browser_transport: execution.browserTransport,
+    endpoint_url: execution.endpointURL,
+    source: execution.source,
+  };
+}
+
 function isLoopbackHostname(hostname) {
   const normalized = String(hostname ?? "").trim().toLowerCase().replace(/^\[/u, "").replace(/\]$/u, "");
   if (normalized === "localhost" || normalized === "::1") {
@@ -259,11 +298,11 @@ function selectAttachedPage(pageDescriptors, attachConfig) {
     if (attachConfig.pageIndex >= candidates.length) {
       throw createStructuredWorkerError("page_target_not_found", `attach.target.page_index ${attachConfig.pageIndex} is out of range`);
     }
-    return candidates[attachConfig.pageIndex].page;
+    return candidates[attachConfig.pageIndex];
   }
 
   if (candidates.length === 1) {
-    return candidates[0].page;
+    return candidates[0];
   }
 
   throw createStructuredWorkerError(
@@ -272,11 +311,8 @@ function selectAttachedPage(pageDescriptors, attachConfig) {
   );
 }
 
-async function openAttachedPage(request, deps, callback) {
-  const attachConfig = resolveAttachConfig(request);
-  if (!attachConfig) {
-    return openBrowserPage(String(request.url ?? ""), deps, callback);
-  }
+async function connectAttachedBrowser(request, deps) {
+  const attachConfig = requireAttachConfig(request);
 
   let browser;
   try {
@@ -286,19 +322,48 @@ async function openAttachedPage(request, deps, callback) {
     throw createStructuredWorkerError("browser_attach_failed", message);
   }
 
-  const pageDescriptors = await describeAttachedPages(browser);
-  const page = selectAttachedPage(pageDescriptors, attachConfig);
+  return {
+    attachConfig,
+    browser,
+    execution: createAttachedExecution(attachConfig),
+    pageDescriptors: await describeAttachedPages(browser),
+  };
+}
 
-  // The real browser is user-owned; the short-lived worker process exits after
-  // one request, so we intentionally leave the remote browser running and let
-  // process teardown release the CDP connection.
-  return callback(page, undefined, {
-    attached: true,
-    browserKind: attachConfig.browserKind,
-    browserTransport: "cdp",
-    endpointURL: attachConfig.endpointURL,
-    source: "playwright_worker_cdp",
+async function withAttachedBrowser(request, deps, callback) {
+  return callback(await connectAttachedBrowser(request, deps));
+}
+
+async function withAttachedPage(request, deps, callback) {
+  return withAttachedBrowser(request, deps, async (session) => {
+    const descriptor = selectAttachedPage(session.pageDescriptors, session.attachConfig);
+    return callback(descriptor, session.execution);
   });
+}
+
+async function openAttachedPage(request, deps, callback) {
+  if (!request?.attach) {
+    return openBrowserPage(String(request.url ?? ""), deps, callback);
+  }
+
+  return withAttachedPage(request, deps, async (descriptor, execution) => {
+    // The real browser is user-owned; the short-lived worker process exits after
+    // one request, so we intentionally leave the remote browser running and let
+    // process teardown release the CDP connection.
+    return callback(descriptor.page, undefined, {
+      ...execution,
+      pageIndex: descriptor.index,
+    });
+  });
+}
+
+function serializeAttachedPageSelection(descriptor, execution) {
+  return {
+    ...serializeExecutionMetadata(execution),
+    page_index: descriptor.index,
+    title: descriptor.title,
+    url: descriptor.url,
+  };
 }
 
 // healthResponse validates that the worker can load Playwright, start a browser,
@@ -363,6 +428,43 @@ async function buildStructuredDOM(request, deps) {
       ...snapshot,
     };
   });
+}
+
+async function buildBrowserSnapshot(request, deps) {
+  return withAttachedPage(request, deps, async (descriptor, execution) => {
+    const page = descriptor.page;
+    const html = await page.content();
+    const bodyText = await page.locator("body").innerText().catch(() => html);
+    const snapshot = await page.evaluate(() => ({
+      headings: Array.from(document.querySelectorAll("h1, h2, h3")).map((node) => node.textContent?.trim()).filter(Boolean).slice(0, 20),
+      links: Array.from(document.querySelectorAll("a[href]")).map((node) => node.textContent?.trim() || node.getAttribute("href") || "").filter(Boolean).slice(0, 20),
+      buttons: Array.from(document.querySelectorAll("button, [role='button']")).map((node) => node.textContent?.trim()).filter(Boolean).slice(0, 20),
+      inputs: Array.from(document.querySelectorAll("input, textarea, select")).map((node) => node.getAttribute("name") || node.getAttribute("aria-label") || node.getAttribute("placeholder") || node.tagName.toLowerCase()).filter(Boolean).slice(0, 20),
+    }));
+    return {
+      ...serializeAttachedPageSelection(descriptor, execution),
+      text_content: normalizeText(bodyText),
+      ...snapshot,
+    };
+  });
+}
+
+async function attachCurrentBrowserPage(request, deps) {
+  return withAttachedPage(request, deps, async (descriptor, execution) => ({
+    ...serializeAttachedPageSelection(descriptor, execution),
+  }));
+}
+
+async function listBrowserTabs(request, deps) {
+  return withAttachedBrowser(request, deps, async ({ execution, pageDescriptors }) => ({
+    ...serializeExecutionMetadata(execution),
+    tab_count: pageDescriptors.length,
+    tabs: pageDescriptors.map((descriptor) => ({
+      page_index: descriptor.index,
+      title: descriptor.title,
+      url: descriptor.url,
+    })),
+  }));
 }
 
 function pageActionTarget(page, selector) {
@@ -521,6 +623,15 @@ export async function handleRequest(request, deps = defaultDependencies) {
     }
     case "structured_dom": {
       return executeBrowserRequest(request, deps, async () => buildStructuredDOM(request, deps));
+    }
+    case "browser_attach_current": {
+      return executeBrowserRequest(request, deps, async () => attachCurrentBrowserPage(request, deps));
+    }
+    case "browser_snapshot": {
+      return executeBrowserRequest(request, deps, async () => buildBrowserSnapshot(request, deps));
+    }
+    case "browser_tabs_list": {
+      return executeBrowserRequest(request, deps, async () => listBrowserTabs(request, deps));
     }
     case "page_interact": {
       const actions = Array.isArray(request.actions) ? request.actions : [];

--- a/workers/playwright-worker/src/index.js
+++ b/workers/playwright-worker/src/index.js
@@ -93,22 +93,27 @@ async function closeResources(context, browser) {
   }
 }
 
+async function navigatePage(page, url) {
+  const response = await page.goto(url, {
+    waitUntil: "networkidle",
+    timeout: browserTimeoutMS,
+  });
+  if (!response) {
+    throw new Error("navigation_failed");
+  }
+  if (!response.ok()) {
+    throw new Error(`http_${response.status()}`);
+  }
+  return response;
+}
+
 async function openBrowserPage(url, deps, callback) {
   const browser = await deps.launchBrowser();
   let context;
   try {
     context = await browser.newContext({ userAgent: workerUserAgent });
     const page = await context.newPage();
-    const response = await page.goto(url, {
-      waitUntil: "networkidle",
-      timeout: browserTimeoutMS,
-    });
-    if (!response) {
-      throw new Error("navigation_failed");
-    }
-    if (!response.ok()) {
-      throw new Error(`http_${response.status()}`);
-    }
+    const response = await navigatePage(page, url);
     return await callback(page, response, {
       attached: false,
       browserKind: undefined,
@@ -366,6 +371,32 @@ function serializeAttachedPageSelection(descriptor, execution) {
   };
 }
 
+function requireTopLevelURL(request, actionName) {
+  const url = normalizeOptionalString(request?.url);
+  if (!url) {
+    throw createStructuredWorkerError("invalid_input", `${actionName} requires a top-level url`);
+  }
+  return url;
+}
+
+async function summarizeLoadedPage(page, fallbackURL, execution, response) {
+  const html = await page.content();
+  const bodyText = await page.locator("body").innerText().catch(() => html);
+  const contentType = response?.headers?.()["content-type"] ?? "text/html";
+  return {
+    attached: execution.attached,
+    browserKind: execution.browserKind,
+    browserTransport: execution.browserTransport,
+    endpointURL: execution.endpointURL,
+    url: page.url() || fallbackURL,
+    html,
+    source: execution.source,
+    title: (await page.title()) || extractTitle(html, page.url()),
+    textContent: normalizeText(bodyText),
+    contentType,
+  };
+}
+
 // healthResponse validates that the worker can load Playwright, start a browser,
 // and create a fresh page before the Go runtime marks the sidecar as ready.
 export async function healthResponse(deps = defaultDependencies) {
@@ -389,22 +420,7 @@ export async function healthResponse(deps = defaultDependencies) {
 
 async function fetchPage(request, deps) {
   return openAttachedPage(request, deps, async (page, response, execution) => {
-    const fallbackURL = String(request?.url ?? "");
-    const html = await page.content();
-    const bodyText = await page.locator("body").innerText().catch(() => html);
-    const contentType = response?.headers?.()["content-type"] ?? "text/html";
-    return {
-      attached: execution.attached,
-      browserKind: execution.browserKind,
-      browserTransport: execution.browserTransport,
-      endpointURL: execution.endpointURL,
-      url: page.url() || fallbackURL,
-      html,
-      source: execution.source,
-      title: (await page.title()) || extractTitle(html, page.url()),
-      textContent: normalizeText(bodyText),
-      contentType,
-    };
+    return summarizeLoadedPage(page, String(request?.url ?? ""), execution, response);
   });
 }
 
@@ -465,6 +481,29 @@ async function listBrowserTabs(request, deps) {
       url: descriptor.url,
     })),
   }));
+}
+
+async function focusBrowserTab(request, deps) {
+  return withAttachedPage(request, deps, async (descriptor, execution) => {
+    await descriptor.page.bringToFront();
+    return serializeAttachedPageSelection(descriptor, execution);
+  });
+}
+
+async function navigateBrowserPage(request, deps) {
+  const destinationURL = requireTopLevelURL(request, "browser_navigate");
+  return withAttachedPage(request, deps, async (descriptor, execution) => {
+    const response = await navigatePage(descriptor.page, destinationURL);
+    const summary = await summarizeLoadedPage(descriptor.page, destinationURL, execution, response);
+    return {
+      ...serializeAttachedPageSelection(descriptor, execution),
+      url: summary.url,
+      title: summary.title,
+      text_content: summary.textContent,
+      mime_type: summary.contentType,
+      text_type: summary.contentType,
+    };
+  });
 }
 
 function pageActionTarget(page, selector) {
@@ -558,6 +597,11 @@ async function interactWithPage(request, actions, deps) {
   });
 }
 
+async function interactWithAttachedBrowserPage(request, actions, deps) {
+  requireAttachConfig(request);
+  return interactWithPage(request, actions, deps);
+}
+
 async function executeBrowserRequest(request, deps, callback) {
   try {
     return {
@@ -632,6 +676,20 @@ export async function handleRequest(request, deps = defaultDependencies) {
     }
     case "browser_tabs_list": {
       return executeBrowserRequest(request, deps, async () => listBrowserTabs(request, deps));
+    }
+    case "browser_navigate": {
+      return executeBrowserRequest(request, deps, async () => navigateBrowserPage(request, deps));
+    }
+    case "browser_tab_focus": {
+      return executeBrowserRequest(request, deps, async () => focusBrowserTab(request, deps));
+    }
+    case "browser_interact": {
+      const actions = Array.isArray(request.actions) ? request.actions : [];
+      const validationError = validatePageActions(actions);
+      if (validationError) {
+        return validationError;
+      }
+      return executeBrowserRequest(request, deps, async () => interactWithAttachedBrowserPage(request, actions, deps));
     }
     case "page_interact": {
       const actions = Array.isArray(request.actions) ? request.actions : [];

--- a/workers/playwright-worker/src/index.js
+++ b/workers/playwright-worker/src/index.js
@@ -206,7 +206,7 @@ function resolveAttachConfig(request) {
     endpointURL: normalizeAttachEndpointURL(attach.endpoint_url),
     pageIndex,
     targetTitleContains: normalizeOptionalString(target.title_contains)?.toLowerCase(),
-    targetURL: normalizeComparableURL(target.url ?? request?.url),
+    targetURL: normalizeComparableURL(target.url),
   };
 }
 

--- a/workers/playwright-worker/src/index.js
+++ b/workers/playwright-worker/src/index.js
@@ -209,16 +209,21 @@ function selectAttachedPage(pageDescriptors, attachConfig) {
   let candidates = pageDescriptors;
   if (attachConfig.targetURL) {
     const exactURLMatches = pageDescriptors.filter((descriptor) => descriptor.url === attachConfig.targetURL);
-    if (exactURLMatches.length > 0) {
-      candidates = exactURLMatches;
+    if (exactURLMatches.length === 0) {
+      throw createStructuredWorkerError("page_target_not_found", `no attached browser page matched url '${attachConfig.targetURL}'`);
     }
+    candidates = exactURLMatches;
   }
 
   if (attachConfig.targetTitleContains) {
     const titleMatches = candidates.filter((descriptor) => descriptor.title.toLowerCase().includes(attachConfig.targetTitleContains));
-    if (titleMatches.length > 0) {
-      candidates = titleMatches;
+    if (titleMatches.length === 0) {
+      throw createStructuredWorkerError(
+        "page_target_not_found",
+        `no attached browser page matched title_contains '${attachConfig.targetTitleContains}'`,
+      );
     }
+    candidates = titleMatches;
   }
 
   if (attachConfig.pageIndex !== undefined) {

--- a/workers/playwright-worker/src/index.test.js
+++ b/workers/playwright-worker/src/index.test.js
@@ -19,6 +19,9 @@ function createPage(overrides = {}) {
     async content() {
       return overrides.html ?? "<html><head><title>Demo Page</title></head><body>Hello world. Search target. Another target.</body></html>";
     },
+    async bringToFront() {
+      actionLog.push({ action: "bringToFront" });
+    },
     async evaluate() {
       return overrides.snapshot ?? {
         headings: ["Heading A"],
@@ -410,6 +413,99 @@ test("browser_tabs_list reports attached browser tabs with stable indexes", asyn
   ]);
 });
 
+test("browser_tab_focus brings the selected tab to the front", async () => {
+  const actionLog = [];
+  const response = await handleRequest({
+    action: "browser_tab_focus",
+    attach: {
+      browser_kind: "edge",
+      target: {
+        page_index: 1,
+      },
+    },
+  }, createDeps({
+    actionLog,
+    connectedPages: [
+      createPage({ actionLog, currentURL: "https://example.com/one", title: "One" }),
+      createPage({ actionLog, currentURL: "https://example.com/two", title: "Two" }),
+    ],
+  }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.page_index, 1);
+  assert.equal(response.result.title, "Two");
+  assert.deepEqual(actionLog.map((entry) => entry.action), ["bringToFront"]);
+});
+
+test("browser_navigate drives the attached tab to a new url", async () => {
+  const lifecycle = [];
+  const navigationLog = [];
+  const response = await handleRequest({
+    action: "browser_navigate",
+    url: "https://example.com/next",
+    attach: {
+      browser_kind: "chrome",
+      target: {
+        page_index: 0,
+      },
+    },
+  }, createDeps({
+    lifecycle,
+    navigationLog,
+    connectedPages: [createPage({
+      navigationLog,
+      currentURL: "https://example.com/current",
+      gotoURL: "https://example.com/next",
+      title: "Next Page",
+      bodyText: "Navigation complete",
+    })],
+  }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.attached, true);
+  assert.equal(response.result.page_index, 0);
+  assert.equal(response.result.url, "https://example.com/next");
+  assert.equal(response.result.title, "Next Page");
+  assert.equal(response.result.text_content, "Navigation complete");
+  assert.deepEqual(lifecycle, ["connect:http://127.0.0.1:9222"]);
+  assert.deepEqual(navigationLog, [{ action: "goto", url: "https://example.com/next" }]);
+});
+
+test("browser_interact keeps real-browser actions on the attached tab", async () => {
+  const actionLog = [];
+  const navigationLog = [];
+  const response = await handleRequest({
+    action: "browser_interact",
+    attach: {
+      browser_kind: "edge",
+      target: {
+        page_index: 0,
+      },
+    },
+    actions: [
+      { type: "click", selector: "button.submit" },
+      { type: "fill", selector: "input[name=email]", value: "demo@example.com" },
+    ],
+  }, createDeps({
+    actionLog,
+    navigationLog,
+    connectedPages: [createPage({
+      actionLog,
+      navigationLog,
+      currentURL: "https://example.com/form",
+      title: "Connected Form",
+      bodyText: "Interaction complete",
+    })],
+  }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.attached, true);
+  assert.equal(response.result.actions_applied, 2);
+  assert.equal(response.result.source, "playwright_worker_cdp");
+  assert.deepEqual(actionLog.map((entry) => entry.action), ["click", "fill"]);
+  assert.deepEqual(navigationLog, []);
+});
+
 test("page_read ignores top-level request url unless attach.target.url is explicit", async () => {
   const singlePage = await handleRequest({
     action: "page_read",
@@ -518,6 +614,19 @@ test("page_read reports invalid attach modes and browser kinds without throwing"
   }, createDeps());
   assert.equal(invalidEndpoint.ok, false);
   assert.equal(invalidEndpoint.error.code, "invalid_input");
+
+  const missingAttach = await handleRequest({
+    action: "browser_attach_current",
+  }, createDeps());
+  assert.equal(missingAttach.ok, false);
+  assert.equal(missingAttach.error.code, "invalid_input");
+
+  const missingNavigationURL = await handleRequest({
+    action: "browser_navigate",
+    attach: { browser_kind: "chrome" },
+  }, createDeps());
+  assert.equal(missingNavigationURL.ok, false);
+  assert.equal(missingNavigationURL.error.code, "invalid_input");
 });
 
 test("page_read reports attached browser resolution failures as structured errors", async () => {

--- a/workers/playwright-worker/src/index.test.js
+++ b/workers/playwright-worker/src/index.test.js
@@ -88,6 +88,9 @@ function createDeps(overrides = {}) {
         throw overrides.connectError;
       }
       return {
+        async version() {
+          return overrides.browserVersion ?? "Chrome/125.0.0.0";
+        },
         contexts() {
           return overrides.connectedContexts ?? [{
             pages() {
@@ -370,6 +373,7 @@ test("browser_snapshot returns structured content for the attached tab", async (
       },
     },
   }, createDeps({
+    browserVersion: "Microsoft Edge/125.0.0.0",
     connectedPages: [createPage({
       currentURL: "https://example.com/current",
       title: "Snapshot Page",
@@ -425,6 +429,7 @@ test("browser_tab_focus brings the selected tab to the front", async () => {
     },
   }, createDeps({
     actionLog,
+    browserVersion: "Microsoft Edge/125.0.0.0",
     connectedPages: [
       createPage({ actionLog, currentURL: "https://example.com/one", title: "One" }),
       createPage({ actionLog, currentURL: "https://example.com/two", title: "Two" }),
@@ -489,6 +494,7 @@ test("browser_interact keeps real-browser actions on the attached tab", async ()
   }, createDeps({
     actionLog,
     navigationLog,
+    browserVersion: "Microsoft Edge/125.0.0.0",
     connectedPages: [createPage({
       actionLog,
       navigationLog,
@@ -555,6 +561,7 @@ test("page_read resolves attached pages by url and title narrowing", async () =>
       },
     },
   }, createDeps({
+    browserVersion: "Microsoft Edge/125.0.0.0",
     connectedPages: [
       createPage({ currentURL: "https://example.com/docs", title: "Background tab", bodyText: "Ignore me" }),
       createPage({ currentURL: "https://example.com/docs", title: "Target Docs", bodyText: "Selected tab" }),
@@ -581,6 +588,16 @@ test("page_read reports invalid attach modes and browser kinds without throwing"
   }, createDeps());
   assert.equal(unsupportedBrowser.ok, false);
   assert.equal(unsupportedBrowser.error.code, "unsupported_browser_kind");
+
+  const mismatchedBrowser = await handleRequest({
+    action: "browser_attach_current",
+    attach: { browser_kind: "edge" },
+  }, createDeps({
+    browserVersion: "Chrome/125.0.0.0",
+    connectedPages: [createPage({ currentURL: "https://example.com/current", title: "Current" })],
+  }));
+  assert.equal(mismatchedBrowser.ok, false);
+  assert.equal(mismatchedBrowser.error.code, "browser_kind_mismatch");
 
   const invalidPageIndex = await handleRequest({
     action: "page_read",
@@ -711,6 +728,7 @@ test("page_interact uses attached tabs without forcing a new navigation", async 
   }, createDeps({
     actionLog,
     navigationLog,
+    browserVersion: "Microsoft Edge/125.0.0.0",
     connectedPages: [createPage({
       actionLog,
       navigationLog,
@@ -736,6 +754,7 @@ test("structured_dom can read an attached page chosen by page index", async () =
       target: { page_index: 1 },
     },
   }, createDeps({
+    browserVersion: "Microsoft Edge/125.0.0.0",
     connectedPages: [
       createPage({ currentURL: "https://example.com/one", title: "One", snapshot: { headings: ["Ignore"], links: [], buttons: [], inputs: [] } }),
       createPage({ currentURL: "https://example.com/two", title: "Two", snapshot: { headings: ["Chosen"], links: ["Docs"], buttons: ["Save"], inputs: ["email"] } }),

--- a/workers/playwright-worker/src/index.test.js
+++ b/workers/playwright-worker/src/index.test.js
@@ -13,6 +13,7 @@ function createResponse(overrides = {}) {
 
 function createPage(overrides = {}) {
   const actionLog = overrides.actionLog ?? [];
+  const navigationLog = overrides.navigationLog ?? [];
   const page = {
     currentURL: overrides.currentURL ?? "https://example.com/final",
     async content() {
@@ -27,8 +28,11 @@ function createPage(overrides = {}) {
       };
     },
     goto: async (url) => {
+      navigationLog.push({ action: "goto", url });
       page.currentURL = overrides.gotoURL ?? url;
-      return overrides.response ?? createResponse();
+      return Object.prototype.hasOwnProperty.call(overrides, "response")
+        ? overrides.response
+        : createResponse();
     },
     locator: (selector) => ({
       async innerText() {
@@ -73,7 +77,23 @@ function createPage(overrides = {}) {
 function createDeps(overrides = {}) {
   const page = overrides.page ?? createPage(overrides);
   const lifecycle = overrides.lifecycle ?? [];
+  const connectedPages = overrides.connectedPages ?? [page];
   return {
+    async connectToBrowser(endpointURL) {
+      lifecycle.push(`connect:${endpointURL}`);
+      if (overrides.connectError) {
+        throw overrides.connectError;
+      }
+      return {
+        contexts() {
+          return overrides.connectedContexts ?? [{
+            pages() {
+              return connectedPages;
+            },
+          }];
+        },
+      };
+    },
     async launchBrowser() {
       lifecycle.push("launch");
       return {
@@ -126,6 +146,15 @@ test("health still closes browser when context cleanup fails", async () => {
   assert.deepEqual(lifecycle, ["launch", "newContext", "newPage", "context.close", "browser.close"]);
 });
 
+test("handleRequest delegates health requests through the worker switch", async () => {
+  const lifecycle = [];
+  const response = await handleRequest({ action: "health" }, createDeps({ lifecycle }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.worker_name, "playwright_worker");
+  assert.deepEqual(lifecycle, ["launch", "newContext", "newPage", "context.close", "browser.close"]);
+});
+
 test("page_read returns normalized page metadata", async () => {
   const response = await handleRequest({ action: "page_read", url: "https://example.com" }, createDeps({
     bodyText: "Hello world from browser",
@@ -140,6 +169,17 @@ test("page_read returns normalized page metadata", async () => {
   assert.equal(response.result.source, "playwright_worker_browser");
 });
 
+test("page_read uses the HTML title tag when Playwright title lookup is empty", async () => {
+  const response = await handleRequest({ action: "page_read", url: "https://example.com" }, createDeps({
+    bodyText: "Hello world from browser",
+    html: "<html><head><title>Fallback Demo</title></head><body>Hello world</body></html>",
+    title: "",
+  }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.title, "Fallback Demo");
+});
+
 test("page_search returns bounded matches", async () => {
   const response = await handleRequest({ action: "page_search", url: "https://example.com", query: "target", limit: 1 }, createDeps({
     bodyText: "First target. Second target. Third miss.",
@@ -148,6 +188,40 @@ test("page_search returns bounded matches", async () => {
   assert.equal(response.ok, true);
   assert.equal(response.result.match_count, 2);
   assert.deepEqual(response.result.matches, ["First target"]);
+});
+
+test("page_read falls back to hostname and untitled titles when needed", async () => {
+  const hostnameFallback = await handleRequest({ action: "page_read", url: "https://example.com/path" }, createDeps({
+    bodyText: "No explicit title",
+    html: "<html><body>No title tag</body></html>",
+    title: "",
+  }));
+  assert.equal(hostnameFallback.ok, true);
+  assert.equal(hostnameFallback.result.title, "example.com");
+
+  const untitledFallback = await handleRequest({ action: "page_read", url: "notaurl" }, createDeps({
+    bodyText: "No explicit title",
+    currentURL: "notaurl",
+    gotoURL: "notaurl",
+    html: "<html><body>No title tag</body></html>",
+    title: "",
+  }));
+  assert.equal(untitledFallback.ok, true);
+  assert.equal(untitledFallback.result.title, "untitled page");
+});
+
+test("page_read keeps launch-path transport failures loud", async () => {
+  await assert.rejects(
+    () => handleRequest({ action: "page_read", url: "https://example.com" }, createDeps({ response: null })),
+    /navigation_failed/,
+  );
+
+  await assert.rejects(
+    () => handleRequest({ action: "page_read", url: "https://example.com" }, createDeps({
+      response: createResponse({ ok: false, status: 503 }),
+    })),
+    /http_503/,
+  );
 });
 
 test("structured_dom returns page snapshot", async () => {
@@ -183,6 +257,24 @@ test("page_interact applies actions and returns updated content", async () => {
   assert.deepEqual(actionLog.map((entry) => entry.action), ["click", "fill", "waitForTimeout"]);
 });
 
+test("page_interact supports press, check, uncheck, and selector waits", async () => {
+  const actionLog = [];
+  const response = await handleRequest({
+    action: "page_interact",
+    url: "https://example.com/settings",
+    actions: [
+      { type: "press", selector: "input[name=email]", key: "Tab" },
+      { type: "check", selector: "input[name=terms]" },
+      { type: "uncheck", selector: "input[name=marketing]" },
+      { type: "wait_for", selector: "div.ready" },
+    ],
+  }, createDeps({ actionLog, bodyText: "Interaction complete" }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.actions_applied, 4);
+  assert.deepEqual(actionLog.map((entry) => entry.action), ["press", "check", "uncheck", "waitFor"]);
+});
+
 test("page_interact rejects selector actions without selectors", async () => {
   const response = await handleRequest({
     action: "page_interact",
@@ -195,6 +287,205 @@ test("page_interact rejects selector actions without selectors", async () => {
   assert.equal(response.ok, false);
   assert.equal(response.error.code, "invalid_input");
   assert.match(response.error.message, /selector is required/);
+
+  const waitForSelector = await handleRequest({
+    action: "page_interact",
+    url: "https://example.com",
+    actions: [
+      { type: "wait_for", selector: "" },
+    ],
+  }, createDeps());
+  assert.equal(waitForSelector.ok, false);
+  assert.equal(waitForSelector.error.code, "invalid_input");
+});
+
+test("page_read can attach to a real browser page over CDP", async () => {
+  const lifecycle = [];
+  const navigationLog = [];
+  const response = await handleRequest({
+    action: "page_read",
+    url: "https://example.com/current",
+    attach: {
+      browser_kind: "chrome",
+      target: {
+        url: "https://example.com/current",
+      },
+    },
+  }, createDeps({
+    lifecycle,
+    navigationLog,
+    connectedPages: [createPage({
+      navigationLog,
+      currentURL: "https://example.com/current",
+      title: "Connected Page",
+      bodyText: "Attached browser content",
+    })],
+  }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.attached, true);
+  assert.equal(response.result.browser_kind, "chrome");
+  assert.equal(response.result.browser_transport, "cdp");
+  assert.equal(response.result.endpoint_url, "http://127.0.0.1:9222");
+  assert.equal(response.result.source, "playwright_worker_cdp");
+  assert.equal(response.result.title, "Connected Page");
+  assert.equal(response.result.text_content, "Attached browser content");
+  assert.deepEqual(lifecycle, ["connect:http://127.0.0.1:9222"]);
+  assert.deepEqual(navigationLog, []);
+});
+
+test("page_read resolves attached pages by url and title narrowing", async () => {
+  const response = await handleRequest({
+    action: "page_read",
+    url: "https://example.com/docs",
+    attach: {
+      endpoint_url: "http://127.0.0.1:9223",
+      browser_kind: "edge",
+      target: {
+        url: "https://example.com/docs",
+        title_contains: "target docs",
+      },
+    },
+  }, createDeps({
+    connectedPages: [
+      createPage({ currentURL: "https://example.com/docs", title: "Background tab", bodyText: "Ignore me" }),
+      createPage({ currentURL: "https://example.com/docs", title: "Target Docs", bodyText: "Selected tab" }),
+    ],
+  }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.title, "Target Docs");
+  assert.equal(response.result.text_content, "Selected tab");
+  assert.equal(response.result.endpoint_url, "http://127.0.0.1:9223");
+});
+
+test("page_read reports invalid attach modes and browser kinds without throwing", async () => {
+  const invalidMode = await handleRequest({
+    action: "page_read",
+    attach: { mode: "launch" },
+  }, createDeps());
+  assert.equal(invalidMode.ok, false);
+  assert.equal(invalidMode.error.code, "invalid_input");
+
+  const unsupportedBrowser = await handleRequest({
+    action: "page_read",
+    attach: { browser_kind: "firefox" },
+  }, createDeps());
+  assert.equal(unsupportedBrowser.ok, false);
+  assert.equal(unsupportedBrowser.error.code, "unsupported_browser_kind");
+
+  const invalidPageIndex = await handleRequest({
+    action: "page_read",
+    attach: {
+      browser_kind: "chrome",
+      target: { page_index: -1 },
+    },
+  }, createDeps());
+  assert.equal(invalidPageIndex.ok, false);
+  assert.equal(invalidPageIndex.error.code, "invalid_input");
+});
+
+test("page_read reports attached browser resolution failures as structured errors", async () => {
+  const attachFailure = await handleRequest({
+    action: "page_read",
+    attach: { browser_kind: "chrome" },
+  }, createDeps({ connectError: new Error("connect ECONNREFUSED") }));
+  assert.equal(attachFailure.ok, false);
+  assert.equal(attachFailure.error.code, "browser_attach_failed");
+
+  const noPageMatch = await handleRequest({
+    action: "page_read",
+    attach: {
+      browser_kind: "chrome",
+      target: { page_index: 2 },
+    },
+  }, createDeps({ connectedPages: [createPage({ currentURL: "https://example.com/current" })] }));
+  assert.equal(noPageMatch.ok, false);
+  assert.equal(noPageMatch.error.code, "page_target_not_found");
+
+  const ambiguousMatch = await handleRequest({
+    action: "page_read",
+    attach: { browser_kind: "chrome" },
+  }, createDeps({
+    connectedPages: [
+      createPage({ currentURL: "https://example.com/one", title: "One" }),
+      createPage({ currentURL: "https://example.com/two", title: "Two" }),
+    ],
+  }));
+  assert.equal(ambiguousMatch.ok, false);
+  assert.equal(ambiguousMatch.error.code, "page_target_not_found");
+
+  const malformedContext = await handleRequest({
+    action: "page_read",
+    attach: { browser_kind: "chrome" },
+  }, createDeps({ connectedContexts: [{}] }));
+  assert.equal(malformedContext.ok, false);
+  assert.equal(malformedContext.error.code, "page_target_not_found");
+});
+
+test("page_interact uses attached tabs without forcing a new navigation", async () => {
+  const actionLog = [];
+  const navigationLog = [];
+  const response = await handleRequest({
+    action: "page_interact",
+    url: "https://example.com/form",
+    attach: {
+      browser_kind: "edge",
+      target: { page_index: 0 },
+    },
+    actions: [
+      { type: "click", selector: "button.submit" },
+      { type: "wait_for", timeout_ms: 100 },
+    ],
+  }, createDeps({
+    actionLog,
+    navigationLog,
+    connectedPages: [createPage({
+      actionLog,
+      navigationLog,
+      currentURL: "https://example.com/form",
+      title: "Connected Form",
+      bodyText: "Interaction complete",
+    })],
+  }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.attached, true);
+  assert.equal(response.result.actions_applied, 2);
+  assert.equal(response.result.source, "playwright_worker_cdp");
+  assert.deepEqual(actionLog.map((entry) => entry.action), ["click", "waitForTimeout"]);
+  assert.deepEqual(navigationLog, []);
+});
+
+test("structured_dom can read an attached page chosen by page index", async () => {
+  const response = await handleRequest({
+    action: "structured_dom",
+    attach: {
+      browser_kind: "edge",
+      target: { page_index: 1 },
+    },
+  }, createDeps({
+    connectedPages: [
+      createPage({ currentURL: "https://example.com/one", title: "One", snapshot: { headings: ["Ignore"], links: [], buttons: [], inputs: [] } }),
+      createPage({ currentURL: "https://example.com/two", title: "Two", snapshot: { headings: ["Chosen"], links: ["Docs"], buttons: ["Save"], inputs: ["email"] } }),
+    ],
+  }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.attached, true);
+  assert.equal(response.result.title, "Two");
+  assert.deepEqual(response.result.headings, ["Chosen"]);
+});
+
+test("page_interact rethrows unsupported interaction types", async () => {
+  await assert.rejects(
+    () => handleRequest({
+      action: "page_interact",
+      url: "https://example.com",
+      actions: [{ type: "hover" }],
+    }, createDeps()),
+    /unsupported_interaction_hover/,
+  );
 });
 
 test("unsupported action stays structured", async () => {

--- a/workers/playwright-worker/src/index.test.js
+++ b/workers/playwright-worker/src/index.test.js
@@ -383,6 +383,29 @@ test("page_read reports invalid attach modes and browser kinds without throwing"
   }, createDeps());
   assert.equal(invalidPageIndex.ok, false);
   assert.equal(invalidPageIndex.error.code, "invalid_input");
+
+  const lifecycle = [];
+  const externalEndpoint = await handleRequest({
+    action: "page_read",
+    attach: {
+      browser_kind: "chrome",
+      endpoint_url: "http://example.com:9222",
+    },
+  }, createDeps({ lifecycle }));
+  assert.equal(externalEndpoint.ok, false);
+  assert.equal(externalEndpoint.error.code, "invalid_input");
+  assert.match(externalEndpoint.error.message, /loopback host/);
+  assert.deepEqual(lifecycle, []);
+
+  const invalidEndpoint = await handleRequest({
+    action: "page_read",
+    attach: {
+      browser_kind: "chrome",
+      endpoint_url: "not-a-url",
+    },
+  }, createDeps());
+  assert.equal(invalidEndpoint.ok, false);
+  assert.equal(invalidEndpoint.error.code, "invalid_input");
 });
 
 test("page_read reports attached browser resolution failures as structured errors", async () => {

--- a/workers/playwright-worker/src/index.test.js
+++ b/workers/playwright-worker/src/index.test.js
@@ -421,6 +421,33 @@ test("page_read reports attached browser resolution failures as structured error
   }, createDeps({ connectedContexts: [{}] }));
   assert.equal(malformedContext.ok, false);
   assert.equal(malformedContext.error.code, "page_target_not_found");
+
+  const missingURLMatch = await handleRequest({
+    action: "page_read",
+    attach: {
+      browser_kind: "chrome",
+      target: { url: "https://example.com/missing" },
+    },
+  }, createDeps({
+    connectedPages: [createPage({ currentURL: "https://example.com/current", title: "Current" })],
+  }));
+  assert.equal(missingURLMatch.ok, false);
+  assert.equal(missingURLMatch.error.code, "page_target_not_found");
+
+  const missingTitleMatch = await handleRequest({
+    action: "page_read",
+    attach: {
+      browser_kind: "chrome",
+      target: {
+        url: "https://example.com/current",
+        title_contains: "missing title",
+      },
+    },
+  }, createDeps({
+    connectedPages: [createPage({ currentURL: "https://example.com/current", title: "Current" })],
+  }));
+  assert.equal(missingTitleMatch.ok, false);
+  assert.equal(missingTitleMatch.error.code, "page_target_not_found");
 });
 
 test("page_interact uses attached tabs without forcing a new navigation", async () => {

--- a/workers/playwright-worker/src/index.test.js
+++ b/workers/playwright-worker/src/index.test.js
@@ -334,6 +334,42 @@ test("page_read can attach to a real browser page over CDP", async () => {
   assert.deepEqual(navigationLog, []);
 });
 
+test("page_read ignores top-level request url unless attach.target.url is explicit", async () => {
+  const singlePage = await handleRequest({
+    action: "page_read",
+    url: "https://example.com/launch-shape",
+    attach: {
+      browser_kind: "chrome",
+    },
+  }, createDeps({
+    connectedPages: [createPage({
+      currentURL: "https://example.com/current-tab",
+      title: "Current Tab",
+      bodyText: "Attached browser content",
+    })],
+  }));
+
+  assert.equal(singlePage.ok, true);
+  assert.equal(singlePage.result.title, "Current Tab");
+  assert.equal(singlePage.result.url, "https://example.com/current-tab");
+
+  const ambiguousWithoutExplicitTarget = await handleRequest({
+    action: "page_read",
+    url: "https://example.com/current-tab",
+    attach: {
+      browser_kind: "chrome",
+    },
+  }, createDeps({
+    connectedPages: [
+      createPage({ currentURL: "https://example.com/current-tab", title: "Matching URL" }),
+      createPage({ currentURL: "https://example.com/other-tab", title: "Other Tab" }),
+    ],
+  }));
+
+  assert.equal(ambiguousWithoutExplicitTarget.ok, false);
+  assert.equal(ambiguousWithoutExplicitTarget.error.code, "page_target_not_found");
+});
+
 test("page_read resolves attached pages by url and title narrowing", async () => {
   const response = await handleRequest({
     action: "page_read",

--- a/workers/playwright-worker/src/index.test.js
+++ b/workers/playwright-worker/src/index.test.js
@@ -334,6 +334,82 @@ test("page_read can attach to a real browser page over CDP", async () => {
   assert.deepEqual(navigationLog, []);
 });
 
+test("browser_attach_current returns the selected real browser tab", async () => {
+  const response = await handleRequest({
+    action: "browser_attach_current",
+    attach: {
+      browser_kind: "chrome",
+      target: {
+        title_contains: "connected page",
+      },
+    },
+  }, createDeps({
+    connectedPages: [
+      createPage({ currentURL: "https://example.com/other", title: "Other Page" }),
+      createPage({ currentURL: "https://example.com/current", title: "Connected Page" }),
+    ],
+  }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.attached, true);
+  assert.equal(response.result.page_index, 1);
+  assert.equal(response.result.title, "Connected Page");
+  assert.equal(response.result.url, "https://example.com/current");
+});
+
+test("browser_snapshot returns structured content for the attached tab", async () => {
+  const response = await handleRequest({
+    action: "browser_snapshot",
+    attach: {
+      browser_kind: "edge",
+      target: {
+        page_index: 0,
+      },
+    },
+  }, createDeps({
+    connectedPages: [createPage({
+      currentURL: "https://example.com/current",
+      title: "Snapshot Page",
+      bodyText: "Snapshot body text",
+      snapshot: {
+        headings: ["Heading A"],
+        links: ["Docs"],
+        buttons: ["Submit"],
+        inputs: ["email"],
+      },
+    })],
+  }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.page_index, 0);
+  assert.equal(response.result.title, "Snapshot Page");
+  assert.equal(response.result.text_content, "Snapshot body text");
+  assert.deepEqual(response.result.headings, ["Heading A"]);
+  assert.deepEqual(response.result.links, ["Docs"]);
+});
+
+test("browser_tabs_list reports attached browser tabs with stable indexes", async () => {
+  const response = await handleRequest({
+    action: "browser_tabs_list",
+    attach: {
+      browser_kind: "chrome",
+    },
+  }, createDeps({
+    connectedPages: [
+      createPage({ currentURL: "https://example.com/one", title: "One" }),
+      createPage({ currentURL: "https://example.com/two", title: "Two" }),
+    ],
+  }));
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.attached, true);
+  assert.equal(response.result.tab_count, 2);
+  assert.deepEqual(response.result.tabs, [
+    { page_index: 0, title: "One", url: "https://example.com/one" },
+    { page_index: 1, title: "Two", url: "https://example.com/two" },
+  ]);
+});
+
 test("page_read ignores top-level request url unless attach.target.url is explicit", async () => {
   const singlePage = await handleRequest({
     action: "page_read",


### PR DESCRIPTION
## 背景

本 PR 实现 Issue 2 的范围：在不改动 Go wiring、tool 注册、agent loop 和交付链路的前提下，为 Playwright worker 增加通过 CDP 附着真实 Chromium 浏览器页面的执行能力。

当前 worker 原本只支持：

- `page_read`
- `page_search`
- `page_interact`
- `structured_dom`

且所有请求都只能通过 `chromium.launch()` 新开临时浏览器执行，无法接管用户已经开启 remote debugging 的真实 Chrome / Edge。

## 改动内容

### 1. 为现有页面能力增加可选的 CDP attach 执行路径

在 `workers/playwright-worker/src/index.js` 中，为现有 action 增加了可选 `attach` 请求形状：

- `page_read`
- `page_search`
- `page_interact`
- `structured_dom`

支持：

- 默认附着端点：`http://127.0.0.1:9222`
- 支持浏览器：
  - `chrome`
  - `edge`

### 2. 支持真实标签页选择

新增 attached page 选择逻辑，支持按以下条件缩小目标页：

- `target.url`
- `target.title_contains`
- `target.page_index`

并修复了一个安全性问题：

- 当显式指定 `target.url` 或 `target.title_contains` 但没有命中时，worker 现在会返回 `page_target_not_found`
- 不再静默回退到更宽泛的候选集，避免误附着到错误用户标签页

### 3. 保持 launch 路径兼容

未传 `attach` 时，worker 仍保持原有行为：

- 新建临时浏览器
- `goto(url)`
- 返回现有页面能力结果

因此本 PR 对现有 Go sidecar / runtime 调用方式保持兼容。

### 4. 返回附着元信息

attached 模式下，worker 结果会额外带回：

- `attached`
- `browser_kind`
- `browser_transport`
- `endpoint_url`
- `source = playwright_worker_cdp`

用于后续 Issue 3 接线时复用。

## 非目标

本 PR 不包含以下内容：

- 不修改 `services/local-service/**`
- 不新增 Go tool 注册
- 不修改 agent loop capability 暴露
- 不改 delivery / dashboard / result page
- 不改 CI workflow
- 不引入真实浏览器 E2E 测试

## 测试

已完成本地验证：

- `pnpm --dir workers/playwright-worker build`
- `node --test workers/playwright-worker/src/index.test.js`
- `node --experimental-test-coverage --test-coverage-lines=80 --test-coverage-branches=80 --test-coverage-include="workers/playwright-worker/src/index.js" --test workers/playwright-worker/src/index.test.js`

### 新增测试覆盖点

- health 通过 `handleRequest` 路径
- launch 模式正常读取与错误路径
- HTML title fallback / hostname fallback / untitled fallback
- `page_interact` 的 `press / check / uncheck / wait_for`
- CDP attach 成功路径
- URL + title 缩小目标页
- 无效 attach mode / browser kind / page index
- attach 失败与 target 未命中
- attached 模式下不触发新导航
- attached `structured_dom`
- 不支持的 interaction type 保持失败

## 提交说明

本 PR 当前包含以下提交：

- `feat(worker): add cdp attach execution path`
- `test(worker): cover cdp attach flows`
- `fix(worker): enforce attach target filters`

Closed #404 
