### PR TITLE
fix(desktop): switch UI to system font stacks

### DIFF
--- a/apps/desktop/src/features/control-panel/ControlPanelApp.tsx
+++ b/apps/desktop/src/features/control-panel/ControlPanelApp.tsx
@@ -807,9 +807,25 @@ export function ControlPanelApp() {
     })();
   }, [onboardingSession]);
 
+  const controlPanelAppearance = draft ? resolveControlPanelAppearance(draft.settings.general.theme_mode, systemAppearance) : systemAppearance;
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return undefined;
+    }
+
+    // Tooltip popups render through a portal, so the window appearance needs a
+    // document-level marker instead of relying on the local shell subtree.
+    document.body.dataset.controlPanelAppearance = controlPanelAppearance;
+
+    return () => {
+      delete document.body.dataset.controlPanelAppearance;
+    };
+  }, [controlPanelAppearance]);
+
   if (!draft || !panelData) {
     return (
-      <main className="app-shell control-panel-shell" data-appearance={systemAppearance}>
+      <main className="app-shell control-panel-shell" data-appearance={controlPanelAppearance}>
         <div className="control-panel-shell__loading">
           <div className="control-panel-shell__loading-stack">
             <Text size="2" className="control-panel-shell__loading-copy">
@@ -832,7 +848,6 @@ export function ControlPanelApp() {
   const modelSettingsDirty = !isEqual(draft.settings.models, panelData.settings.models) || draft.providerApiKeyInput.trim() !== "";
   const hasChanges = inspectorDirty || settingsDirty;
   const providerApiKeyStatus = draft.settings.models.provider_api_key_configured ? "已配置" : "未配置";
-  const resolvedAppearance = resolveControlPanelAppearance(draft.settings.general.theme_mode, systemAppearance);
   const providerApiKeyHint = "通过 JSON-RPC `agent.settings.update` 提交；只写入后端 Stronghold，不会回显明文。";
   const hasRpcLoadError = loadError !== null;
   const onboardingReplayDisabled = isSaving || isRunningInspection || isReplayingOnboarding;
@@ -1658,7 +1673,7 @@ export function ControlPanelApp() {
   };
 
   return (
-    <main className="app-shell control-panel-shell" data-appearance={resolvedAppearance}>
+    <main className="app-shell control-panel-shell" data-appearance={controlPanelAppearance}>
       <div className="control-panel-shell__titlebar" aria-label="控制面板窗口操作" onPointerDown={handleTopbarPointerDown}>
         <div className="control-panel-shell__titlebar-copy">
           <Heading size="5" className="control-panel-shell__titlebar-title">

--- a/apps/desktop/src/features/control-panel/controlPanel.css
+++ b/apps/desktop/src/features/control-panel/controlPanel.css
@@ -644,7 +644,7 @@
 
 .control-panel-shell__about-link {
   color: var(--cp-copy);
-  font-family: "Consolas", "SFMono-Regular", monospace;
+  font-family: var(--font-mono);
   font-size: 0.84rem;
   word-break: break-all;
 }
@@ -717,7 +717,7 @@
 
 .control-panel-shell__feedback-link-copy {
   color: var(--cp-copy);
-  font-family: "Consolas", "SFMono-Regular", monospace;
+  font-family: var(--font-mono);
   font-size: 0.8rem;
   word-break: break-all;
 }

--- a/apps/desktop/src/features/control-panel/controlPanel.css
+++ b/apps/desktop/src/features/control-panel/controlPanel.css
@@ -86,7 +86,7 @@
   --cp-ink: #f7efe7;
   --cp-copy: #d8cdc2;
   --cp-muted: #af9f92;
-  --cp-placeholder: rgba(247, 239, 231, 0.92);
+  --cp-placeholder: rgba(216, 205, 194, 0.72);
   --cp-accent: #ff9f43;
   --cp-accent-soft: rgba(255, 159, 67, 0.2);
   --cp-accent-strong: #ffb76a;
@@ -866,11 +866,6 @@ body[data-control-panel-appearance="dark"] .control-panel-shell__tooltip {
 
 .control-panel-shell :where(.control-panel-shell__input input::placeholder) {
   color: var(--cp-placeholder);
-  opacity: 1;
-}
-
-.control-panel-shell[data-appearance="dark"] :where(.control-panel-shell__input input::placeholder) {
-  color: rgba(247, 239, 231, 0.92);
   opacity: 1;
 }
 

--- a/apps/desktop/src/features/control-panel/controlPanel.css
+++ b/apps/desktop/src/features/control-panel/controlPanel.css
@@ -86,7 +86,7 @@
   --cp-ink: #f7efe7;
   --cp-copy: #d8cdc2;
   --cp-muted: #af9f92;
-  --cp-placeholder: rgba(216, 205, 194, 0.56);
+  --cp-placeholder: rgba(247, 239, 231, 0.92);
   --cp-accent: #ff9f43;
   --cp-accent-soft: rgba(255, 159, 67, 0.2);
   --cp-accent-strong: #ffb76a;
@@ -122,9 +122,9 @@
   --cp-choice-track-shadow: 0 0 0 1px rgba(255, 241, 228, 0.08);
   --cp-choice-ink: #f7efe7;
   --cp-choice-selected: rgba(61, 47, 42, 0.98);
-  --cp-tooltip-surface: rgba(49, 38, 34, 0.94);
-  --cp-tooltip-ink: #15120f;
-  --cp-tooltip-copy: rgba(247, 239, 231, 0.74);
+  --cp-tooltip-surface: rgba(59, 45, 40, 0.98);
+  --cp-tooltip-ink: #f7efe7;
+  --cp-tooltip-copy: rgba(247, 239, 231, 0.9);
   --cp-action-bar-surface: rgba(38, 30, 27, 0.96);
   --cp-slider-track: rgba(74, 58, 52, 0.92);
   --cp-slider-range: linear-gradient(90deg, rgba(255, 183, 106, 0.98), rgba(255, 159, 67, 0.9));
@@ -386,15 +386,22 @@
 .control-panel-shell__tooltip {
   max-width: 18rem;
   border-radius: 14px;
-  background: var(--cp-tooltip-surface) !important;
-  color: var(--cp-tooltip-copy) !important;
-  border: 1px solid color-mix(in srgb, var(--cp-border-strong) 62%, transparent);
+  background: rgba(255, 252, 248, 0.96) !important;
+  color: rgba(116, 103, 91, 0.92) !important;
+  border: 1px solid rgba(126, 101, 76, 0.16);
   box-shadow: 0 18px 38px -28px rgba(71, 54, 34, 0.32);
   font-size: 0.82rem;
   font-weight: 500;
   line-height: 1.58;
   padding: 0.56rem 0.72rem;
   text-wrap: pretty;
+}
+
+body[data-control-panel-appearance="dark"] .control-panel-shell__tooltip {
+  background: rgba(59, 45, 40, 0.98) !important;
+  color: rgba(247, 239, 231, 0.9) !important;
+  border-color: rgba(255, 241, 228, 0.16);
+  box-shadow: 0 18px 42px -26px rgba(0, 0, 0, 0.5);
 }
 
 .control-panel-shell__tooltip * {
@@ -859,6 +866,12 @@
 
 .control-panel-shell :where(.control-panel-shell__input input::placeholder) {
   color: var(--cp-placeholder);
+  opacity: 1;
+}
+
+.control-panel-shell[data-appearance="dark"] :where(.control-panel-shell__input input::placeholder) {
+  color: rgba(247, 239, 231, 0.92);
+  opacity: 1;
 }
 
 .control-panel-shell :where(.control-panel-shell__textarea) {

--- a/apps/desktop/src/features/dashboard/notes/notePage.css
+++ b/apps/desktop/src/features/dashboard/notes/notePage.css
@@ -227,7 +227,7 @@
 
 .note-preview-page__title-row h1 {
   color: var(--note-ink);
-  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  font-family: var(--cc-font-display);
   font-size: clamp(1.55rem, 2.05vw, 2.2rem);
   font-weight: 700;
   letter-spacing: -0.05em;
@@ -301,7 +301,7 @@
 
 .note-preview-page__summary-item strong {
   color: var(--note-ink);
-  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  font-family: var(--cc-font-display);
   font-size: 1.08rem;
   font-weight: 700;
   letter-spacing: -0.06em;
@@ -377,7 +377,7 @@
 
 .note-source-studio__title-row h2 {
   color: var(--note-ink);
-  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  font-family: var(--cc-font-display);
   font-size: clamp(1.15rem, 1.5vw, 1.45rem);
   letter-spacing: -0.04em;
   line-height: 1;
@@ -658,7 +658,7 @@
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.66);
   color: var(--note-ink);
   height: 100%;
-  font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 0.9rem;
   line-height: 1.6;
   min-height: 0;
@@ -783,7 +783,7 @@
 
 .note-preview-page__rail-dropzone-title {
   color: var(--note-ink);
-  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  font-family: var(--cc-font-display);
   font-size: 1rem;
   font-weight: 700;
   line-height: 1.08;
@@ -936,7 +936,7 @@
 .note-preview-shell__header .dashboard-card__kicker,
 .note-preview-finished-group__title {
   color: var(--note-ink);
-  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  font-family: var(--cc-font-display);
   font-size: 1rem;
   font-weight: 700;
   letter-spacing: -0.03em;
@@ -1142,7 +1142,7 @@
 
 .note-preview-card__title,
 .note-preview-page__board-card-title {
-  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  font-family: var(--cc-font-display);
   font-size: 1.02rem;
   font-weight: 700;
   letter-spacing: -0.03em;
@@ -1285,7 +1285,7 @@
 
 .note-preview-page__board-stat strong {
   color: var(--note-ink);
-  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  font-family: var(--cc-font-display);
   font-size: 0.98rem;
   font-weight: 700;
   letter-spacing: -0.04em;
@@ -1440,7 +1440,7 @@
 
 .note-preview-page__drag-ghost-title {
   color: var(--note-ink);
-  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  font-family: var(--cc-font-display);
   font-size: 1rem;
   font-weight: 700;
   line-height: 1.28;
@@ -1494,7 +1494,7 @@
 
 .note-source-modal__title {
   color: var(--note-ink);
-  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  font-family: var(--cc-font-display);
   font-size: clamp(1.25rem, 1.7vw, 1.7rem);
   font-weight: 700;
   letter-spacing: -0.04em;

--- a/apps/desktop/src/features/dashboard/tasks/taskPage.css
+++ b/apps/desktop/src/features/dashboard/tasks/taskPage.css
@@ -1353,7 +1353,7 @@
 
 .task-detail-runtime-item__payload {
   color: var(--task-ink, #5f544b);
-  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-family: var(--task-font-mono);
   font-size: 0.76rem;
   line-height: 1.6;
   overflow-wrap: anywhere;

--- a/apps/desktop/src/styles/desktopTheme.css
+++ b/apps/desktop/src/styles/desktopTheme.css
@@ -1,8 +1,8 @@
 /* Shared desktop tokens keep the mascot, dashboard modules, and settings pages visually aligned without changing formal task data. */
 :root {
-  --cc-font-ui: "Nunito", "LXGW WenKai TC", "Segoe UI Variable Text", sans-serif;
-  --cc-font-display: "LXGW WenKai TC", "Nunito", "Iowan Old Style", Georgia, serif;
-  --cc-font-mono: "IBM Plex Mono", Consolas, monospace;
+  --cc-font-ui: "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Segoe UI Variable Text", "Segoe UI", sans-serif;
+  --cc-font-display: "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Segoe UI Variable Text", "Segoe UI", sans-serif;
+  --cc-font-mono: "Cascadia Mono", "SFMono-Regular", "Segoe UI Mono", Consolas, monospace;
 
   --cc-cream-0: #fffaf6;
   --cc-cream-1: #fcf5ed;

--- a/apps/desktop/src/styles/desktopTheme.css
+++ b/apps/desktop/src/styles/desktopTheme.css
@@ -1,8 +1,26 @@
 /* Shared desktop tokens keep the mascot, dashboard modules, and settings pages visually aligned without changing formal task data. */
 :root {
-  --cc-font-ui: "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Segoe UI Variable Text", "Segoe UI", sans-serif;
-  --cc-font-display: "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Segoe UI Variable Text", "Segoe UI", sans-serif;
-  --cc-font-mono: "Cascadia Mono", "SFMono-Regular", "Segoe UI Mono", Consolas, monospace;
+  --cc-font-ui:
+    "PingFang SC",
+    "Hiragino Sans GB",
+    "Microsoft YaHei",
+    "Segoe UI Variable Text",
+    "Segoe UI",
+    "Noto Sans CJK SC",
+    "Source Han Sans SC",
+    "WenQuanYi Micro Hei",
+    sans-serif;
+  --cc-font-display:
+    "PingFang SC",
+    "Hiragino Sans GB",
+    "Microsoft YaHei",
+    "Segoe UI Variable Text",
+    "Segoe UI",
+    "Noto Sans CJK SC",
+    "Source Han Sans SC",
+    "WenQuanYi Micro Hei",
+    sans-serif;
+  --cc-font-mono: "Cascadia Mono", "SFMono-Regular", "Segoe UI Mono", Consolas, Menlo, "Liberation Mono", monospace;
 
   --cc-cream-0: #fffaf6;
   --cc-cream-1: #fcf5ed;

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=LXGW+WenKai+TC&family=Nunito:wght@400;500;600;700;800&display=swap");
 @import "./desktopTheme.css";
 
 @tailwind base;


### PR DESCRIPTION
## Summary
- Remove the webfont import that introduced Traditional Chinese-styled glyphs in the desktop UI.
- Switch shared desktop UI, display, and monospace tokens to system font stacks for a more standard Simplified Chinese appearance.
- Align notes and task detail typography with the shared system font tokens to avoid mixed font styles across modules.
## Validation
- `corepack pnpm --dir apps/desktop typecheck`
- `corepack pnpm --dir apps/desktop lint`
- `corepack pnpm --dir apps/desktop build`
## Notes
- This is a visual-only follow-up after PR #366.
- Lint still reports existing warnings only; no new errors were introduced.