### PR TITLE
feat(execution): persist browser attach hints and inject them into page tools

### DIFF
--- a/services/local-service/internal/bootstrap/bootstrap_test.go
+++ b/services/local-service/internal/bootstrap/bootstrap_test.go
@@ -91,8 +91,8 @@ func TestNewWiresStorageBackedMemoryService(t *testing.T) {
 	if app.toolRegistry == nil || app.toolExecutor == nil {
 		t.Fatal("expected tool registry and executor to be wired")
 	}
-	if app.toolRegistry.Count() != 15 {
-		t.Fatalf("expected 15 tools to be registered, got %d", app.toolRegistry.Count())
+	if app.toolRegistry.Count() != 21 {
+		t.Fatalf("expected 21 tools to be registered, got %d", app.toolRegistry.Count())
 	}
 	if _, err := app.toolRegistry.Get("generate_text"); err != nil {
 		t.Fatalf("expected generate_text to be registered, got %v", err)
@@ -115,7 +115,7 @@ func TestNewWiresStorageBackedMemoryService(t *testing.T) {
 	if _, err := app.toolRegistry.Get("page_search"); err != nil {
 		t.Fatalf("expected page_search to be registered, got %v", err)
 	}
-	for _, toolName := range []string{"page_interact", "structured_dom", "extract_text", "ocr_image", "ocr_pdf", "transcode_media", "extract_frames", "normalize_recording"} {
+	for _, toolName := range []string{"page_interact", "structured_dom", "browser_attach_current", "browser_snapshot", "browser_navigate", "browser_tabs_list", "browser_tab_focus", "browser_interact", "extract_text", "ocr_image", "ocr_pdf", "transcode_media", "extract_frames", "normalize_recording"} {
 		if _, err := app.toolRegistry.Get(toolName); err != nil {
 			t.Fatalf("expected %s to be registered, got %v", toolName, err)
 		}

--- a/services/local-service/internal/context/service.go
+++ b/services/local-service/internal/context/service.go
@@ -17,6 +17,9 @@ type TaskContextSnapshot struct {
 	PageTitle      string
 	PageURL        string
 	AppName        string
+	BrowserKind    string
+	ProcessPath    string
+	ProcessID      int
 	WindowTitle    string
 	VisibleText    string
 	ScreenSummary  string
@@ -101,6 +104,9 @@ func (s *Service) Capture(params map[string]any) TaskContextSnapshot {
 		PageTitle:      firstNonEmpty(stringValue(pageContext, "title"), stringValue(pageFallback, "title")),
 		PageURL:        firstNonEmpty(stringValue(pageContext, "url"), stringValue(pageFallback, "url")),
 		AppName:        firstNonEmpty(stringValue(pageContext, "app_name"), stringValue(pageFallback, "app_name")),
+		BrowserKind:    firstNonEmpty(stringValue(pageContext, "browser_kind"), stringValue(pageFallback, "browser_kind")),
+		ProcessPath:    firstNonEmpty(stringValue(pageContext, "process_path"), stringValue(pageFallback, "process_path")),
+		ProcessID:      intValue(pageContext, "process_id", intValue(pageFallback, "process_id", 0)),
 		WindowTitle:    firstNonEmpty(stringValue(pageContext, "window_title"), stringValue(pageFallback, "window_title"), stringValue(screen, "window_title")),
 		VisibleText:    firstNonEmpty(stringValue(pageContext, "visible_text"), stringValue(pageFallback, "visible_text"), stringValue(screen, "visible_text")),
 		ScreenSummary:  firstNonEmpty(stringValue(contextValue, "screen_summary"), stringValue(screen, "summary"), stringValue(screen, "screen_summary")),

--- a/services/local-service/internal/context/service_test.go
+++ b/services/local-service/internal/context/service_test.go
@@ -18,6 +18,9 @@ func TestServiceCaptureNormalizesNestedContext(t *testing.T) {
 				"title":        " Editor ",
 				"url":          " https://example.com/doc ",
 				"app_name":     " desktop ",
+				"browser_kind": " chrome ",
+				"process_path": " C:/Program Files/Google/Chrome/Application/chrome.exe ",
+				"process_id":   float64(4242),
 				"window_title": " Browser - Example ",
 				"visible_text": " visible paragraph ",
 			},
@@ -53,6 +56,9 @@ func TestServiceCaptureNormalizesNestedContext(t *testing.T) {
 	if snapshot.PageTitle != "Editor" || snapshot.PageURL != "https://example.com/doc" || snapshot.AppName != "desktop" {
 		t.Fatalf("expected page fields to be normalized, got %+v", snapshot)
 	}
+	if snapshot.BrowserKind != "chrome" || snapshot.ProcessPath != "C:/Program Files/Google/Chrome/Application/chrome.exe" || snapshot.ProcessID != 4242 {
+		t.Fatalf("expected browser attach hints to be normalized, got %+v", snapshot)
+	}
 	if snapshot.WindowTitle != "Browser - Example" || snapshot.VisibleText != "visible paragraph" || snapshot.ScreenSummary != "dashboard warning" {
 		t.Fatalf("expected richer perception fields to be normalized, got %+v", snapshot)
 	}
@@ -76,6 +82,9 @@ func TestServiceCapturePrefersInputPageContextAndFlatFallbackSignals(t *testing.
 				"title":        " Build Pipeline ",
 				"url":          " https://example.com/build ",
 				"app_name":     " Chrome ",
+				"browser_kind": " edge ",
+				"process_path": " C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe ",
+				"process_id":   float64(5150),
 				"window_title": " Build Pipeline - Browser ",
 			},
 		},
@@ -84,6 +93,9 @@ func TestServiceCapturePrefersInputPageContextAndFlatFallbackSignals(t *testing.
 				"title":        " Legacy Page Title ",
 				"url":          " https://example.com/legacy ",
 				"app_name":     " Legacy Browser ",
+				"browser_kind": " chrome ",
+				"process_path": " C:/Legacy/browser.exe ",
+				"process_id":   float64(99),
 				"window_title": " Legacy Window ",
 				"visible_text": " fallback visible text ",
 			},
@@ -102,6 +114,9 @@ func TestServiceCapturePrefersInputPageContextAndFlatFallbackSignals(t *testing.
 
 	if snapshot.PageTitle != "Build Pipeline" || snapshot.PageURL != "https://example.com/build" || snapshot.AppName != "Chrome" {
 		t.Fatalf("expected input.page_context to stay authoritative, got %+v", snapshot)
+	}
+	if snapshot.BrowserKind != "edge" || snapshot.ProcessPath != "C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe" || snapshot.ProcessID != 5150 {
+		t.Fatalf("expected input.page_context attach hints to stay authoritative, got %+v", snapshot)
 	}
 	if snapshot.WindowTitle != "Build Pipeline - Browser" {
 		t.Fatalf("expected input.page_context window title to win, got %+v", snapshot)

--- a/services/local-service/internal/context/service_test.go
+++ b/services/local-service/internal/context/service_test.go
@@ -131,3 +131,46 @@ func TestServiceCapturePrefersInputPageContextAndFlatFallbackSignals(t *testing.
 		t.Fatalf("expected flat behavior counters to be normalized, got %+v", snapshot)
 	}
 }
+
+func TestServiceSnapshotAndCaptureInferenceHelpers(t *testing.T) {
+	service := NewService()
+	if snapshot := service.Snapshot(); snapshot["source"] != "desktop" {
+		t.Fatalf("expected snapshot descriptor to report desktop source, got %+v", snapshot)
+	}
+
+	selectionOnly := service.Capture(map[string]any{
+		"context": map[string]any{
+			"selection": map[string]any{"text": " selected line "},
+		},
+	})
+	if selectionOnly.InputType != "text_selection" || selectionOnly.Trigger != "text_selected_click" || selectionOnly.Text != "selected line" {
+		t.Fatalf("expected selection-only payload to infer text selection input, got %+v", selectionOnly)
+	}
+
+	errorOnly := service.Capture(map[string]any{
+		"context": map[string]any{
+			"error": map[string]any{"message": " build failed "},
+		},
+	})
+	if errorOnly.InputType != "error" || errorOnly.Trigger != "error_detected" || errorOnly.Text != "build failed" {
+		t.Fatalf("expected error-only payload to infer error input, got %+v", errorOnly)
+	}
+}
+
+func TestContextPrimitiveHelpersCoverAdditionalBranches(t *testing.T) {
+	if values := stringSliceValue([]string{" demo ", "demo", "notes"}); len(values) != 2 || values[0] != "demo" || values[1] != "notes" {
+		t.Fatalf("expected []string branch to trim and dedupe, got %+v", values)
+	}
+	if values := stringSliceValue("  single-item  "); len(values) != 1 || values[0] != "single-item" {
+		t.Fatalf("expected string branch to trim values, got %+v", values)
+	}
+	if values := stringSliceValue("   "); values != nil {
+		t.Fatalf("expected blank string branch to return nil, got %+v", values)
+	}
+	if value := intValue(map[string]any{"count": int64(9)}, "count", 1); value != 9 {
+		t.Fatalf("expected int64 branch to decode value, got %d", value)
+	}
+	if value := intValue(map[string]any{"count": "invalid"}, "count", 3); value != 3 {
+		t.Fatalf("expected fallback branch to preserve fallback, got %d", value)
+	}
+}

--- a/services/local-service/internal/execution/service.go
+++ b/services/local-service/internal/execution/service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/url"
 	"path"
 	"path/filepath"
 	"strings"
@@ -3389,27 +3390,43 @@ func resolvePageToolInput(intentName string, arguments map[string]any, snapshot 
 }
 
 func pageAttachInput(urlValue string, arguments map[string]any, snapshot contextsvc.TaskContextSnapshot) map[string]any {
-	browserKind := strings.ToLower(strings.TrimSpace(firstNonEmpty(stringValue(arguments, "browser_kind", ""), snapshot.BrowserKind)))
+	// Page-level attach hints must come from trusted desktop context. The planner
+	// can request a page tool, but it must not steer browser kind or CDP endpoint
+	// away from the observed foreground session.
+	browserKind := strings.ToLower(strings.TrimSpace(snapshot.BrowserKind))
 	if browserKind != "chrome" && browserKind != "edge" {
 		return nil
 	}
-	pageURL := strings.TrimSpace(snapshot.PageURL)
-	if pageURL == "" || pageURL != strings.TrimSpace(urlValue) {
+	pageURL := comparablePageURL(snapshot.PageURL)
+	requestURL := comparablePageURL(urlValue)
+	if pageURL == "" || requestURL == "" || pageURL != requestURL {
 		return nil
 	}
 	target := map[string]any{"url": pageURL}
-	if windowTitle := strings.TrimSpace(snapshot.WindowTitle); windowTitle != "" {
-		target["title_contains"] = windowTitle
+	if pageTitle := strings.TrimSpace(snapshot.PageTitle); pageTitle != "" {
+		target["title_contains"] = pageTitle
 	}
 	attach := map[string]any{
 		"mode":         string(tools.BrowserAttachModeCDP),
 		"browser_kind": browserKind,
 		"target":       target,
 	}
-	if endpointURL := strings.TrimSpace(stringValue(arguments, "endpoint_url", "")); endpointURL != "" {
-		attach["endpoint_url"] = endpointURL
-	}
 	return attach
+}
+
+func comparablePageURL(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return trimmed
+	}
+	if parsed.Path == "" {
+		parsed.Path = "/"
+	}
+	return parsed.String()
 }
 
 func requireAuthorizationFlag(intent map[string]any) bool {

--- a/services/local-service/internal/execution/service.go
+++ b/services/local-service/internal/execution/service.go
@@ -978,40 +978,45 @@ func (s *Service) executeDirectBuiltinTool(ctx context.Context, request Request)
 		return Result{}, false, nil
 	}
 	args := mapValue(request.Intent, "arguments")
-	toolResult, recoveryPoint, err := s.executeTool(ctx, request, s.workspace, intentName, args)
+	toolInput, ok := resolveDirectToolInput(intentName, args, request.Snapshot)
+	if !ok {
+		return Result{}, false, nil
+	}
+	toolName := intentName
+	toolResult, recoveryPoint, err := s.executeTool(ctx, request, s.workspace, toolName, toolInput)
 	if err != nil {
 		failedResult := Result{
 			RecoveryPoint: cloneMap(recoveryPoint),
 		}
 		if toolResult != nil {
-			failedResult.ToolCalls = []tools.ToolCallRecord{normalizeFilesystemToolCall(toolResult.ToolCall, map[string]any{"path": stringValue(args, "path", "")})}
-			failedResult.ToolName = intentName
-			failedResult.ToolInput = mergeToolInputs(args, map[string]any{
-				"intent_name":     intentName,
+			failedResult.ToolCalls = []tools.ToolCallRecord{normalizeFilesystemToolCall(toolResult.ToolCall, toolInput)}
+			failedResult.ToolName = toolName
+			failedResult.ToolInput = mergeToolInputs(toolInput, map[string]any{
+				"intent_name":     toolName,
 				"delivery_type":   "bubble",
 				"available_tools": s.availableToolNames(),
 				"workers":         s.availableWorkers(),
 			})
-			failedResult.ToolOutput = normalizeFilesystemToolOutput(intentName, mergeToolOutputs(toolResult.RawOutput, toolResult.SummaryOutput), args)
+			failedResult.ToolOutput = normalizeFilesystemToolOutput(toolName, mergeToolOutputs(toolResult.RawOutput, toolResult.SummaryOutput), toolInput)
 		}
-		return failedResult, false, fmt.Errorf("execute builtin tool %s: %w", intentName, err)
+		return failedResult, false, fmt.Errorf("execute builtin tool %s: %w", toolName, err)
 	}
-	bubbleText := toolBubbleText(intentName, toolResult)
+	bubbleText := toolBubbleText(toolName, toolResult)
 	return Result{
 		Content:        bubbleText,
 		DeliveryResult: s.delivery.BuildDeliveryResultWithTargetPath(request.TaskID, "bubble", request.ResultTitle, bubbleText, ""),
 		Artifacts:      toolArtifactsFromResult(request.TaskID, toolResult),
 		BubbleText:     bubbleText,
 		RecoveryPoint:  cloneMap(recoveryPoint),
-		ToolCalls:      []tools.ToolCallRecord{normalizeFilesystemToolCall(toolResult.ToolCall, map[string]any{"path": stringValue(args, "path", "")})},
-		ToolName:       intentName,
-		ToolInput: mergeToolInputs(args, map[string]any{
-			"intent_name":     intentName,
+		ToolCalls:      []tools.ToolCallRecord{normalizeFilesystemToolCall(toolResult.ToolCall, toolInput)},
+		ToolName:       toolName,
+		ToolInput: mergeToolInputs(toolInput, map[string]any{
+			"intent_name":     toolName,
 			"delivery_type":   "bubble",
 			"available_tools": s.availableToolNames(),
 			"workers":         s.availableWorkers(),
 		}),
-		ToolOutput: normalizeFilesystemToolOutput(intentName, mergeToolOutputs(toolResult.RawOutput, toolResult.SummaryOutput), args),
+		ToolOutput: normalizeFilesystemToolOutput(toolName, mergeToolOutputs(toolResult.RawOutput, toolResult.SummaryOutput), toolInput),
 	}, true, nil
 }
 
@@ -1101,23 +1106,31 @@ func (s *Service) resolveToolExecution(request Request, deliveryResult map[strin
 		return "", nil, false
 	}
 
+	input, ok := resolveDirectToolInput(intentName, args, request.Snapshot)
+	if !ok {
+		return "", nil, false
+	}
+	return intentName, input, true
+}
+
+func resolveDirectToolInput(intentName string, args map[string]any, snapshot contextsvc.TaskContextSnapshot) (map[string]any, bool) {
 	switch intentName {
 	case "read_file":
 		pathValue := stringValue(args, "path", stringValue(args, "target_path", ""))
 		if pathValue == "" {
-			return "", nil, false
+			return nil, false
 		}
-		return intentName, map[string]any{"path": pathValue}, true
+		return map[string]any{"path": pathValue}, true
 	case "list_dir":
 		pathValue := stringValue(args, "path", stringValue(args, "target_path", ""))
 		if pathValue == "" {
-			return "", nil, false
+			return nil, false
 		}
 		input := map[string]any{"path": pathValue}
 		if limit, ok := args["limit"]; ok {
 			input["limit"] = limit
 		}
-		return intentName, input, true
+		return input, true
 	case "exec_command":
 		input := map[string]any{}
 		for _, key := range []string{"command", "args", "working_dir"} {
@@ -1126,68 +1139,43 @@ func (s *Service) resolveToolExecution(request Request, deliveryResult map[strin
 			}
 		}
 		if len(input) == 0 {
-			return "", nil, false
+			return nil, false
 		}
-		return intentName, input, true
+		return input, true
 	case "page_read":
-		urlValue := stringValue(args, "url", "")
-		if urlValue == "" {
-			return "", nil, false
-		}
-		return intentName, map[string]any{"url": urlValue}, true
+		return resolvePageToolInput(intentName, args, snapshot)
 	case "page_search":
-		urlValue := stringValue(args, "url", "")
-		queryValue := stringValue(args, "query", "")
-		if urlValue == "" || queryValue == "" {
-			return "", nil, false
-		}
-		input := map[string]any{"url": urlValue, "query": queryValue}
-		if limit, ok := args["limit"]; ok {
-			input["limit"] = limit
-		}
-		return intentName, input, true
+		return resolvePageToolInput(intentName, args, snapshot)
 	case "page_interact":
-		urlValue := stringValue(args, "url", "")
-		if urlValue == "" {
-			return "", nil, false
-		}
-		input := map[string]any{"url": urlValue}
-		if actions, ok := args["actions"]; ok {
-			input["actions"] = actions
-		}
-		return intentName, input, true
+		return resolvePageToolInput(intentName, args, snapshot)
 	case "structured_dom":
-		urlValue := stringValue(args, "url", "")
-		if urlValue == "" {
-			return "", nil, false
-		}
-		return intentName, map[string]any{"url": urlValue}, true
+		return resolvePageToolInput(intentName, args, snapshot)
 	case "extract_text", "ocr_image", "ocr_pdf":
 		pathValue := stringValue(args, "path", stringValue(args, "file_path", ""))
 		if pathValue == "" {
-			return "", nil, false
+			return nil, false
 		}
 		input := map[string]any{"path": pathValue}
 		if language, ok := args["language"]; ok {
 			input["language"] = language
 		}
-		return intentName, input, true
+		return input, true
 	case "transcode_media", "normalize_recording":
 		pathValue := stringValue(args, "path", stringValue(args, "file_path", ""))
 		outputPath := stringValue(args, "output_path", "")
 		if pathValue == "" || outputPath == "" {
-			return "", nil, false
+			return nil, false
 		}
 		input := map[string]any{"path": pathValue, "output_path": outputPath}
 		if format, ok := args["format"]; ok {
 			input["format"] = format
 		}
-		return intentName, input, true
+		return input, true
 	case "extract_frames":
 		pathValue := stringValue(args, "path", stringValue(args, "file_path", ""))
 		outputDir := stringValue(args, "output_dir", "")
 		if pathValue == "" || outputDir == "" {
-			return "", nil, false
+			return nil, false
 		}
 		input := map[string]any{"path": pathValue, "output_dir": outputDir}
 		if everySeconds, ok := args["every_seconds"]; ok {
@@ -1196,9 +1184,9 @@ func (s *Service) resolveToolExecution(request Request, deliveryResult map[strin
 		if limit, ok := args["limit"]; ok {
 			input["limit"] = limit
 		}
-		return intentName, input, true
+		return input, true
 	default:
-		return "", nil, false
+		return nil, false
 	}
 }
 
@@ -3187,33 +3175,20 @@ func (s *Service) resolveGovernanceToolExecution(request Request) (string, map[s
 					return intentName, input, s.toolExecutionContext(s.workspace, request), true, nil
 				}
 			case "page_read":
-				urlValue := stringValue(args, "url", "")
-				if urlValue != "" {
-					return intentName, map[string]any{"url": urlValue}, s.toolExecutionContext(s.workspace, request), true, nil
+				if input, ok := resolvePageToolInput(intentName, args, request.Snapshot); ok {
+					return intentName, input, s.toolExecutionContext(s.workspace, request), true, nil
 				}
 			case "page_search":
-				urlValue := stringValue(args, "url", "")
-				queryValue := stringValue(args, "query", "")
-				if urlValue != "" && queryValue != "" {
-					input := map[string]any{"url": urlValue, "query": queryValue}
-					if limit, ok := args["limit"]; ok {
-						input["limit"] = limit
-					}
+				if input, ok := resolvePageToolInput(intentName, args, request.Snapshot); ok {
 					return intentName, input, s.toolExecutionContext(s.workspace, request), true, nil
 				}
 			case "page_interact":
-				urlValue := stringValue(args, "url", "")
-				if urlValue != "" {
-					input := map[string]any{"url": urlValue}
-					if actions, ok := args["actions"]; ok {
-						input["actions"] = actions
-					}
+				if input, ok := resolvePageToolInput(intentName, args, request.Snapshot); ok {
 					return intentName, input, s.toolExecutionContext(s.workspace, request), true, nil
 				}
 			case "structured_dom":
-				urlValue := stringValue(args, "url", "")
-				if urlValue != "" {
-					return intentName, map[string]any{"url": urlValue}, s.toolExecutionContext(s.workspace, request), true, nil
+				if input, ok := resolvePageToolInput(intentName, args, request.Snapshot); ok {
+					return intentName, input, s.toolExecutionContext(s.workspace, request), true, nil
 				}
 			case "extract_text", "ocr_image", "ocr_pdf":
 				pathValue := stringValue(args, "path", stringValue(args, "file_path", ""))
@@ -3384,6 +3359,57 @@ func approvedTargetKeys(intentName string) []string {
 	default:
 		return []string{"target_path", "path", "working_dir"}
 	}
+}
+
+func resolvePageToolInput(intentName string, arguments map[string]any, snapshot contextsvc.TaskContextSnapshot) (map[string]any, bool) {
+	urlValue := strings.TrimSpace(stringValue(arguments, "url", ""))
+	if urlValue == "" {
+		return nil, false
+	}
+	input := map[string]any{"url": urlValue}
+	switch intentName {
+	case "page_search":
+		queryValue := strings.TrimSpace(stringValue(arguments, "query", ""))
+		if queryValue == "" {
+			return nil, false
+		}
+		input["query"] = queryValue
+		if limit, ok := arguments["limit"]; ok {
+			input["limit"] = limit
+		}
+	case "page_interact":
+		if actions, ok := arguments["actions"]; ok {
+			input["actions"] = actions
+		}
+	}
+	if attach := pageAttachInput(urlValue, arguments, snapshot); len(attach) > 0 {
+		input["attach"] = attach
+	}
+	return input, true
+}
+
+func pageAttachInput(urlValue string, arguments map[string]any, snapshot contextsvc.TaskContextSnapshot) map[string]any {
+	browserKind := strings.ToLower(strings.TrimSpace(firstNonEmpty(stringValue(arguments, "browser_kind", ""), snapshot.BrowserKind)))
+	if browserKind != "chrome" && browserKind != "edge" {
+		return nil
+	}
+	pageURL := strings.TrimSpace(snapshot.PageURL)
+	if pageURL == "" || pageURL != strings.TrimSpace(urlValue) {
+		return nil
+	}
+	target := map[string]any{"url": pageURL}
+	if windowTitle := strings.TrimSpace(snapshot.WindowTitle); windowTitle != "" {
+		target["title_contains"] = windowTitle
+	}
+	attach := map[string]any{
+		"mode":         string(tools.BrowserAttachModeCDP),
+		"browser_kind": browserKind,
+		"target":       target,
+	}
+	if endpointURL := strings.TrimSpace(stringValue(arguments, "endpoint_url", "")); endpointURL != "" {
+		attach["endpoint_url"] = endpointURL
+	}
+	return attach
 }
 
 func requireAuthorizationFlag(intent map[string]any) bool {

--- a/services/local-service/internal/execution/service.go
+++ b/services/local-service/internal/execution/service.go
@@ -3394,7 +3394,7 @@ func pageAttachInput(urlValue string, arguments map[string]any, snapshot context
 	// can request a page tool, but it must not steer browser kind or CDP endpoint
 	// away from the observed foreground session.
 	browserKind := strings.ToLower(strings.TrimSpace(snapshot.BrowserKind))
-	if browserKind != "chrome" && browserKind != "edge" {
+	if browserKind != "" && browserKind != "chrome" && browserKind != "edge" {
 		return nil
 	}
 	pageURL := comparablePageURL(snapshot.PageURL)
@@ -3407,9 +3407,11 @@ func pageAttachInput(urlValue string, arguments map[string]any, snapshot context
 		target["title_contains"] = pageTitle
 	}
 	attach := map[string]any{
-		"mode":         string(tools.BrowserAttachModeCDP),
-		"browser_kind": browserKind,
-		"target":       target,
+		"mode":   string(tools.BrowserAttachModeCDP),
+		"target": target,
+	}
+	if browserKind != "" {
+		attach["browser_kind"] = browserKind
 	}
 	return attach
 }

--- a/services/local-service/internal/execution/service_test.go
+++ b/services/local-service/internal/execution/service_test.go
@@ -3203,6 +3203,10 @@ type stubPlaywrightClient struct {
 	searchResult     tools.BrowserPageSearchResult
 	interactResult   tools.BrowserPageInteractResult
 	structuredResult tools.BrowserStructuredDOMResult
+	attachResult     tools.BrowserAttachedPageResult
+	snapshotResult   tools.BrowserSnapshotResult
+	navigateResult   tools.BrowserNavigationResult
+	tabsResult       tools.BrowserTabsListResult
 	err              error
 }
 
@@ -3266,6 +3270,48 @@ func (s stubPlaywrightClient) StructuredDOM(_ context.Context, url string) (tool
 		result.URL = url
 	}
 	return result, nil
+}
+
+func (s stubPlaywrightClient) AttachCurrentPage(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserAttachedPageResult, error) {
+	if s.err != nil {
+		return tools.BrowserAttachedPageResult{}, s.err
+	}
+	return s.attachResult, nil
+}
+
+func (s stubPlaywrightClient) SnapshotBrowser(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserSnapshotResult, error) {
+	if s.err != nil {
+		return tools.BrowserSnapshotResult{}, s.err
+	}
+	return s.snapshotResult, nil
+}
+
+func (s stubPlaywrightClient) NavigateBrowser(_ context.Context, _ tools.BrowserNavigateRequest) (tools.BrowserNavigationResult, error) {
+	if s.err != nil {
+		return tools.BrowserNavigationResult{}, s.err
+	}
+	return s.navigateResult, nil
+}
+
+func (s stubPlaywrightClient) ListBrowserTabs(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserTabsListResult, error) {
+	if s.err != nil {
+		return tools.BrowserTabsListResult{}, s.err
+	}
+	return s.tabsResult, nil
+}
+
+func (s stubPlaywrightClient) FocusBrowserTab(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserAttachedPageResult, error) {
+	if s.err != nil {
+		return tools.BrowserAttachedPageResult{}, s.err
+	}
+	return s.attachResult, nil
+}
+
+func (s stubPlaywrightClient) InteractBrowser(_ context.Context, _ tools.BrowserInteractRequest) (tools.BrowserPageInteractResult, error) {
+	if s.err != nil {
+		return tools.BrowserPageInteractResult{}, s.err
+	}
+	return s.interactResult, nil
 }
 
 func (s stubOCRWorkerClient) ExtractText(_ context.Context, _ string) (tools.OCRTextResult, error) {

--- a/services/local-service/internal/execution/service_test.go
+++ b/services/local-service/internal/execution/service_test.go
@@ -1858,6 +1858,30 @@ func TestResolvePageToolInputMatchesEquivalentRootURLs(t *testing.T) {
 	}
 }
 
+func TestResolvePageToolInputAllowsWorkerDetectedBrowserKind(t *testing.T) {
+	snapshot := contextsvc.TaskContextSnapshot{
+		PageURL:     "https://example.com/current",
+		PageTitle:   "Current Tab",
+		ProcessPath: "C:/Program Files/Google/Chrome/Application/chrome.exe",
+		WindowTitle: "Current Tab - Google Chrome",
+	}
+	input, ok := resolvePageToolInput("page_read", map[string]any{"url": "https://example.com/current", "browser_kind": "edge"}, snapshot)
+	if !ok {
+		t.Fatal("expected page_read tool input to resolve when browser kind is omitted from snapshot")
+	}
+	attach, ok := input["attach"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected attach hints with worker-detected browser kind fallback, got %+v", input)
+	}
+	if _, exists := attach["browser_kind"]; exists {
+		t.Fatalf("expected attach hints to omit browser_kind when snapshot does not classify it, got %+v", attach)
+	}
+	target, ok := attach["target"].(map[string]any)
+	if !ok || target["url"] != "https://example.com/current" || target["title_contains"] != "Current Tab" {
+		t.Fatalf("expected attach target to remain based on the trusted page snapshot, got %+v", attach)
+	}
+}
+
 func TestExecuteFallsBackWhenModelFails(t *testing.T) {
 	workspaceRoot := filepath.Join(t.TempDir(), "workspace")
 	pathPolicy, err := platform.NewLocalPathPolicy(workspaceRoot)

--- a/services/local-service/internal/execution/service_test.go
+++ b/services/local-service/internal/execution/service_test.go
@@ -3330,7 +3330,6 @@ func (s stubPlaywrightClient) SearchPage(_ context.Context, url, query string, l
 	}
 	return result, nil
 }
-
 func (s stubPlaywrightClient) InteractPage(_ context.Context, url string, _ []map[string]any) (tools.BrowserPageInteractResult, error) {
 	if s.err != nil {
 		return tools.BrowserPageInteractResult{}, s.err
@@ -3341,7 +3340,6 @@ func (s stubPlaywrightClient) InteractPage(_ context.Context, url string, _ []ma
 	}
 	return result, nil
 }
-
 func (s stubPlaywrightClient) StructuredDOM(_ context.Context, url string) (tools.BrowserStructuredDOMResult, error) {
 	if s.err != nil {
 		return tools.BrowserStructuredDOMResult{}, s.err

--- a/services/local-service/internal/execution/service_test.go
+++ b/services/local-service/internal/execution/service_test.go
@@ -1574,12 +1574,13 @@ func TestExecuteDirectBuiltinReadFileUsesToolExecutor(t *testing.T) {
 }
 
 func TestExecuteDirectSidecarPageReadUsesToolExecutor(t *testing.T) {
-	service, _ := newTestExecutionServiceWithPlaywright(t, "unused", stubPlaywrightClient{readResult: tools.BrowserPageReadResult{
-		Title:       "Example Page",
-		TextContent: "page content from sidecar",
-		MIMEType:    "text/html",
-		TextType:    "text/html",
-		Source:      "playwright_sidecar",
+	service, _ := newTestExecutionServiceWithPlaywright(t, "unused", stubPlaywrightClient{attachedReadResult: tools.BrowserPageReadResult{
+		BrowserExecutionMetadata: tools.BrowserExecutionMetadata{Attached: true, BrowserKind: "chrome", BrowserTransport: "cdp", EndpointURL: "http://127.0.0.1:9222"},
+		Title:                    "Example Page",
+		TextContent:              "page content from sidecar",
+		MIMEType:                 "text/html",
+		TextType:                 "text/html",
+		Source:                   "playwright_worker_cdp",
 	}})
 
 	result, err := service.Execute(context.Background(), Request{
@@ -1587,7 +1588,7 @@ func TestExecuteDirectSidecarPageReadUsesToolExecutor(t *testing.T) {
 		RunID:                "run_005",
 		Title:                "页面读取",
 		Intent:               map[string]any{"name": "page_read", "arguments": map[string]any{"url": "https://example.com"}},
-		Snapshot:             contextsvc.TaskContextSnapshot{InputType: "text", Text: "请读取页面", BrowserKind: "chrome", PageURL: "https://example.com", WindowTitle: "Example Page"},
+		Snapshot:             contextsvc.TaskContextSnapshot{InputType: "text", Text: "请读取页面", BrowserKind: "chrome", PageURL: "https://example.com", PageTitle: "Example Page", WindowTitle: "Example Page - Google Chrome"},
 		DeliveryType:         "bubble",
 		ResultTitle:          "页面读取结果",
 		ApprovalGranted:      true,
@@ -1607,8 +1608,15 @@ func TestExecuteDirectSidecarPageReadUsesToolExecutor(t *testing.T) {
 	if attachInput["browser_kind"] != "chrome" {
 		t.Fatalf("expected page_read attach browser kind, got %+v", attachInput)
 	}
+	target, ok := attachInput["target"].(map[string]any)
+	if !ok || target["title_contains"] != "Example Page" {
+		t.Fatalf("expected page_read attach target to use page title, got %+v", attachInput)
+	}
 	if result.ToolOutput["summary_output"] == nil {
 		t.Fatalf("expected sidecar tool summary output, got %+v", result.ToolOutput)
+	}
+	if attached, _ := result.ToolOutput["attached"].(bool); !attached {
+		t.Fatalf("expected page_read tool output to expose attached execution metadata, got %+v", result.ToolOutput)
 	}
 	if len(result.ExtensionAssets) < 4 {
 		t.Fatalf("expected static execution assets plus plugin manifest refs, got %+v", result.ExtensionAssets)
@@ -1799,8 +1807,8 @@ func TestExecuteDirectSidecarPageReadFailureReturnsMappedToolTrace(t *testing.T)
 }
 
 func TestResolvePageToolInputInjectsAttachHintsFromSnapshot(t *testing.T) {
-	snapshot := contextsvc.TaskContextSnapshot{BrowserKind: "edge", PageURL: "https://example.com/current", WindowTitle: "Current Tab"}
-	input, ok := resolvePageToolInput("page_search", map[string]any{"url": "https://example.com/current", "query": "docs", "limit": 2.0}, snapshot)
+	snapshot := contextsvc.TaskContextSnapshot{BrowserKind: "edge", PageURL: "https://example.com/current", PageTitle: "Current Tab", WindowTitle: "Current Tab - Microsoft Edge"}
+	input, ok := resolvePageToolInput("page_search", map[string]any{"url": "https://example.com/current", "query": "docs", "limit": 2.0, "browser_kind": "chrome", "endpoint_url": "http://127.0.0.1:9999"}, snapshot)
 	if !ok {
 		t.Fatal("expected page_search tool input to resolve")
 	}
@@ -1815,6 +1823,9 @@ func TestResolvePageToolInputInjectsAttachHintsFromSnapshot(t *testing.T) {
 	if !ok || target["url"] != "https://example.com/current" || target["title_contains"] != "Current Tab" {
 		t.Fatalf("expected attach target to use current page snapshot, got %+v", attach)
 	}
+	if _, exists := attach["endpoint_url"]; exists {
+		t.Fatalf("expected injected attach hints to ignore model-controlled endpoint override, got %+v", attach)
+	}
 	if input["query"] != "docs" || input["limit"] != 2.0 {
 		t.Fatalf("expected search-specific input to survive attach injection, got %+v", input)
 	}
@@ -1828,6 +1839,22 @@ func TestResolvePageToolInputSkipsAttachWhenSnapshotDoesNotMatchRequestedPage(t 
 	}
 	if _, exists := input["attach"]; exists {
 		t.Fatalf("expected mismatched snapshot to fall back to launch path, got %+v", input)
+	}
+}
+
+func TestResolvePageToolInputMatchesEquivalentRootURLs(t *testing.T) {
+	snapshot := contextsvc.TaskContextSnapshot{BrowserKind: "chrome", PageURL: "https://example.com", PageTitle: "Home"}
+	input, ok := resolvePageToolInput("page_read", map[string]any{"url": "https://example.com/"}, snapshot)
+	if !ok {
+		t.Fatal("expected page_read tool input to resolve for equivalent root URL forms")
+	}
+	attach, ok := input["attach"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected equivalent root URLs to keep attach hints, got %+v", input)
+	}
+	target, ok := attach["target"].(map[string]any)
+	if !ok || target["url"] != "https://example.com/" {
+		t.Fatalf("expected root URL target normalization, got %+v", attach)
 	}
 }
 
@@ -3249,15 +3276,19 @@ type stubExecutionCapability struct {
 }
 
 type stubPlaywrightClient struct {
-	readResult       tools.BrowserPageReadResult
-	searchResult     tools.BrowserPageSearchResult
-	interactResult   tools.BrowserPageInteractResult
-	structuredResult tools.BrowserStructuredDOMResult
-	attachResult     tools.BrowserAttachedPageResult
-	snapshotResult   tools.BrowserSnapshotResult
-	navigateResult   tools.BrowserNavigationResult
-	tabsResult       tools.BrowserTabsListResult
-	err              error
+	readResult               tools.BrowserPageReadResult
+	searchResult             tools.BrowserPageSearchResult
+	interactResult           tools.BrowserPageInteractResult
+	structuredResult         tools.BrowserStructuredDOMResult
+	attachedReadResult       tools.BrowserPageReadResult
+	attachedSearchResult     tools.BrowserPageSearchResult
+	attachedInteractResult   tools.BrowserPageInteractResult
+	attachedStructuredResult tools.BrowserStructuredDOMResult
+	attachResult             tools.BrowserAttachedPageResult
+	snapshotResult           tools.BrowserSnapshotResult
+	navigateResult           tools.BrowserNavigationResult
+	tabsResult               tools.BrowserTabsListResult
+	err                      error
 }
 
 type stubOCRWorkerClient struct {
@@ -3318,6 +3349,73 @@ func (s stubPlaywrightClient) StructuredDOM(_ context.Context, url string) (tool
 	result := s.structuredResult
 	if result.URL == "" {
 		result.URL = url
+	}
+	return result, nil
+}
+
+func (s stubPlaywrightClient) ReadPageAttached(_ context.Context, url string, attach tools.BrowserAttachConfig) (tools.BrowserPageReadResult, error) {
+	if s.err != nil {
+		return tools.BrowserPageReadResult{}, s.err
+	}
+	result := s.attachedReadResult
+	if result.URL == "" {
+		result.URL = url
+	}
+	result.Attached = true
+	if result.BrowserKind == "" {
+		result.BrowserKind = attach.BrowserKind
+	}
+	return result, nil
+}
+
+func (s stubPlaywrightClient) SearchPageAttached(_ context.Context, url, query string, limit int, attach tools.BrowserAttachConfig) (tools.BrowserPageSearchResult, error) {
+	if s.err != nil {
+		return tools.BrowserPageSearchResult{}, s.err
+	}
+	result := s.attachedSearchResult
+	if result.URL == "" {
+		result.URL = url
+	}
+	if result.Query == "" {
+		result.Query = query
+	}
+	if limit > 0 && len(result.Matches) > limit {
+		result.Matches = result.Matches[:limit]
+		result.MatchCount = len(result.Matches)
+	}
+	result.Attached = true
+	if result.BrowserKind == "" {
+		result.BrowserKind = attach.BrowserKind
+	}
+	return result, nil
+}
+
+func (s stubPlaywrightClient) InteractPageAttached(_ context.Context, url string, _ []map[string]any, attach tools.BrowserAttachConfig) (tools.BrowserPageInteractResult, error) {
+	if s.err != nil {
+		return tools.BrowserPageInteractResult{}, s.err
+	}
+	result := s.attachedInteractResult
+	if result.URL == "" {
+		result.URL = url
+	}
+	result.Attached = true
+	if result.BrowserKind == "" {
+		result.BrowserKind = attach.BrowserKind
+	}
+	return result, nil
+}
+
+func (s stubPlaywrightClient) StructuredDOMAttached(_ context.Context, url string, attach tools.BrowserAttachConfig) (tools.BrowserStructuredDOMResult, error) {
+	if s.err != nil {
+		return tools.BrowserStructuredDOMResult{}, s.err
+	}
+	result := s.attachedStructuredResult
+	if result.URL == "" {
+		result.URL = url
+	}
+	result.Attached = true
+	if result.BrowserKind == "" {
+		result.BrowserKind = attach.BrowserKind
 	}
 	return result, nil
 }

--- a/services/local-service/internal/execution/service_test.go
+++ b/services/local-service/internal/execution/service_test.go
@@ -1587,7 +1587,7 @@ func TestExecuteDirectSidecarPageReadUsesToolExecutor(t *testing.T) {
 		RunID:                "run_005",
 		Title:                "页面读取",
 		Intent:               map[string]any{"name": "page_read", "arguments": map[string]any{"url": "https://example.com"}},
-		Snapshot:             contextsvc.TaskContextSnapshot{InputType: "text", Text: "请读取页面"},
+		Snapshot:             contextsvc.TaskContextSnapshot{InputType: "text", Text: "请读取页面", BrowserKind: "chrome", PageURL: "https://example.com", WindowTitle: "Example Page"},
 		DeliveryType:         "bubble",
 		ResultTitle:          "页面读取结果",
 		ApprovalGranted:      true,
@@ -1599,6 +1599,13 @@ func TestExecuteDirectSidecarPageReadUsesToolExecutor(t *testing.T) {
 	}
 	if result.ToolName != "page_read" {
 		t.Fatalf("expected page_read tool, got %s", result.ToolName)
+	}
+	attachInput, ok := result.ToolInput["attach"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected page_read tool input to carry attach hints, got %+v", result.ToolInput)
+	}
+	if attachInput["browser_kind"] != "chrome" {
+		t.Fatalf("expected page_read attach browser kind, got %+v", attachInput)
 	}
 	if result.ToolOutput["summary_output"] == nil {
 		t.Fatalf("expected sidecar tool summary output, got %+v", result.ToolOutput)
@@ -1788,6 +1795,39 @@ func TestExecuteDirectSidecarPageReadFailureReturnsMappedToolTrace(t *testing.T)
 	}
 	if result.ToolCalls[0].ErrorCode == nil || *result.ToolCalls[0].ErrorCode != tools.ToolErrorCodePlaywrightSidecarFail {
 		t.Fatalf("expected unified sidecar error code, got %+v", result.ToolCalls[0])
+	}
+}
+
+func TestResolvePageToolInputInjectsAttachHintsFromSnapshot(t *testing.T) {
+	snapshot := contextsvc.TaskContextSnapshot{BrowserKind: "edge", PageURL: "https://example.com/current", WindowTitle: "Current Tab"}
+	input, ok := resolvePageToolInput("page_search", map[string]any{"url": "https://example.com/current", "query": "docs", "limit": 2.0}, snapshot)
+	if !ok {
+		t.Fatal("expected page_search tool input to resolve")
+	}
+	attach, ok := input["attach"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected attach hints in page_search input, got %+v", input)
+	}
+	if attach["browser_kind"] != "edge" {
+		t.Fatalf("expected attach browser kind edge, got %+v", attach)
+	}
+	target, ok := attach["target"].(map[string]any)
+	if !ok || target["url"] != "https://example.com/current" || target["title_contains"] != "Current Tab" {
+		t.Fatalf("expected attach target to use current page snapshot, got %+v", attach)
+	}
+	if input["query"] != "docs" || input["limit"] != 2.0 {
+		t.Fatalf("expected search-specific input to survive attach injection, got %+v", input)
+	}
+}
+
+func TestResolvePageToolInputSkipsAttachWhenSnapshotDoesNotMatchRequestedPage(t *testing.T) {
+	snapshot := contextsvc.TaskContextSnapshot{BrowserKind: "chrome", PageURL: "https://example.com/current", WindowTitle: "Current Tab"}
+	input, ok := resolvePageToolInput("page_read", map[string]any{"url": "https://example.com/other"}, snapshot)
+	if !ok {
+		t.Fatal("expected page_read tool input to resolve")
+	}
+	if _, exists := input["attach"]; exists {
+		t.Fatalf("expected mismatched snapshot to fall back to launch path, got %+v", input)
 	}
 }
 
@@ -2896,13 +2936,14 @@ func TestAssessGovernancePageSearchPreservesQueryInput(t *testing.T) {
 func TestResolveToolExecutionSupportsWorkerAndInteractiveIntents(t *testing.T) {
 	service, _ := newTestExecutionServiceWithWorkers(t, "unused", sidecarclient.NewNoopPlaywrightSidecarClient(), sidecarclient.NewNoopOCRWorkerClient(), sidecarclient.NewNoopMediaWorkerClient())
 	tests := []struct {
-		name     string
-		request  Request
-		wantTool string
-		wantKey  string
+		name       string
+		request    Request
+		wantTool   string
+		wantKey    string
+		wantAttach bool
 	}{
-		{name: "page_interact", request: Request{Intent: map[string]any{"name": "page_interact", "arguments": map[string]any{"url": "https://example.com", "actions": []any{map[string]any{"type": "click", "selector": "button"}}}}}, wantTool: "page_interact", wantKey: "url"},
-		{name: "structured_dom", request: Request{Intent: map[string]any{"name": "structured_dom", "arguments": map[string]any{"url": "https://example.com"}}}, wantTool: "structured_dom", wantKey: "url"},
+		{name: "page_interact", request: Request{Intent: map[string]any{"name": "page_interact", "arguments": map[string]any{"url": "https://example.com", "actions": []any{map[string]any{"type": "click", "selector": "button"}}}}, Snapshot: contextsvc.TaskContextSnapshot{BrowserKind: "chrome", PageURL: "https://example.com", WindowTitle: "Example"}}, wantTool: "page_interact", wantKey: "url", wantAttach: true},
+		{name: "structured_dom", request: Request{Intent: map[string]any{"name": "structured_dom", "arguments": map[string]any{"url": "https://example.com"}}, Snapshot: contextsvc.TaskContextSnapshot{BrowserKind: "chrome", PageURL: "https://example.com", WindowTitle: "Example"}}, wantTool: "structured_dom", wantKey: "url", wantAttach: true},
 		{name: "extract_text", request: Request{Intent: map[string]any{"name": "extract_text", "arguments": map[string]any{"path": "notes/demo.txt"}}}, wantTool: "extract_text", wantKey: "path"},
 		{name: "transcode_media", request: Request{Intent: map[string]any{"name": "transcode_media", "arguments": map[string]any{"path": "clips/demo.mov", "output_path": "clips/demo.mp4", "format": "mp4"}}}, wantTool: "transcode_media", wantKey: "output_path"},
 		{name: "extract_frames", request: Request{Intent: map[string]any{"name": "extract_frames", "arguments": map[string]any{"path": "clips/demo.mov", "output_dir": "frames", "limit": 2.0}}}, wantTool: "extract_frames", wantKey: "output_dir"},
@@ -2916,6 +2957,10 @@ func TestResolveToolExecutionSupportsWorkerAndInteractiveIntents(t *testing.T) {
 			if _, exists := input[test.wantKey]; !exists {
 				t.Fatalf("expected input key %s, got %+v", test.wantKey, input)
 			}
+			_, hasAttach := input["attach"]
+			if hasAttach != test.wantAttach {
+				t.Fatalf("expected attach=%v, got input %+v", test.wantAttach, input)
+			}
 		})
 	}
 }
@@ -2923,12 +2968,13 @@ func TestResolveToolExecutionSupportsWorkerAndInteractiveIntents(t *testing.T) {
 func TestResolveGovernanceToolExecutionSupportsWorkerAndInteractiveIntents(t *testing.T) {
 	service, workspaceRoot := newTestExecutionServiceWithWorkers(t, "unused", sidecarclient.NewNoopPlaywrightSidecarClient(), sidecarclient.NewNoopOCRWorkerClient(), sidecarclient.NewNoopMediaWorkerClient())
 	tests := []struct {
-		name     string
-		request  Request
-		wantTool string
+		name       string
+		request    Request
+		wantTool   string
+		wantAttach bool
 	}{
-		{name: "page_interact", request: Request{TaskID: "task_001", RunID: "run_001", DeliveryType: "bubble", ResultTitle: "页面交互结果", Intent: map[string]any{"name": "page_interact", "arguments": map[string]any{"url": "https://example.com", "actions": []any{map[string]any{"type": "click", "selector": "button"}}}}}, wantTool: "page_interact"},
-		{name: "structured_dom", request: Request{TaskID: "task_002", RunID: "run_002", DeliveryType: "bubble", ResultTitle: "结构化结果", Intent: map[string]any{"name": "structured_dom", "arguments": map[string]any{"url": "https://example.com"}}}, wantTool: "structured_dom"},
+		{name: "page_interact", request: Request{TaskID: "task_001", RunID: "run_001", DeliveryType: "bubble", ResultTitle: "页面交互结果", Intent: map[string]any{"name": "page_interact", "arguments": map[string]any{"url": "https://example.com", "actions": []any{map[string]any{"type": "click", "selector": "button"}}}}, Snapshot: contextsvc.TaskContextSnapshot{BrowserKind: "chrome", PageURL: "https://example.com", WindowTitle: "Example"}}, wantTool: "page_interact", wantAttach: true},
+		{name: "structured_dom", request: Request{TaskID: "task_002", RunID: "run_002", DeliveryType: "bubble", ResultTitle: "结构化结果", Intent: map[string]any{"name": "structured_dom", "arguments": map[string]any{"url": "https://example.com"}}, Snapshot: contextsvc.TaskContextSnapshot{BrowserKind: "chrome", PageURL: "https://example.com", WindowTitle: "Example"}}, wantTool: "structured_dom", wantAttach: true},
 		{name: "ocr_pdf", request: Request{TaskID: "task_003", RunID: "run_003", DeliveryType: "bubble", ResultTitle: "OCR 结果", Intent: map[string]any{"name": "ocr_pdf", "arguments": map[string]any{"path": "docs/demo.pdf", "language": "eng"}}}, wantTool: "ocr_pdf"},
 		{name: "normalize_recording", request: Request{TaskID: "task_004", RunID: "run_004", DeliveryType: "bubble", ResultTitle: "归一化结果", Intent: map[string]any{"name": "normalize_recording", "arguments": map[string]any{"path": "clips/demo.mov", "output_path": "clips/demo.mp4"}}}, wantTool: "normalize_recording"},
 	}
@@ -2946,6 +2992,10 @@ func TestResolveGovernanceToolExecutionSupportsWorkerAndInteractiveIntents(t *te
 			}
 			if len(input) == 0 {
 				t.Fatalf("expected tool input, got %+v", input)
+			}
+			_, hasAttach := input["attach"]
+			if hasAttach != test.wantAttach {
+				t.Fatalf("expected attach=%v, got input %+v", test.wantAttach, input)
 			}
 		})
 	}

--- a/services/local-service/internal/orchestrator/service.go
+++ b/services/local-service/internal/orchestrator/service.go
@@ -3714,6 +3714,15 @@ func snapshotWithMissingAnchors(selected, fallback contextsvc.TaskContextSnapsho
 	if strings.TrimSpace(merged.AppName) == "" {
 		merged.AppName = fallback.AppName
 	}
+	if strings.TrimSpace(merged.BrowserKind) == "" {
+		merged.BrowserKind = fallback.BrowserKind
+	}
+	if strings.TrimSpace(merged.ProcessPath) == "" {
+		merged.ProcessPath = fallback.ProcessPath
+	}
+	if merged.ProcessID == 0 {
+		merged.ProcessID = fallback.ProcessID
+	}
 	if strings.TrimSpace(merged.WindowTitle) == "" {
 		merged.WindowTitle = fallback.WindowTitle
 	}
@@ -6551,6 +6560,9 @@ func isEmptySnapshot(snapshot contextsvc.TaskContextSnapshot) bool {
 		strings.TrimSpace(snapshot.PageTitle) == "" &&
 		strings.TrimSpace(snapshot.PageURL) == "" &&
 		strings.TrimSpace(snapshot.AppName) == "" &&
+		strings.TrimSpace(snapshot.BrowserKind) == "" &&
+		strings.TrimSpace(snapshot.ProcessPath) == "" &&
+		snapshot.ProcessID == 0 &&
 		strings.TrimSpace(snapshot.WindowTitle) == "" &&
 		strings.TrimSpace(snapshot.VisibleText) == "" &&
 		strings.TrimSpace(snapshot.ScreenSummary) == "" &&

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -144,6 +144,10 @@ func (s stubPlaywrightClient) ReadPage(_ context.Context, url string) (tools.Bro
 	return result, nil
 }
 
+func (s stubPlaywrightClient) ReadPageAttached(ctx context.Context, url string, _ tools.BrowserAttachConfig) (tools.BrowserPageReadResult, error) {
+	return s.ReadPage(ctx, url)
+}
+
 func (localHTTPPlaywrightClient) ReadPage(_ context.Context, url string) (tools.BrowserPageReadResult, error) {
 	response, err := http.Get(url)
 	if err != nil {
@@ -172,16 +176,44 @@ func (localHTTPPlaywrightClient) ReadPage(_ context.Context, url string) (tools.
 	}, nil
 }
 
+func (c localHTTPPlaywrightClient) ReadPageAttached(ctx context.Context, url string, _ tools.BrowserAttachConfig) (tools.BrowserPageReadResult, error) {
+	return c.ReadPage(ctx, url)
+}
+
 func (localHTTPPlaywrightClient) SearchPage(_ context.Context, url, query string, _ int) (tools.BrowserPageSearchResult, error) {
 	return tools.BrowserPageSearchResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (localHTTPPlaywrightClient) SearchPageAttached(_ context.Context, _, _ string, _ int, _ tools.BrowserAttachConfig) (tools.BrowserPageSearchResult, error) {
+	return tools.BrowserPageSearchResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (s stubPlaywrightClient) SearchPageAttached(ctx context.Context, url, query string, limit int, _ tools.BrowserAttachConfig) (tools.BrowserPageSearchResult, error) {
+	return s.SearchPage(ctx, url, query, limit)
 }
 
 func (localHTTPPlaywrightClient) InteractPage(_ context.Context, _ string, _ []map[string]any) (tools.BrowserPageInteractResult, error) {
 	return tools.BrowserPageInteractResult{}, tools.ErrPlaywrightSidecarFailed
 }
 
+func (localHTTPPlaywrightClient) InteractPageAttached(_ context.Context, _ string, _ []map[string]any, _ tools.BrowserAttachConfig) (tools.BrowserPageInteractResult, error) {
+	return tools.BrowserPageInteractResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (s stubPlaywrightClient) InteractPageAttached(ctx context.Context, url string, actions []map[string]any, _ tools.BrowserAttachConfig) (tools.BrowserPageInteractResult, error) {
+	return s.InteractPage(ctx, url, actions)
+}
+
 func (localHTTPPlaywrightClient) StructuredDOM(_ context.Context, _ string) (tools.BrowserStructuredDOMResult, error) {
 	return tools.BrowserStructuredDOMResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (localHTTPPlaywrightClient) StructuredDOMAttached(_ context.Context, _ string, _ tools.BrowserAttachConfig) (tools.BrowserStructuredDOMResult, error) {
+	return tools.BrowserStructuredDOMResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (s stubPlaywrightClient) StructuredDOMAttached(ctx context.Context, url string, _ tools.BrowserAttachConfig) (tools.BrowserStructuredDOMResult, error) {
+	return s.StructuredDOM(ctx, url)
 }
 
 func (localHTTPPlaywrightClient) AttachCurrentPage(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserAttachedPageResult, error) {

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -14496,6 +14496,9 @@ func TestFresherTaskRecordRestoresRuntimeAnchorsWhenStorageProjectionIsNewer(t *
 		Snapshot: contextsvc.TaskContextSnapshot{
 			PageURL:     "https://example.com/build",
 			AppName:     "Chrome",
+			BrowserKind: "chrome",
+			ProcessPath: "C:/Program Files/Google/Chrome/Application/chrome.exe",
+			ProcessID:   4242,
 			WindowTitle: "Browser - Build Dashboard",
 		},
 	}
@@ -14523,6 +14526,9 @@ func TestFresherTaskRecordRestoresRuntimeAnchorsWhenStorageProjectionIsNewer(t *
 	}
 	if selected.Snapshot.PageURL != runtimeTask.Snapshot.PageURL ||
 		selected.Snapshot.AppName != runtimeTask.Snapshot.AppName ||
+		selected.Snapshot.BrowserKind != runtimeTask.Snapshot.BrowserKind ||
+		selected.Snapshot.ProcessPath != runtimeTask.Snapshot.ProcessPath ||
+		selected.Snapshot.ProcessID != runtimeTask.Snapshot.ProcessID ||
 		selected.Snapshot.WindowTitle != runtimeTask.Snapshot.WindowTitle {
 		t.Fatalf("expected runtime snapshot anchors to fill the newer partial storage snapshot, got %+v", selected.Snapshot)
 	}
@@ -14530,6 +14536,26 @@ func TestFresherTaskRecordRestoresRuntimeAnchorsWhenStorageProjectionIsNewer(t *
 		len(selected.Snapshot.Files) != 1 ||
 		selected.Snapshot.Files[0] != storageTask.Snapshot.Files[0] {
 		t.Fatalf("expected newer storage snapshot payload to stay selected, got %+v", selected.Snapshot)
+	}
+}
+
+func TestSnapshotFromTaskPreservesAttachOnlySnapshot(t *testing.T) {
+	attachOnlyTask := runengine.TaskRecord{
+		TaskID: "task_attach_only",
+		Title:  "Resume attached browser task",
+		Snapshot: contextsvc.TaskContextSnapshot{
+			BrowserKind: "edge",
+			ProcessPath: "C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe",
+			ProcessID:   5150,
+		},
+	}
+
+	snapshot := snapshotFromTask(attachOnlyTask)
+	if snapshot.BrowserKind != "edge" || snapshot.ProcessPath != attachOnlyTask.Snapshot.ProcessPath || snapshot.ProcessID != 5150 {
+		t.Fatalf("expected attach-only snapshot to survive resume reconstruction, got %+v", snapshot)
+	}
+	if snapshot.InputType != "" || snapshot.Text != "" {
+		t.Fatalf("expected attach-only snapshot to avoid synthetic text fallback, got %+v", snapshot)
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -91,6 +91,10 @@ type stubPlaywrightClient struct {
 	searchResult     tools.BrowserPageSearchResult
 	interactResult   tools.BrowserPageInteractResult
 	structuredResult tools.BrowserStructuredDOMResult
+	attachResult     tools.BrowserAttachedPageResult
+	snapshotResult   tools.BrowserSnapshotResult
+	navigateResult   tools.BrowserNavigationResult
+	tabsResult       tools.BrowserTabsListResult
 	err              error
 }
 
@@ -180,6 +184,30 @@ func (localHTTPPlaywrightClient) StructuredDOM(_ context.Context, _ string) (too
 	return tools.BrowserStructuredDOMResult{}, tools.ErrPlaywrightSidecarFailed
 }
 
+func (localHTTPPlaywrightClient) AttachCurrentPage(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserAttachedPageResult, error) {
+	return tools.BrowserAttachedPageResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (localHTTPPlaywrightClient) SnapshotBrowser(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserSnapshotResult, error) {
+	return tools.BrowserSnapshotResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (localHTTPPlaywrightClient) NavigateBrowser(_ context.Context, _ tools.BrowserNavigateRequest) (tools.BrowserNavigationResult, error) {
+	return tools.BrowserNavigationResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (localHTTPPlaywrightClient) ListBrowserTabs(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserTabsListResult, error) {
+	return tools.BrowserTabsListResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (localHTTPPlaywrightClient) FocusBrowserTab(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserAttachedPageResult, error) {
+	return tools.BrowserAttachedPageResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (localHTTPPlaywrightClient) InteractBrowser(_ context.Context, _ tools.BrowserInteractRequest) (tools.BrowserPageInteractResult, error) {
+	return tools.BrowserPageInteractResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
 func (c *recordingScreenCaptureClient) StartSession(ctx context.Context, input tools.ScreenSessionStartInput) (tools.ScreenSessionState, error) {
 	c.startCalls = append(c.startCalls, input)
 	return c.base.StartSession(ctx, input)
@@ -258,6 +286,48 @@ func (s stubPlaywrightClient) StructuredDOM(_ context.Context, url string) (tool
 		result.URL = url
 	}
 	return result, nil
+}
+
+func (s stubPlaywrightClient) AttachCurrentPage(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserAttachedPageResult, error) {
+	if s.err != nil {
+		return tools.BrowserAttachedPageResult{}, s.err
+	}
+	return s.attachResult, nil
+}
+
+func (s stubPlaywrightClient) SnapshotBrowser(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserSnapshotResult, error) {
+	if s.err != nil {
+		return tools.BrowserSnapshotResult{}, s.err
+	}
+	return s.snapshotResult, nil
+}
+
+func (s stubPlaywrightClient) NavigateBrowser(_ context.Context, _ tools.BrowserNavigateRequest) (tools.BrowserNavigationResult, error) {
+	if s.err != nil {
+		return tools.BrowserNavigationResult{}, s.err
+	}
+	return s.navigateResult, nil
+}
+
+func (s stubPlaywrightClient) ListBrowserTabs(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserTabsListResult, error) {
+	if s.err != nil {
+		return tools.BrowserTabsListResult{}, s.err
+	}
+	return s.tabsResult, nil
+}
+
+func (s stubPlaywrightClient) FocusBrowserTab(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserAttachedPageResult, error) {
+	if s.err != nil {
+		return tools.BrowserAttachedPageResult{}, s.err
+	}
+	return s.attachResult, nil
+}
+
+func (s stubPlaywrightClient) InteractBrowser(_ context.Context, _ tools.BrowserInteractRequest) (tools.BrowserPageInteractResult, error) {
+	if s.err != nil {
+		return tools.BrowserPageInteractResult{}, s.err
+	}
+	return s.interactResult, nil
 }
 
 func (s stubOCRWorkerClient) ExtractText(_ context.Context, _ string) (tools.OCRTextResult, error) {

--- a/services/local-service/internal/runengine/continuation_runtime_test.go
+++ b/services/local-service/internal/runengine/continuation_runtime_test.go
@@ -17,8 +17,11 @@ func TestEngineContinueTaskMergesContinuationStateAndDrainsSteeringMessages(t *t
 		CurrentStep: "collect_input",
 		RiskLevel:   "green",
 		Snapshot: contextsvc.TaskContextSnapshot{
-			Source: "floating_ball",
-			Text:   "original text",
+			Source:      "floating_ball",
+			Text:        "original text",
+			BrowserKind: "chrome",
+			ProcessPath: "C:/Program Files/Google/Chrome/Application/chrome.exe",
+			ProcessID:   4242,
 		},
 	})
 
@@ -33,6 +36,9 @@ func TestEngineContinueTaskMergesContinuationStateAndDrainsSteeringMessages(t *t
 		Snapshot: contextsvc.TaskContextSnapshot{
 			Text:          "updated text",
 			SelectionText: "important paragraph",
+			BrowserKind:   "edge",
+			ProcessPath:   "C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe",
+			ProcessID:     5150,
 		},
 		SteeringMessage: "focus on highlights",
 	})
@@ -44,6 +50,9 @@ func TestEngineContinueTaskMergesContinuationStateAndDrainsSteeringMessages(t *t
 	}
 	if updated.Snapshot.SelectionText != "important paragraph" || updated.Snapshot.Source != "floating_ball" {
 		t.Fatalf("expected continuation snapshot to merge with prior source, got %+v", updated.Snapshot)
+	}
+	if updated.Snapshot.BrowserKind != "edge" || updated.Snapshot.ProcessPath != "C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe" || updated.Snapshot.ProcessID != 5150 {
+		t.Fatalf("expected continuation snapshot to keep latest attach hints, got %+v", updated.Snapshot)
 	}
 	if !strings.Contains(updated.Snapshot.Text, "original text") || !strings.Contains(updated.Snapshot.Text, "updated text") {
 		t.Fatalf("expected continuation snapshot to merge with prior source, got %+v", updated.Snapshot)

--- a/services/local-service/internal/runengine/engine.go
+++ b/services/local-service/internal/runengine/engine.go
@@ -2439,6 +2439,11 @@ func mergeTaskSnapshot(base, update contextsvc.TaskContextSnapshot) contextsvc.T
 	merged.PageTitle = pickLastNonEmpty(base.PageTitle, update.PageTitle)
 	merged.PageURL = pickLastNonEmpty(base.PageURL, update.PageURL)
 	merged.AppName = pickLastNonEmpty(base.AppName, update.AppName)
+	merged.BrowserKind = pickLastNonEmpty(base.BrowserKind, update.BrowserKind)
+	merged.ProcessPath = pickLastNonEmpty(base.ProcessPath, update.ProcessPath)
+	if update.ProcessID > 0 {
+		merged.ProcessID = update.ProcessID
+	}
 	merged.WindowTitle = pickLastNonEmpty(base.WindowTitle, update.WindowTitle)
 	merged.VisibleText = mergeSnapshotText(base.VisibleText, update.VisibleText)
 	merged.ScreenSummary = mergeSnapshotText(base.ScreenSummary, update.ScreenSummary)

--- a/services/local-service/internal/tools/sidecarclient/playwright.go
+++ b/services/local-service/internal/tools/sidecarclient/playwright.go
@@ -57,6 +57,13 @@ func (noopPlaywrightSidecarClient) InteractBrowser(_ context.Context, _ tools.Br
 	return tools.BrowserPageInteractResult{}, tools.ErrPlaywrightSidecarFailed
 }
 
+type attachAwarePageClient interface {
+	ReadPageAttached(ctx context.Context, url string, attach tools.BrowserAttachConfig) (tools.BrowserPageReadResult, error)
+	SearchPageAttached(ctx context.Context, url, query string, limit int, attach tools.BrowserAttachConfig) (tools.BrowserPageSearchResult, error)
+	InteractPageAttached(ctx context.Context, url string, actions []map[string]any, attach tools.BrowserAttachConfig) (tools.BrowserPageInteractResult, error)
+	StructuredDOMAttached(ctx context.Context, url string, attach tools.BrowserAttachConfig) (tools.BrowserStructuredDOMResult, error)
+}
+
 type PageReadTool struct {
 	meta tools.ToolMetadata
 }
@@ -90,22 +97,28 @@ func (t *PageReadTool) Execute(ctx context.Context, execCtx *tools.ToolExecuteCo
 		return nil, tools.ErrPlaywrightSidecarFailed
 	}
 	url := strings.TrimSpace(input["url"].(string))
-	result, err := execCtx.Playwright.ReadPage(ctx, url)
+	result, err := pageReadResult(ctx, execCtx.Playwright, url, input)
 	if err != nil {
 		return nil, err
 	}
-	rawOutput := map[string]any{
-		"url":          result.URL,
-		"title":        result.Title,
-		"text_content": result.TextContent,
-		"mime_type":    result.MIMEType,
-		"text_type":    result.TextType,
-		"source":       firstNonEmptyString(result.Source, "playwright_sidecar"),
-	}
+	rawOutput := browserExecutionMetadataOutput(result.BrowserExecutionMetadata)
+	rawOutput["url"] = result.URL
+	rawOutput["title"] = result.Title
+	rawOutput["text_content"] = result.TextContent
+	rawOutput["mime_type"] = result.MIMEType
+	rawOutput["text_type"] = result.TextType
+	rawOutput["source"] = firstNonEmptyString(result.Source, "playwright_sidecar")
 	return &tools.ToolResult{
-		ToolName:      t.meta.Name,
-		RawOutput:     rawOutput,
-		SummaryOutput: map[string]any{"url": result.URL, "title": result.Title, "content_preview": previewPageText(result.TextContent), "source": firstNonEmptyString(result.Source, "playwright_sidecar")},
+		ToolName:  t.meta.Name,
+		RawOutput: rawOutput,
+		SummaryOutput: map[string]any{
+			"url":             result.URL,
+			"title":           result.Title,
+			"browser_kind":    result.BrowserKind,
+			"attached":        result.Attached,
+			"content_preview": previewPageText(result.TextContent),
+			"source":          firstNonEmptyString(result.Source, "playwright_sidecar"),
+		},
 	}, nil
 }
 
@@ -170,21 +183,28 @@ func (t *PageInteractTool) Execute(ctx context.Context, execCtx *tools.ToolExecu
 	}
 	url := strings.TrimSpace(input["url"].(string))
 	actions := mapSliceValue(input, "actions")
-	result, err := execCtx.Playwright.InteractPage(ctx, url, actions)
+	result, err := pageInteractResult(ctx, execCtx.Playwright, url, actions, input)
 	if err != nil {
 		return nil, err
 	}
-	rawOutput := map[string]any{
-		"url":             result.URL,
-		"title":           result.Title,
-		"text_content":    result.TextContent,
-		"actions_applied": result.ActionsApplied,
-		"source":          firstNonEmptyString(result.Source, "playwright_sidecar"),
-	}
+	rawOutput := browserExecutionMetadataOutput(result.BrowserExecutionMetadata)
+	rawOutput["url"] = result.URL
+	rawOutput["title"] = result.Title
+	rawOutput["text_content"] = result.TextContent
+	rawOutput["actions_applied"] = result.ActionsApplied
+	rawOutput["source"] = firstNonEmptyString(result.Source, "playwright_sidecar")
 	return &tools.ToolResult{
-		ToolName:      t.meta.Name,
-		RawOutput:     rawOutput,
-		SummaryOutput: map[string]any{"url": result.URL, "title": result.Title, "content_preview": previewPageText(result.TextContent), "actions_applied": result.ActionsApplied, "source": firstNonEmptyString(result.Source, "playwright_sidecar")},
+		ToolName:  t.meta.Name,
+		RawOutput: rawOutput,
+		SummaryOutput: map[string]any{
+			"url":             result.URL,
+			"title":           result.Title,
+			"browser_kind":    result.BrowserKind,
+			"attached":        result.Attached,
+			"content_preview": previewPageText(result.TextContent),
+			"actions_applied": result.ActionsApplied,
+			"source":          firstNonEmptyString(result.Source, "playwright_sidecar"),
+		},
 	}, nil
 }
 
@@ -221,23 +241,22 @@ func (t *StructuredDOMTool) Execute(ctx context.Context, execCtx *tools.ToolExec
 		return nil, tools.ErrPlaywrightSidecarFailed
 	}
 	url := strings.TrimSpace(input["url"].(string))
-	result, err := execCtx.Playwright.StructuredDOM(ctx, url)
+	result, err := structuredDOMResult(ctx, execCtx.Playwright, url, input)
 	if err != nil {
 		return nil, err
 	}
-	rawOutput := map[string]any{
-		"url":      result.URL,
-		"title":    result.Title,
-		"headings": append([]string(nil), result.Headings...),
-		"links":    append([]string(nil), result.Links...),
-		"buttons":  append([]string(nil), result.Buttons...),
-		"inputs":   append([]string(nil), result.Inputs...),
-		"source":   firstNonEmptyString(result.Source, "playwright_sidecar"),
-	}
+	rawOutput := browserExecutionMetadataOutput(result.BrowserExecutionMetadata)
+	rawOutput["url"] = result.URL
+	rawOutput["title"] = result.Title
+	rawOutput["headings"] = append([]string(nil), result.Headings...)
+	rawOutput["links"] = append([]string(nil), result.Links...)
+	rawOutput["buttons"] = append([]string(nil), result.Buttons...)
+	rawOutput["inputs"] = append([]string(nil), result.Inputs...)
+	rawOutput["source"] = firstNonEmptyString(result.Source, "playwright_sidecar")
 	return &tools.ToolResult{
 		ToolName:      t.meta.Name,
 		RawOutput:     rawOutput,
-		SummaryOutput: map[string]any{"url": result.URL, "title": result.Title, "heading_count": len(result.Headings), "link_count": len(result.Links), "button_count": len(result.Buttons), "input_count": len(result.Inputs), "source": firstNonEmptyString(result.Source, "playwright_sidecar")},
+		SummaryOutput: map[string]any{"url": result.URL, "title": result.Title, "browser_kind": result.BrowserKind, "attached": result.Attached, "heading_count": len(result.Headings), "link_count": len(result.Links), "button_count": len(result.Buttons), "input_count": len(result.Inputs), "source": firstNonEmptyString(result.Source, "playwright_sidecar")},
 	}, nil
 }
 
@@ -274,21 +293,20 @@ func (t *PageSearchTool) Execute(ctx context.Context, execCtx *tools.ToolExecute
 			}
 		}
 	}
-	result, err := execCtx.Playwright.SearchPage(ctx, url, query, limit)
+	result, err := pageSearchResult(ctx, execCtx.Playwright, url, query, limit, input)
 	if err != nil {
 		return nil, err
 	}
-	rawOutput := map[string]any{
-		"url":         result.URL,
-		"query":       result.Query,
-		"match_count": result.MatchCount,
-		"matches":     append([]string(nil), result.Matches...),
-		"source":      firstNonEmptyString(result.Source, "playwright_sidecar"),
-	}
+	rawOutput := browserExecutionMetadataOutput(result.BrowserExecutionMetadata)
+	rawOutput["url"] = result.URL
+	rawOutput["query"] = result.Query
+	rawOutput["match_count"] = result.MatchCount
+	rawOutput["matches"] = append([]string(nil), result.Matches...)
+	rawOutput["source"] = firstNonEmptyString(result.Source, "playwright_sidecar")
 	return &tools.ToolResult{
 		ToolName:      t.meta.Name,
 		RawOutput:     rawOutput,
-		SummaryOutput: map[string]any{"url": result.URL, "query": result.Query, "match_count": result.MatchCount, "source": firstNonEmptyString(result.Source, "playwright_sidecar")},
+		SummaryOutput: map[string]any{"url": result.URL, "query": result.Query, "browser_kind": result.BrowserKind, "attached": result.Attached, "match_count": result.MatchCount, "source": firstNonEmptyString(result.Source, "playwright_sidecar")},
 	}, nil
 }
 
@@ -310,6 +328,77 @@ func RegisterPlaywrightTools(registry *tools.Registry) error {
 		}
 	}
 	return nil
+}
+
+func pageReadResult(ctx context.Context, client tools.PlaywrightSidecarClient, url string, input map[string]any) (tools.BrowserPageReadResult, error) {
+	attach, ok, err := optionalAttachConfigFromInput(input)
+	if err != nil {
+		return tools.BrowserPageReadResult{}, err
+	}
+	if !ok {
+		return client.ReadPage(ctx, url)
+	}
+	attachClient, ok := client.(attachAwarePageClient)
+	if !ok {
+		return tools.BrowserPageReadResult{}, tools.ErrPlaywrightSidecarFailed
+	}
+	return attachClient.ReadPageAttached(ctx, url, attach)
+}
+
+func pageSearchResult(ctx context.Context, client tools.PlaywrightSidecarClient, url, query string, limit int, input map[string]any) (tools.BrowserPageSearchResult, error) {
+	attach, ok, err := optionalAttachConfigFromInput(input)
+	if err != nil {
+		return tools.BrowserPageSearchResult{}, err
+	}
+	if !ok {
+		return client.SearchPage(ctx, url, query, limit)
+	}
+	attachClient, ok := client.(attachAwarePageClient)
+	if !ok {
+		return tools.BrowserPageSearchResult{}, tools.ErrPlaywrightSidecarFailed
+	}
+	return attachClient.SearchPageAttached(ctx, url, query, limit, attach)
+}
+
+func pageInteractResult(ctx context.Context, client tools.PlaywrightSidecarClient, url string, actions []map[string]any, input map[string]any) (tools.BrowserPageInteractResult, error) {
+	attach, ok, err := optionalAttachConfigFromInput(input)
+	if err != nil {
+		return tools.BrowserPageInteractResult{}, err
+	}
+	if !ok {
+		return client.InteractPage(ctx, url, actions)
+	}
+	attachClient, ok := client.(attachAwarePageClient)
+	if !ok {
+		return tools.BrowserPageInteractResult{}, tools.ErrPlaywrightSidecarFailed
+	}
+	return attachClient.InteractPageAttached(ctx, url, actions, attach)
+}
+
+func structuredDOMResult(ctx context.Context, client tools.PlaywrightSidecarClient, url string, input map[string]any) (tools.BrowserStructuredDOMResult, error) {
+	attach, ok, err := optionalAttachConfigFromInput(input)
+	if err != nil {
+		return tools.BrowserStructuredDOMResult{}, err
+	}
+	if !ok {
+		return client.StructuredDOM(ctx, url)
+	}
+	attachClient, ok := client.(attachAwarePageClient)
+	if !ok {
+		return tools.BrowserStructuredDOMResult{}, tools.ErrPlaywrightSidecarFailed
+	}
+	return attachClient.StructuredDOMAttached(ctx, url, attach)
+}
+
+func optionalAttachConfigFromInput(input map[string]any) (tools.BrowserAttachConfig, bool, error) {
+	if _, ok := input["attach"]; !ok {
+		return tools.BrowserAttachConfig{}, false, nil
+	}
+	attach, err := attachConfigFromInput(input)
+	if err != nil {
+		return tools.BrowserAttachConfig{}, false, err
+	}
+	return attach, true, nil
 }
 
 func mapSliceValue(values map[string]any, key string) []map[string]any {

--- a/services/local-service/internal/tools/sidecarclient/playwright.go
+++ b/services/local-service/internal/tools/sidecarclient/playwright.go
@@ -33,6 +33,30 @@ func (noopPlaywrightSidecarClient) StructuredDOM(_ context.Context, _ string) (t
 	return tools.BrowserStructuredDOMResult{}, tools.ErrPlaywrightSidecarFailed
 }
 
+func (noopPlaywrightSidecarClient) AttachCurrentPage(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserAttachedPageResult, error) {
+	return tools.BrowserAttachedPageResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (noopPlaywrightSidecarClient) SnapshotBrowser(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserSnapshotResult, error) {
+	return tools.BrowserSnapshotResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (noopPlaywrightSidecarClient) NavigateBrowser(_ context.Context, _ tools.BrowserNavigateRequest) (tools.BrowserNavigationResult, error) {
+	return tools.BrowserNavigationResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (noopPlaywrightSidecarClient) ListBrowserTabs(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserTabsListResult, error) {
+	return tools.BrowserTabsListResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (noopPlaywrightSidecarClient) FocusBrowserTab(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserAttachedPageResult, error) {
+	return tools.BrowserAttachedPageResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (noopPlaywrightSidecarClient) InteractBrowser(_ context.Context, _ tools.BrowserInteractRequest) (tools.BrowserPageInteractResult, error) {
+	return tools.BrowserPageInteractResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
 type PageReadTool struct {
 	meta tools.ToolMetadata
 }
@@ -269,7 +293,18 @@ func (t *PageSearchTool) Execute(ctx context.Context, execCtx *tools.ToolExecute
 }
 
 func RegisterPlaywrightTools(registry *tools.Registry) error {
-	for _, tool := range []tools.Tool{NewPageReadTool(), NewPageSearchTool(), NewPageInteractTool(), NewStructuredDOMTool()} {
+	for _, tool := range []tools.Tool{
+		NewPageReadTool(),
+		NewPageSearchTool(),
+		NewPageInteractTool(),
+		NewStructuredDOMTool(),
+		NewBrowserAttachCurrentTool(),
+		NewBrowserSnapshotTool(),
+		NewBrowserNavigateTool(),
+		NewBrowserTabsListTool(),
+		NewBrowserTabFocusTool(),
+		NewBrowserInteractTool(),
+	} {
 		if err := registry.Register(tool); err != nil {
 			return err
 		}

--- a/services/local-service/internal/tools/sidecarclient/playwright.go
+++ b/services/local-service/internal/tools/sidecarclient/playwright.go
@@ -21,7 +21,15 @@ func (noopPlaywrightSidecarClient) ReadPage(_ context.Context, _ string) (tools.
 	return tools.BrowserPageReadResult{}, tools.ErrPlaywrightSidecarFailed
 }
 
+func (noopPlaywrightSidecarClient) ReadPageAttached(_ context.Context, _ string, _ tools.BrowserAttachConfig) (tools.BrowserPageReadResult, error) {
+	return tools.BrowserPageReadResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
 func (noopPlaywrightSidecarClient) SearchPage(_ context.Context, _, _ string, _ int) (tools.BrowserPageSearchResult, error) {
+	return tools.BrowserPageSearchResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (noopPlaywrightSidecarClient) SearchPageAttached(_ context.Context, _, _ string, _ int, _ tools.BrowserAttachConfig) (tools.BrowserPageSearchResult, error) {
 	return tools.BrowserPageSearchResult{}, tools.ErrPlaywrightSidecarFailed
 }
 
@@ -29,7 +37,15 @@ func (noopPlaywrightSidecarClient) InteractPage(_ context.Context, _ string, _ [
 	return tools.BrowserPageInteractResult{}, tools.ErrPlaywrightSidecarFailed
 }
 
+func (noopPlaywrightSidecarClient) InteractPageAttached(_ context.Context, _ string, _ []map[string]any, _ tools.BrowserAttachConfig) (tools.BrowserPageInteractResult, error) {
+	return tools.BrowserPageInteractResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
 func (noopPlaywrightSidecarClient) StructuredDOM(_ context.Context, _ string) (tools.BrowserStructuredDOMResult, error) {
+	return tools.BrowserStructuredDOMResult{}, tools.ErrPlaywrightSidecarFailed
+}
+
+func (noopPlaywrightSidecarClient) StructuredDOMAttached(_ context.Context, _ string, _ tools.BrowserAttachConfig) (tools.BrowserStructuredDOMResult, error) {
 	return tools.BrowserStructuredDOMResult{}, tools.ErrPlaywrightSidecarFailed
 }
 
@@ -57,13 +73,6 @@ func (noopPlaywrightSidecarClient) InteractBrowser(_ context.Context, _ tools.Br
 	return tools.BrowserPageInteractResult{}, tools.ErrPlaywrightSidecarFailed
 }
 
-type attachAwarePageClient interface {
-	ReadPageAttached(ctx context.Context, url string, attach tools.BrowserAttachConfig) (tools.BrowserPageReadResult, error)
-	SearchPageAttached(ctx context.Context, url, query string, limit int, attach tools.BrowserAttachConfig) (tools.BrowserPageSearchResult, error)
-	InteractPageAttached(ctx context.Context, url string, actions []map[string]any, attach tools.BrowserAttachConfig) (tools.BrowserPageInteractResult, error)
-	StructuredDOMAttached(ctx context.Context, url string, attach tools.BrowserAttachConfig) (tools.BrowserStructuredDOMResult, error)
-}
-
 type PageReadTool struct {
 	meta tools.ToolMetadata
 }
@@ -89,6 +98,9 @@ func (t *PageReadTool) Validate(input map[string]any) error {
 	if !ok || strings.TrimSpace(url) == "" {
 		return fmt.Errorf("input field 'url' must be a non-empty string")
 	}
+	if _, _, err := optionalAttachConfigFromInput(input); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -97,7 +109,16 @@ func (t *PageReadTool) Execute(ctx context.Context, execCtx *tools.ToolExecuteCo
 		return nil, tools.ErrPlaywrightSidecarFailed
 	}
 	url := strings.TrimSpace(input["url"].(string))
-	result, err := pageReadResult(ctx, execCtx.Playwright, url, input)
+	attach, attached, err := optionalAttachConfigFromInput(input)
+	if err != nil {
+		return nil, err
+	}
+	var result tools.BrowserPageReadResult
+	if attached {
+		result, err = execCtx.Playwright.ReadPageAttached(ctx, url, attach)
+	} else {
+		result, err = execCtx.Playwright.ReadPage(ctx, url)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -114,8 +135,8 @@ func (t *PageReadTool) Execute(ctx context.Context, execCtx *tools.ToolExecuteCo
 		SummaryOutput: map[string]any{
 			"url":             result.URL,
 			"title":           result.Title,
-			"browser_kind":    result.BrowserKind,
 			"attached":        result.Attached,
+			"browser_kind":    result.BrowserKind,
 			"content_preview": previewPageText(result.TextContent),
 			"source":          firstNonEmptyString(result.Source, "playwright_sidecar"),
 		},
@@ -165,6 +186,9 @@ func (t *PageInteractTool) Validate(input map[string]any) error {
 	if !ok || strings.TrimSpace(url) == "" {
 		return fmt.Errorf("input field 'url' must be a non-empty string")
 	}
+	if _, _, err := optionalAttachConfigFromInput(input); err != nil {
+		return err
+	}
 	actions := mapSliceValue(input, "actions")
 	if len(actions) == 0 {
 		return fmt.Errorf("input field 'actions' must be a non-empty array")
@@ -183,7 +207,16 @@ func (t *PageInteractTool) Execute(ctx context.Context, execCtx *tools.ToolExecu
 	}
 	url := strings.TrimSpace(input["url"].(string))
 	actions := mapSliceValue(input, "actions")
-	result, err := pageInteractResult(ctx, execCtx.Playwright, url, actions, input)
+	attach, attached, err := optionalAttachConfigFromInput(input)
+	if err != nil {
+		return nil, err
+	}
+	var result tools.BrowserPageInteractResult
+	if attached {
+		result, err = execCtx.Playwright.InteractPageAttached(ctx, url, actions, attach)
+	} else {
+		result, err = execCtx.Playwright.InteractPage(ctx, url, actions)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -199,8 +232,8 @@ func (t *PageInteractTool) Execute(ctx context.Context, execCtx *tools.ToolExecu
 		SummaryOutput: map[string]any{
 			"url":             result.URL,
 			"title":           result.Title,
-			"browser_kind":    result.BrowserKind,
 			"attached":        result.Attached,
+			"browser_kind":    result.BrowserKind,
 			"content_preview": previewPageText(result.TextContent),
 			"actions_applied": result.ActionsApplied,
 			"source":          firstNonEmptyString(result.Source, "playwright_sidecar"),
@@ -233,6 +266,9 @@ func (t *StructuredDOMTool) Validate(input map[string]any) error {
 	if !ok || strings.TrimSpace(url) == "" {
 		return fmt.Errorf("input field 'url' must be a non-empty string")
 	}
+	if _, _, err := optionalAttachConfigFromInput(input); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -241,7 +277,16 @@ func (t *StructuredDOMTool) Execute(ctx context.Context, execCtx *tools.ToolExec
 		return nil, tools.ErrPlaywrightSidecarFailed
 	}
 	url := strings.TrimSpace(input["url"].(string))
-	result, err := structuredDOMResult(ctx, execCtx.Playwright, url, input)
+	attach, attached, err := optionalAttachConfigFromInput(input)
+	if err != nil {
+		return nil, err
+	}
+	var result tools.BrowserStructuredDOMResult
+	if attached {
+		result, err = execCtx.Playwright.StructuredDOMAttached(ctx, url, attach)
+	} else {
+		result, err = execCtx.Playwright.StructuredDOM(ctx, url)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +301,7 @@ func (t *StructuredDOMTool) Execute(ctx context.Context, execCtx *tools.ToolExec
 	return &tools.ToolResult{
 		ToolName:      t.meta.Name,
 		RawOutput:     rawOutput,
-		SummaryOutput: map[string]any{"url": result.URL, "title": result.Title, "browser_kind": result.BrowserKind, "attached": result.Attached, "heading_count": len(result.Headings), "link_count": len(result.Links), "button_count": len(result.Buttons), "input_count": len(result.Inputs), "source": firstNonEmptyString(result.Source, "playwright_sidecar")},
+		SummaryOutput: map[string]any{"url": result.URL, "title": result.Title, "attached": result.Attached, "browser_kind": result.BrowserKind, "heading_count": len(result.Headings), "link_count": len(result.Links), "button_count": len(result.Buttons), "input_count": len(result.Inputs), "source": firstNonEmptyString(result.Source, "playwright_sidecar")},
 	}, nil
 }
 
@@ -270,6 +315,9 @@ func (t *PageSearchTool) Validate(input map[string]any) error {
 	query, ok := input["query"].(string)
 	if !ok || strings.TrimSpace(query) == "" {
 		return fmt.Errorf("input field 'query' must be a non-empty string")
+	}
+	if _, _, err := optionalAttachConfigFromInput(input); err != nil {
+		return err
 	}
 	return nil
 }
@@ -293,7 +341,16 @@ func (t *PageSearchTool) Execute(ctx context.Context, execCtx *tools.ToolExecute
 			}
 		}
 	}
-	result, err := pageSearchResult(ctx, execCtx.Playwright, url, query, limit, input)
+	attach, attached, err := optionalAttachConfigFromInput(input)
+	if err != nil {
+		return nil, err
+	}
+	var result tools.BrowserPageSearchResult
+	if attached {
+		result, err = execCtx.Playwright.SearchPageAttached(ctx, url, query, limit, attach)
+	} else {
+		result, err = execCtx.Playwright.SearchPage(ctx, url, query, limit)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +363,7 @@ func (t *PageSearchTool) Execute(ctx context.Context, execCtx *tools.ToolExecute
 	return &tools.ToolResult{
 		ToolName:      t.meta.Name,
 		RawOutput:     rawOutput,
-		SummaryOutput: map[string]any{"url": result.URL, "query": result.Query, "browser_kind": result.BrowserKind, "attached": result.Attached, "match_count": result.MatchCount, "source": firstNonEmptyString(result.Source, "playwright_sidecar")},
+		SummaryOutput: map[string]any{"url": result.URL, "query": result.Query, "attached": result.Attached, "browser_kind": result.BrowserKind, "match_count": result.MatchCount, "source": firstNonEmptyString(result.Source, "playwright_sidecar")},
 	}, nil
 }
 
@@ -328,77 +385,6 @@ func RegisterPlaywrightTools(registry *tools.Registry) error {
 		}
 	}
 	return nil
-}
-
-func pageReadResult(ctx context.Context, client tools.PlaywrightSidecarClient, url string, input map[string]any) (tools.BrowserPageReadResult, error) {
-	attach, ok, err := optionalAttachConfigFromInput(input)
-	if err != nil {
-		return tools.BrowserPageReadResult{}, err
-	}
-	if !ok {
-		return client.ReadPage(ctx, url)
-	}
-	attachClient, ok := client.(attachAwarePageClient)
-	if !ok {
-		return tools.BrowserPageReadResult{}, tools.ErrPlaywrightSidecarFailed
-	}
-	return attachClient.ReadPageAttached(ctx, url, attach)
-}
-
-func pageSearchResult(ctx context.Context, client tools.PlaywrightSidecarClient, url, query string, limit int, input map[string]any) (tools.BrowserPageSearchResult, error) {
-	attach, ok, err := optionalAttachConfigFromInput(input)
-	if err != nil {
-		return tools.BrowserPageSearchResult{}, err
-	}
-	if !ok {
-		return client.SearchPage(ctx, url, query, limit)
-	}
-	attachClient, ok := client.(attachAwarePageClient)
-	if !ok {
-		return tools.BrowserPageSearchResult{}, tools.ErrPlaywrightSidecarFailed
-	}
-	return attachClient.SearchPageAttached(ctx, url, query, limit, attach)
-}
-
-func pageInteractResult(ctx context.Context, client tools.PlaywrightSidecarClient, url string, actions []map[string]any, input map[string]any) (tools.BrowserPageInteractResult, error) {
-	attach, ok, err := optionalAttachConfigFromInput(input)
-	if err != nil {
-		return tools.BrowserPageInteractResult{}, err
-	}
-	if !ok {
-		return client.InteractPage(ctx, url, actions)
-	}
-	attachClient, ok := client.(attachAwarePageClient)
-	if !ok {
-		return tools.BrowserPageInteractResult{}, tools.ErrPlaywrightSidecarFailed
-	}
-	return attachClient.InteractPageAttached(ctx, url, actions, attach)
-}
-
-func structuredDOMResult(ctx context.Context, client tools.PlaywrightSidecarClient, url string, input map[string]any) (tools.BrowserStructuredDOMResult, error) {
-	attach, ok, err := optionalAttachConfigFromInput(input)
-	if err != nil {
-		return tools.BrowserStructuredDOMResult{}, err
-	}
-	if !ok {
-		return client.StructuredDOM(ctx, url)
-	}
-	attachClient, ok := client.(attachAwarePageClient)
-	if !ok {
-		return tools.BrowserStructuredDOMResult{}, tools.ErrPlaywrightSidecarFailed
-	}
-	return attachClient.StructuredDOMAttached(ctx, url, attach)
-}
-
-func optionalAttachConfigFromInput(input map[string]any) (tools.BrowserAttachConfig, bool, error) {
-	if _, ok := input["attach"]; !ok {
-		return tools.BrowserAttachConfig{}, false, nil
-	}
-	attach, err := attachConfigFromInput(input)
-	if err != nil {
-		return tools.BrowserAttachConfig{}, false, err
-	}
-	return attach, true, nil
 }
 
 func mapSliceValue(values map[string]any, key string) []map[string]any {
@@ -463,4 +449,15 @@ func firstNonEmptyString(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func optionalAttachConfigFromInput(input map[string]any) (tools.BrowserAttachConfig, bool, error) {
+	if _, ok := input["attach"]; !ok {
+		return tools.BrowserAttachConfig{}, false, nil
+	}
+	attach, err := attachConfigFromInput(input)
+	if err != nil {
+		return tools.BrowserAttachConfig{}, false, err
+	}
+	return attach, true, nil
 }

--- a/services/local-service/internal/tools/sidecarclient/playwright_browser.go
+++ b/services/local-service/internal/tools/sidecarclient/playwright_browser.go
@@ -372,11 +372,10 @@ func attachConfigFromInput(input map[string]any) (tools.BrowserAttachConfig, err
 		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.mode must be 'cdp'")
 	}
 	browserKind := strings.ToLower(strings.TrimSpace(stringValueMap(attachInput, "browser_kind")))
-	if browserKind == "" {
-		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.browser_kind must be a non-empty string")
-	}
-	if _, ok := supportedAttachedBrowserKinds[browserKind]; !ok {
-		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.browser_kind must be one of chrome or edge")
+	if browserKind != "" {
+		if _, ok := supportedAttachedBrowserKinds[browserKind]; !ok {
+			return tools.BrowserAttachConfig{}, fmt.Errorf("attach.browser_kind must be one of chrome or edge")
+		}
 	}
 	targetInput, ok := attachInput["target"].(map[string]any)
 	if !ok {

--- a/services/local-service/internal/tools/sidecarclient/playwright_browser.go
+++ b/services/local-service/internal/tools/sidecarclient/playwright_browser.go
@@ -377,8 +377,8 @@ func attachConfigFromInput(input map[string]any) (tools.BrowserAttachConfig, err
 		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.browser_kind must be one of chrome or edge")
 	}
 	targetInput, ok := attachInput["target"].(map[string]any)
-	if !ok || len(targetInput) == 0 {
-		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.target must be an object")
+	if !ok {
+		targetInput = nil
 	}
 	target := tools.BrowserAttachTarget{
 		URL:           strings.TrimSpace(stringValueMap(targetInput, "url")),
@@ -387,9 +387,6 @@ func attachConfigFromInput(input map[string]any) (tools.BrowserAttachConfig, err
 	}
 	if _, exists := targetInput["page_index"]; exists && target.PageIndex == nil {
 		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.target.page_index must be a non-negative integer")
-	}
-	if target.URL == "" && target.TitleContains == "" && target.PageIndex == nil {
-		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.target must include at least one of url, title_contains, or page_index")
 	}
 	return tools.BrowserAttachConfig{
 		Mode:        mode,

--- a/services/local-service/internal/tools/sidecarclient/playwright_browser.go
+++ b/services/local-service/internal/tools/sidecarclient/playwright_browser.go
@@ -410,6 +410,12 @@ func validateLoopbackEndpointURL(raw string) error {
 	if err != nil {
 		return fmt.Errorf("attach.endpoint_url must be a valid URL")
 	}
+	scheme := strings.TrimSpace(strings.ToLower(parsed.Scheme))
+	switch scheme {
+	case "http", "https", "ws", "wss":
+	default:
+		return fmt.Errorf("attach.endpoint_url must use http, https, ws, or wss")
+	}
 	hostname := strings.TrimSpace(strings.ToLower(parsed.Hostname()))
 	if hostname == "" {
 		return fmt.Errorf("attach.endpoint_url must include a host")

--- a/services/local-service/internal/tools/sidecarclient/playwright_browser.go
+++ b/services/local-service/internal/tools/sidecarclient/playwright_browser.go
@@ -3,6 +3,8 @@ package sidecarclient
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/tools"
@@ -388,12 +390,38 @@ func attachConfigFromInput(input map[string]any) (tools.BrowserAttachConfig, err
 	if _, exists := targetInput["page_index"]; exists && target.PageIndex == nil {
 		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.target.page_index must be a non-negative integer")
 	}
+	endpointURL := strings.TrimSpace(stringValueMap(attachInput, "endpoint_url"))
+	if err := validateLoopbackEndpointURL(endpointURL); err != nil {
+		return tools.BrowserAttachConfig{}, err
+	}
 	return tools.BrowserAttachConfig{
 		Mode:        mode,
 		BrowserKind: browserKind,
-		EndpointURL: strings.TrimSpace(stringValueMap(attachInput, "endpoint_url")),
+		EndpointURL: endpointURL,
 		Target:      target,
 	}, nil
+}
+
+func validateLoopbackEndpointURL(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("attach.endpoint_url must be a valid URL")
+	}
+	hostname := strings.TrimSpace(strings.ToLower(parsed.Hostname()))
+	if hostname == "" {
+		return fmt.Errorf("attach.endpoint_url must include a host")
+	}
+	if hostname == "localhost" {
+		return nil
+	}
+	ip := net.ParseIP(hostname)
+	if ip != nil && ip.IsLoopback() {
+		return nil
+	}
+	return fmt.Errorf("attach.endpoint_url must target a loopback host")
 }
 
 func intPointerValue(values map[string]any, key string) *int {

--- a/services/local-service/internal/tools/sidecarclient/playwright_browser.go
+++ b/services/local-service/internal/tools/sidecarclient/playwright_browser.go
@@ -1,0 +1,462 @@
+package sidecarclient
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/tools"
+)
+
+var supportedAttachedBrowserKinds = map[string]struct{}{
+	"chrome": {},
+	"edge":   {},
+}
+
+type BrowserAttachCurrentTool struct {
+	meta tools.ToolMetadata
+}
+
+// NewBrowserAttachCurrentTool returns the attach-only tool that resolves the
+// user's current Chromium tab selection before any mutating action is attempted.
+func NewBrowserAttachCurrentTool() *BrowserAttachCurrentTool {
+	return &BrowserAttachCurrentTool{meta: tools.ToolMetadata{
+		Name:            "browser_attach_current",
+		DisplayName:     "附着浏览器当前页",
+		Description:     "通过 Playwright sidecar 附着用户当前 Chromium 浏览器页并返回匹配结果",
+		Source:          tools.ToolSourceSidecar,
+		RiskHint:        "green",
+		TimeoutSec:      20,
+		InputSchemaRef:  "tools/browser_attach_current/input",
+		OutputSchemaRef: "tools/browser_attach_current/output",
+		SupportsDryRun:  false,
+	}}
+}
+
+func (t *BrowserAttachCurrentTool) Metadata() tools.ToolMetadata { return t.meta }
+
+func (t *BrowserAttachCurrentTool) Validate(input map[string]any) error {
+	_, err := attachConfigFromInput(input)
+	return err
+}
+
+func (t *BrowserAttachCurrentTool) Execute(ctx context.Context, execCtx *tools.ToolExecuteContext, input map[string]any) (*tools.ToolResult, error) {
+	if execCtx == nil || execCtx.Playwright == nil {
+		return nil, tools.ErrPlaywrightSidecarFailed
+	}
+	attach, err := attachConfigFromInput(input)
+	if err != nil {
+		return nil, err
+	}
+	result, err := execCtx.Playwright.AttachCurrentPage(ctx, attach)
+	if err != nil {
+		return nil, err
+	}
+	rawOutput := browserAttachedPageRawOutput(result)
+	return &tools.ToolResult{
+		ToolName:      t.meta.Name,
+		RawOutput:     rawOutput,
+		SummaryOutput: map[string]any{"url": result.URL, "title": result.Title, "page_index": result.PageIndex, "browser_kind": result.BrowserKind, "source": firstNonEmptyString(result.Source, "playwright_sidecar")},
+	}, nil
+}
+
+type BrowserSnapshotTool struct {
+	meta tools.ToolMetadata
+}
+
+// NewBrowserSnapshotTool returns the tool that reads the currently attached
+// browser tab without navigating away from the user's real browser state.
+func NewBrowserSnapshotTool() *BrowserSnapshotTool {
+	return &BrowserSnapshotTool{meta: tools.ToolMetadata{
+		Name:            "browser_snapshot",
+		DisplayName:     "浏览器快照",
+		Description:     "通过 Playwright sidecar 读取当前附着浏览器页的文本与结构化摘要",
+		Source:          tools.ToolSourceSidecar,
+		RiskHint:        "green",
+		TimeoutSec:      20,
+		InputSchemaRef:  "tools/browser_snapshot/input",
+		OutputSchemaRef: "tools/browser_snapshot/output",
+		SupportsDryRun:  false,
+	}}
+}
+
+func (t *BrowserSnapshotTool) Metadata() tools.ToolMetadata { return t.meta }
+
+func (t *BrowserSnapshotTool) Validate(input map[string]any) error {
+	_, err := attachConfigFromInput(input)
+	return err
+}
+
+func (t *BrowserSnapshotTool) Execute(ctx context.Context, execCtx *tools.ToolExecuteContext, input map[string]any) (*tools.ToolResult, error) {
+	if execCtx == nil || execCtx.Playwright == nil {
+		return nil, tools.ErrPlaywrightSidecarFailed
+	}
+	attach, err := attachConfigFromInput(input)
+	if err != nil {
+		return nil, err
+	}
+	result, err := execCtx.Playwright.SnapshotBrowser(ctx, attach)
+	if err != nil {
+		return nil, err
+	}
+	rawOutput := browserAttachedPageRawOutput(result.BrowserAttachedPageResult)
+	rawOutput["text_content"] = result.TextContent
+	rawOutput["headings"] = append([]string(nil), result.Headings...)
+	rawOutput["links"] = append([]string(nil), result.Links...)
+	rawOutput["buttons"] = append([]string(nil), result.Buttons...)
+	rawOutput["inputs"] = append([]string(nil), result.Inputs...)
+	return &tools.ToolResult{
+		ToolName:  t.meta.Name,
+		RawOutput: rawOutput,
+		SummaryOutput: map[string]any{
+			"url":             result.URL,
+			"title":           result.Title,
+			"page_index":      result.PageIndex,
+			"browser_kind":    result.BrowserKind,
+			"content_preview": previewPageText(result.TextContent),
+			"heading_count":   len(result.Headings),
+			"link_count":      len(result.Links),
+			"button_count":    len(result.Buttons),
+			"input_count":     len(result.Inputs),
+			"source":          firstNonEmptyString(result.Source, "playwright_sidecar"),
+		},
+	}, nil
+}
+
+type BrowserNavigateTool struct {
+	meta tools.ToolMetadata
+}
+
+// NewBrowserNavigateTool returns the tool that navigates the currently
+// attached browser tab through the real-browser CDP session.
+func NewBrowserNavigateTool() *BrowserNavigateTool {
+	return &BrowserNavigateTool{meta: tools.ToolMetadata{
+		Name:            "browser_navigate",
+		DisplayName:     "浏览器导航",
+		Description:     "通过 Playwright sidecar 在当前附着浏览器页中导航到指定 URL",
+		Source:          tools.ToolSourceSidecar,
+		RiskHint:        "yellow",
+		TimeoutSec:      30,
+		InputSchemaRef:  "tools/browser_navigate/input",
+		OutputSchemaRef: "tools/browser_navigate/output",
+		SupportsDryRun:  false,
+	}}
+}
+
+func (t *BrowserNavigateTool) Metadata() tools.ToolMetadata { return t.meta }
+
+func (t *BrowserNavigateTool) Validate(input map[string]any) error {
+	if _, err := attachConfigFromInput(input); err != nil {
+		return err
+	}
+	url, ok := input["url"].(string)
+	if !ok || strings.TrimSpace(url) == "" {
+		return fmt.Errorf("input field 'url' must be a non-empty string")
+	}
+	return nil
+}
+
+func (t *BrowserNavigateTool) Execute(ctx context.Context, execCtx *tools.ToolExecuteContext, input map[string]any) (*tools.ToolResult, error) {
+	if execCtx == nil || execCtx.Playwright == nil {
+		return nil, tools.ErrPlaywrightSidecarFailed
+	}
+	attach, err := attachConfigFromInput(input)
+	if err != nil {
+		return nil, err
+	}
+	request := tools.BrowserNavigateRequest{Attach: attach, URL: strings.TrimSpace(input["url"].(string))}
+	result, err := execCtx.Playwright.NavigateBrowser(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	rawOutput := browserAttachedPageRawOutput(result.BrowserAttachedPageResult)
+	rawOutput["text_content"] = result.TextContent
+	rawOutput["mime_type"] = result.MIMEType
+	rawOutput["text_type"] = result.TextType
+	return &tools.ToolResult{
+		ToolName:  t.meta.Name,
+		RawOutput: rawOutput,
+		SummaryOutput: map[string]any{
+			"url":             result.URL,
+			"title":           result.Title,
+			"page_index":      result.PageIndex,
+			"browser_kind":    result.BrowserKind,
+			"content_preview": previewPageText(result.TextContent),
+			"source":          firstNonEmptyString(result.Source, "playwright_sidecar"),
+		},
+	}, nil
+}
+
+type BrowserTabsListTool struct {
+	meta tools.ToolMetadata
+}
+
+// NewBrowserTabsListTool returns the tool that lists attached browser tabs so
+// the planner can reason about the user's real browsing context.
+func NewBrowserTabsListTool() *BrowserTabsListTool {
+	return &BrowserTabsListTool{meta: tools.ToolMetadata{
+		Name:            "browser_tabs_list",
+		DisplayName:     "浏览器标签页列表",
+		Description:     "通过 Playwright sidecar 列出当前附着浏览器的标签页摘要",
+		Source:          tools.ToolSourceSidecar,
+		RiskHint:        "green",
+		TimeoutSec:      20,
+		InputSchemaRef:  "tools/browser_tabs_list/input",
+		OutputSchemaRef: "tools/browser_tabs_list/output",
+		SupportsDryRun:  false,
+	}}
+}
+
+func (t *BrowserTabsListTool) Metadata() tools.ToolMetadata { return t.meta }
+
+func (t *BrowserTabsListTool) Validate(input map[string]any) error {
+	_, err := attachConfigFromInput(input)
+	return err
+}
+
+func (t *BrowserTabsListTool) Execute(ctx context.Context, execCtx *tools.ToolExecuteContext, input map[string]any) (*tools.ToolResult, error) {
+	if execCtx == nil || execCtx.Playwright == nil {
+		return nil, tools.ErrPlaywrightSidecarFailed
+	}
+	attach, err := attachConfigFromInput(input)
+	if err != nil {
+		return nil, err
+	}
+	result, err := execCtx.Playwright.ListBrowserTabs(ctx, attach)
+	if err != nil {
+		return nil, err
+	}
+	rawOutput := browserExecutionMetadataOutput(result.BrowserExecutionMetadata)
+	rawOutput["tab_count"] = result.TabCount
+	rawOutput["tabs"] = browserTabOutputItems(result.Tabs)
+	rawOutput["source"] = firstNonEmptyString(result.Source, "playwright_sidecar")
+	return &tools.ToolResult{
+		ToolName:  t.meta.Name,
+		RawOutput: rawOutput,
+		SummaryOutput: map[string]any{
+			"tab_count":     result.TabCount,
+			"browser_kind":  result.BrowserKind,
+			"first_tab_url": firstBrowserTabURL(result.Tabs),
+			"source":        firstNonEmptyString(result.Source, "playwright_sidecar"),
+		},
+	}, nil
+}
+
+type BrowserTabFocusTool struct {
+	meta tools.ToolMetadata
+}
+
+// NewBrowserTabFocusTool returns the tool that focuses one attached browser
+// tab before follow-up inspection or interaction.
+func NewBrowserTabFocusTool() *BrowserTabFocusTool {
+	return &BrowserTabFocusTool{meta: tools.ToolMetadata{
+		Name:            "browser_tab_focus",
+		DisplayName:     "聚焦浏览器标签页",
+		Description:     "通过 Playwright sidecar 聚焦当前附着浏览器中的目标标签页",
+		Source:          tools.ToolSourceSidecar,
+		RiskHint:        "yellow",
+		TimeoutSec:      20,
+		InputSchemaRef:  "tools/browser_tab_focus/input",
+		OutputSchemaRef: "tools/browser_tab_focus/output",
+		SupportsDryRun:  false,
+	}}
+}
+
+func (t *BrowserTabFocusTool) Metadata() tools.ToolMetadata { return t.meta }
+
+func (t *BrowserTabFocusTool) Validate(input map[string]any) error {
+	_, err := attachConfigFromInput(input)
+	return err
+}
+
+func (t *BrowserTabFocusTool) Execute(ctx context.Context, execCtx *tools.ToolExecuteContext, input map[string]any) (*tools.ToolResult, error) {
+	if execCtx == nil || execCtx.Playwright == nil {
+		return nil, tools.ErrPlaywrightSidecarFailed
+	}
+	attach, err := attachConfigFromInput(input)
+	if err != nil {
+		return nil, err
+	}
+	result, err := execCtx.Playwright.FocusBrowserTab(ctx, attach)
+	if err != nil {
+		return nil, err
+	}
+	rawOutput := browserAttachedPageRawOutput(result)
+	return &tools.ToolResult{
+		ToolName:      t.meta.Name,
+		RawOutput:     rawOutput,
+		SummaryOutput: map[string]any{"url": result.URL, "title": result.Title, "page_index": result.PageIndex, "browser_kind": result.BrowserKind, "source": firstNonEmptyString(result.Source, "playwright_sidecar")},
+	}, nil
+}
+
+type BrowserInteractTool struct {
+	meta tools.ToolMetadata
+}
+
+// NewBrowserInteractTool returns the tool that performs controlled interactions
+// against the currently attached real-browser tab.
+func NewBrowserInteractTool() *BrowserInteractTool {
+	return &BrowserInteractTool{meta: tools.ToolMetadata{
+		Name:            "browser_interact",
+		DisplayName:     "浏览器交互",
+		Description:     "通过 Playwright sidecar 在当前附着浏览器页执行交互并返回最新页面摘要",
+		Source:          tools.ToolSourceSidecar,
+		RiskHint:        "yellow",
+		TimeoutSec:      30,
+		InputSchemaRef:  "tools/browser_interact/input",
+		OutputSchemaRef: "tools/browser_interact/output",
+		SupportsDryRun:  false,
+	}}
+}
+
+func (t *BrowserInteractTool) Metadata() tools.ToolMetadata { return t.meta }
+
+func (t *BrowserInteractTool) Validate(input map[string]any) error {
+	if _, err := attachConfigFromInput(input); err != nil {
+		return err
+	}
+	actions := mapSliceValue(input, "actions")
+	if len(actions) == 0 {
+		return fmt.Errorf("input field 'actions' must be a non-empty array")
+	}
+	for _, action := range actions {
+		if strings.TrimSpace(stringValueMap(action, "type")) == "" {
+			return fmt.Errorf("each browser interaction action must include a non-empty type")
+		}
+	}
+	return nil
+}
+
+func (t *BrowserInteractTool) Execute(ctx context.Context, execCtx *tools.ToolExecuteContext, input map[string]any) (*tools.ToolResult, error) {
+	if execCtx == nil || execCtx.Playwright == nil {
+		return nil, tools.ErrPlaywrightSidecarFailed
+	}
+	attach, err := attachConfigFromInput(input)
+	if err != nil {
+		return nil, err
+	}
+	request := tools.BrowserInteractRequest{Attach: attach, Actions: mapSliceValue(input, "actions")}
+	result, err := execCtx.Playwright.InteractBrowser(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	rawOutput := browserExecutionMetadataOutput(result.BrowserExecutionMetadata)
+	rawOutput["url"] = result.URL
+	rawOutput["title"] = result.Title
+	rawOutput["text_content"] = result.TextContent
+	rawOutput["actions_applied"] = result.ActionsApplied
+	rawOutput["source"] = firstNonEmptyString(result.Source, "playwright_sidecar")
+	return &tools.ToolResult{
+		ToolName:  t.meta.Name,
+		RawOutput: rawOutput,
+		SummaryOutput: map[string]any{
+			"url":             result.URL,
+			"title":           result.Title,
+			"browser_kind":    result.BrowserKind,
+			"content_preview": previewPageText(result.TextContent),
+			"actions_applied": result.ActionsApplied,
+			"source":          firstNonEmptyString(result.Source, "playwright_sidecar"),
+		},
+	}, nil
+}
+
+func attachConfigFromInput(input map[string]any) (tools.BrowserAttachConfig, error) {
+	attachInput, ok := input["attach"].(map[string]any)
+	if !ok || len(attachInput) == 0 {
+		return tools.BrowserAttachConfig{}, fmt.Errorf("input field 'attach' must be an object")
+	}
+	mode := tools.BrowserAttachMode(firstNonEmptyString(stringValueMap(attachInput, "mode"), string(tools.BrowserAttachModeCDP)))
+	if mode != tools.BrowserAttachModeCDP {
+		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.mode must be 'cdp'")
+	}
+	browserKind := strings.ToLower(strings.TrimSpace(stringValueMap(attachInput, "browser_kind")))
+	if browserKind == "" {
+		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.browser_kind must be a non-empty string")
+	}
+	if _, ok := supportedAttachedBrowserKinds[browserKind]; !ok {
+		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.browser_kind must be one of chrome or edge")
+	}
+	targetInput, ok := attachInput["target"].(map[string]any)
+	if !ok || len(targetInput) == 0 {
+		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.target must be an object")
+	}
+	target := tools.BrowserAttachTarget{
+		URL:           strings.TrimSpace(stringValueMap(targetInput, "url")),
+		TitleContains: strings.TrimSpace(stringValueMap(targetInput, "title_contains")),
+		PageIndex:     intPointerValue(targetInput, "page_index"),
+	}
+	if _, exists := targetInput["page_index"]; exists && target.PageIndex == nil {
+		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.target.page_index must be a non-negative integer")
+	}
+	if target.URL == "" && target.TitleContains == "" && target.PageIndex == nil {
+		return tools.BrowserAttachConfig{}, fmt.Errorf("attach.target must include at least one of url, title_contains, or page_index")
+	}
+	return tools.BrowserAttachConfig{
+		Mode:        mode,
+		BrowserKind: browserKind,
+		EndpointURL: strings.TrimSpace(stringValueMap(attachInput, "endpoint_url")),
+		Target:      target,
+	}, nil
+}
+
+func intPointerValue(values map[string]any, key string) *int {
+	if len(values) == 0 {
+		return nil
+	}
+	var value int
+	switch typed := values[key].(type) {
+	case int:
+		value = typed
+	case float64:
+		if typed != float64(int(typed)) {
+			return nil
+		}
+		value = int(typed)
+	default:
+		return nil
+	}
+	if value < 0 {
+		return nil
+	}
+	return &value
+}
+
+func browserExecutionMetadataOutput(metadata tools.BrowserExecutionMetadata) map[string]any {
+	return map[string]any{
+		"attached":          metadata.Attached,
+		"browser_kind":      metadata.BrowserKind,
+		"browser_transport": metadata.BrowserTransport,
+		"endpoint_url":      metadata.EndpointURL,
+	}
+}
+
+func browserAttachedPageRawOutput(result tools.BrowserAttachedPageResult) map[string]any {
+	rawOutput := browserExecutionMetadataOutput(result.BrowserExecutionMetadata)
+	rawOutput["page_index"] = result.PageIndex
+	rawOutput["title"] = result.Title
+	rawOutput["url"] = result.URL
+	rawOutput["source"] = firstNonEmptyString(result.Source, "playwright_sidecar")
+	return rawOutput
+}
+
+func browserTabOutputItems(items []tools.BrowserTabInfo) []map[string]any {
+	if len(items) == 0 {
+		return nil
+	}
+	result := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		result = append(result, map[string]any{
+			"page_index": item.PageIndex,
+			"title":      item.Title,
+			"url":        item.URL,
+		})
+	}
+	return result
+}
+
+func firstBrowserTabURL(items []tools.BrowserTabInfo) string {
+	if len(items) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(items[0].URL)
+}

--- a/services/local-service/internal/tools/sidecarclient/playwright_test.go
+++ b/services/local-service/internal/tools/sidecarclient/playwright_test.go
@@ -20,6 +20,15 @@ func attachedBrowserInput() map[string]any {
 	}
 }
 
+func attachedBrowserInputWithoutTarget() map[string]any {
+	return map[string]any{
+		"attach": map[string]any{
+			"mode":         "cdp",
+			"browser_kind": "chrome",
+		},
+	}
+}
+
 type stubPlaywrightClient struct {
 	readResult       tools.BrowserPageReadResult
 	searchResult     tools.BrowserPageSearchResult
@@ -300,7 +309,7 @@ func TestBrowserAttachToolsExecuteSuccess(t *testing.T) {
 		t.Fatalf("unexpected browser_navigate result=%+v err=%v", navigateResult, err)
 	}
 
-	tabsResult, err := NewBrowserTabsListTool().Execute(context.Background(), execCtx, attachedBrowserInput())
+	tabsResult, err := NewBrowserTabsListTool().Execute(context.Background(), execCtx, attachedBrowserInputWithoutTarget())
 	if err != nil || tabsResult.SummaryOutput["tab_count"] != 2 {
 		t.Fatalf("unexpected browser_tabs_list result=%+v err=%v", tabsResult, err)
 	}
@@ -324,8 +333,11 @@ func TestBrowserAttachToolsValidateAttachContract(t *testing.T) {
 	if err := NewBrowserAttachCurrentTool().Validate(map[string]any{}); err == nil {
 		t.Fatal("expected browser_attach_current validate to fail without attach")
 	}
-	if err := NewBrowserSnapshotTool().Validate(map[string]any{"attach": map[string]any{"browser_kind": "chrome", "target": map[string]any{}}}); err == nil {
-		t.Fatal("expected browser_snapshot validate to fail without target filters")
+	if err := NewBrowserSnapshotTool().Validate(attachedBrowserInputWithoutTarget()); err != nil {
+		t.Fatalf("expected browser_snapshot validate to allow attach without target filters, got %v", err)
+	}
+	if err := NewBrowserTabsListTool().Validate(attachedBrowserInputWithoutTarget()); err != nil {
+		t.Fatalf("expected browser_tabs_list validate to allow attach without target filters, got %v", err)
 	}
 	if err := NewBrowserNavigateTool().Validate(attachedBrowserInput()); err == nil {
 		t.Fatal("expected browser_navigate validate to require url")

--- a/services/local-service/internal/tools/sidecarclient/playwright_test.go
+++ b/services/local-service/internal/tools/sidecarclient/playwright_test.go
@@ -8,11 +8,27 @@ import (
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/tools"
 )
 
+func attachedBrowserInput() map[string]any {
+	return map[string]any{
+		"attach": map[string]any{
+			"mode":         "cdp",
+			"browser_kind": "chrome",
+			"target": map[string]any{
+				"url": "https://example.com/docs",
+			},
+		},
+	}
+}
+
 type stubPlaywrightClient struct {
 	readResult       tools.BrowserPageReadResult
 	searchResult     tools.BrowserPageSearchResult
 	interactResult   tools.BrowserPageInteractResult
 	structuredResult tools.BrowserStructuredDOMResult
+	attachResult     tools.BrowserAttachedPageResult
+	snapshotResult   tools.BrowserSnapshotResult
+	navigateResult   tools.BrowserNavigationResult
+	tabsResult       tools.BrowserTabsListResult
 	err              error
 }
 
@@ -67,6 +83,48 @@ func (s stubPlaywrightClient) StructuredDOM(_ context.Context, url string) (tool
 	return result, nil
 }
 
+func (s stubPlaywrightClient) AttachCurrentPage(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserAttachedPageResult, error) {
+	if s.err != nil {
+		return tools.BrowserAttachedPageResult{}, s.err
+	}
+	return s.attachResult, nil
+}
+
+func (s stubPlaywrightClient) SnapshotBrowser(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserSnapshotResult, error) {
+	if s.err != nil {
+		return tools.BrowserSnapshotResult{}, s.err
+	}
+	return s.snapshotResult, nil
+}
+
+func (s stubPlaywrightClient) NavigateBrowser(_ context.Context, _ tools.BrowserNavigateRequest) (tools.BrowserNavigationResult, error) {
+	if s.err != nil {
+		return tools.BrowserNavigationResult{}, s.err
+	}
+	return s.navigateResult, nil
+}
+
+func (s stubPlaywrightClient) ListBrowserTabs(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserTabsListResult, error) {
+	if s.err != nil {
+		return tools.BrowserTabsListResult{}, s.err
+	}
+	return s.tabsResult, nil
+}
+
+func (s stubPlaywrightClient) FocusBrowserTab(_ context.Context, _ tools.BrowserAttachConfig) (tools.BrowserAttachedPageResult, error) {
+	if s.err != nil {
+		return tools.BrowserAttachedPageResult{}, s.err
+	}
+	return s.attachResult, nil
+}
+
+func (s stubPlaywrightClient) InteractBrowser(_ context.Context, _ tools.BrowserInteractRequest) (tools.BrowserPageInteractResult, error) {
+	if s.err != nil {
+		return tools.BrowserPageInteractResult{}, s.err
+	}
+	return s.interactResult, nil
+}
+
 func TestPageReadToolExecuteSuccess(t *testing.T) {
 	tool := NewPageReadTool()
 	result, err := tool.Execute(context.Background(), &tools.ToolExecuteContext{
@@ -104,6 +162,9 @@ func TestPlaywrightNoopClientAndValidators(t *testing.T) {
 	}
 	if _, err := client.InteractPage(context.Background(), "https://example.com", nil); !errors.Is(err, tools.ErrPlaywrightSidecarFailed) {
 		t.Fatalf("expected noop interact failure, got %v", err)
+	}
+	if _, err := client.AttachCurrentPage(context.Background(), tools.BrowserAttachConfig{Mode: tools.BrowserAttachModeCDP}); !errors.Is(err, tools.ErrPlaywrightSidecarFailed) {
+		t.Fatalf("expected noop attach failure, got %v", err)
 	}
 	if err := NewPageReadTool().Validate(map[string]any{"url": "https://example.com"}); err != nil {
 		t.Fatalf("expected page_read validate to pass, got %v", err)
@@ -171,6 +232,111 @@ func TestStructuredDOMToolExecuteSuccess(t *testing.T) {
 	}
 }
 
+func TestBrowserAttachToolsExecuteSuccess(t *testing.T) {
+	execCtx := &tools.ToolExecuteContext{Playwright: stubPlaywrightClient{
+		attachResult: tools.BrowserAttachedPageResult{
+			BrowserExecutionMetadata: tools.BrowserExecutionMetadata{Attached: true, BrowserKind: "chrome", BrowserTransport: "cdp", EndpointURL: "http://127.0.0.1:9222"},
+			PageIndex:                2,
+			Title:                    "Docs",
+			URL:                      "https://example.com/docs",
+			Source:                   "playwright_worker_cdp",
+		},
+		snapshotResult: tools.BrowserSnapshotResult{
+			BrowserAttachedPageResult: tools.BrowserAttachedPageResult{
+				BrowserExecutionMetadata: tools.BrowserExecutionMetadata{Attached: true, BrowserKind: "chrome", BrowserTransport: "cdp", EndpointURL: "http://127.0.0.1:9222"},
+				PageIndex:                2,
+				Title:                    "Docs",
+				URL:                      "https://example.com/docs",
+				Source:                   "playwright_worker_cdp",
+			},
+			TextContent: "Install guide",
+			Headings:    []string{"Install"},
+			Links:       []string{"Guide"},
+			Buttons:     []string{"Next"},
+			Inputs:      []string{"search"},
+		},
+		navigateResult: tools.BrowserNavigationResult{
+			BrowserAttachedPageResult: tools.BrowserAttachedPageResult{
+				BrowserExecutionMetadata: tools.BrowserExecutionMetadata{Attached: true, BrowserKind: "chrome", BrowserTransport: "cdp", EndpointURL: "http://127.0.0.1:9222"},
+				PageIndex:                2,
+				Title:                    "Start",
+				URL:                      "https://example.com/docs/start",
+				Source:                   "playwright_worker_cdp",
+			},
+			TextContent: "Getting started",
+			MIMEType:    "text/html",
+			TextType:    "text/html",
+		},
+		tabsResult: tools.BrowserTabsListResult{
+			BrowserExecutionMetadata: tools.BrowserExecutionMetadata{Attached: true, BrowserKind: "chrome", BrowserTransport: "cdp", EndpointURL: "http://127.0.0.1:9222"},
+			TabCount:                 2,
+			Tabs:                     []tools.BrowserTabInfo{{PageIndex: 0, Title: "Home", URL: "https://example.com"}, {PageIndex: 2, Title: "Docs", URL: "https://example.com/docs"}},
+			Source:                   "playwright_worker_cdp",
+		},
+		interactResult: tools.BrowserPageInteractResult{
+			BrowserExecutionMetadata: tools.BrowserExecutionMetadata{Attached: true, BrowserKind: "chrome", BrowserTransport: "cdp", EndpointURL: "http://127.0.0.1:9222"},
+			Title:                    "Docs",
+			URL:                      "https://example.com/docs",
+			TextContent:              "Clicked next",
+			ActionsApplied:           1,
+			Source:                   "playwright_worker_cdp",
+		},
+	}}
+
+	attachResult, err := NewBrowserAttachCurrentTool().Execute(context.Background(), execCtx, attachedBrowserInput())
+	if err != nil || attachResult.RawOutput["page_index"] != 2 {
+		t.Fatalf("unexpected browser_attach_current result=%+v err=%v", attachResult, err)
+	}
+
+	snapshotResult, err := NewBrowserSnapshotTool().Execute(context.Background(), execCtx, attachedBrowserInput())
+	if err != nil || snapshotResult.SummaryOutput["heading_count"] != 1 {
+		t.Fatalf("unexpected browser_snapshot result=%+v err=%v", snapshotResult, err)
+	}
+
+	navigateInput := attachedBrowserInput()
+	navigateInput["url"] = "https://example.com/docs/start"
+	navigateResult, err := NewBrowserNavigateTool().Execute(context.Background(), execCtx, navigateInput)
+	if err != nil || navigateResult.SummaryOutput["content_preview"] != "Getting started" {
+		t.Fatalf("unexpected browser_navigate result=%+v err=%v", navigateResult, err)
+	}
+
+	tabsResult, err := NewBrowserTabsListTool().Execute(context.Background(), execCtx, attachedBrowserInput())
+	if err != nil || tabsResult.SummaryOutput["tab_count"] != 2 {
+		t.Fatalf("unexpected browser_tabs_list result=%+v err=%v", tabsResult, err)
+	}
+
+	focusInput := attachedBrowserInput()
+	focusInput["attach"].(map[string]any)["target"] = map[string]any{"page_index": 2.0}
+	focusResult, err := NewBrowserTabFocusTool().Execute(context.Background(), execCtx, focusInput)
+	if err != nil || focusResult.SummaryOutput["page_index"] != 2 {
+		t.Fatalf("unexpected browser_tab_focus result=%+v err=%v", focusResult, err)
+	}
+
+	interactInput := attachedBrowserInput()
+	interactInput["actions"] = []any{map[string]any{"type": "click", "selector": "a.next"}}
+	interactResult, err := NewBrowserInteractTool().Execute(context.Background(), execCtx, interactInput)
+	if err != nil || interactResult.RawOutput["actions_applied"] != 1 {
+		t.Fatalf("unexpected browser_interact result=%+v err=%v", interactResult, err)
+	}
+}
+
+func TestBrowserAttachToolsValidateAttachContract(t *testing.T) {
+	if err := NewBrowserAttachCurrentTool().Validate(map[string]any{}); err == nil {
+		t.Fatal("expected browser_attach_current validate to fail without attach")
+	}
+	if err := NewBrowserSnapshotTool().Validate(map[string]any{"attach": map[string]any{"browser_kind": "chrome", "target": map[string]any{}}}); err == nil {
+		t.Fatal("expected browser_snapshot validate to fail without target filters")
+	}
+	if err := NewBrowserNavigateTool().Validate(attachedBrowserInput()); err == nil {
+		t.Fatal("expected browser_navigate validate to require url")
+	}
+	interactInput := attachedBrowserInput()
+	interactInput["actions"] = []any{map[string]any{"selector": "a.next"}}
+	if err := NewBrowserInteractTool().Validate(interactInput); err == nil {
+		t.Fatal("expected browser_interact validate to require action type")
+	}
+}
+
 func TestRegisterPlaywrightTools(t *testing.T) {
 	registry := tools.NewRegistry()
 	if err := RegisterPlaywrightTools(registry); err != nil {
@@ -187,5 +353,10 @@ func TestRegisterPlaywrightTools(t *testing.T) {
 	}
 	if _, err := registry.Get("structured_dom"); err != nil {
 		t.Fatalf("expected structured_dom to be registered, got %v", err)
+	}
+	for _, name := range []string{"browser_attach_current", "browser_snapshot", "browser_navigate", "browser_tabs_list", "browser_tab_focus", "browser_interact"} {
+		if _, err := registry.Get(name); err != nil {
+			t.Fatalf("expected %s to be registered, got %v", name, err)
+		}
 	}
 }

--- a/services/local-service/internal/tools/sidecarclient/playwright_test.go
+++ b/services/local-service/internal/tools/sidecarclient/playwright_test.go
@@ -29,6 +29,17 @@ func attachedBrowserInputWithoutTarget() map[string]any {
 	}
 }
 
+func attachedBrowserInputWithoutBrowserKind() map[string]any {
+	return map[string]any{
+		"attach": map[string]any{
+			"mode": "cdp",
+			"target": map[string]any{
+				"url": "https://example.com/docs",
+			},
+		},
+	}
+}
+
 func attachedBrowserInputWithEndpoint(endpointURL string) map[string]any {
 	input := attachedBrowserInputWithoutTarget()
 	input["attach"].(map[string]any)["endpoint_url"] = endpointURL
@@ -36,19 +47,19 @@ func attachedBrowserInputWithEndpoint(endpointURL string) map[string]any {
 }
 
 type stubPlaywrightClient struct {
-	readResult       tools.BrowserPageReadResult
-	searchResult     tools.BrowserPageSearchResult
-	interactResult   tools.BrowserPageInteractResult
-	structuredResult tools.BrowserStructuredDOMResult
-	attachedRead     tools.BrowserPageReadResult
-	attachedSearch   tools.BrowserPageSearchResult
-	attachedInteract tools.BrowserPageInteractResult
-	attachedDOM      tools.BrowserStructuredDOMResult
-	attachResult     tools.BrowserAttachedPageResult
-	snapshotResult   tools.BrowserSnapshotResult
-	navigateResult   tools.BrowserNavigationResult
-	tabsResult       tools.BrowserTabsListResult
-	err              error
+	readResult               tools.BrowserPageReadResult
+	readAttachedResult       tools.BrowserPageReadResult
+	searchResult             tools.BrowserPageSearchResult
+	searchAttachedResult     tools.BrowserPageSearchResult
+	interactResult           tools.BrowserPageInteractResult
+	interactAttachedResult   tools.BrowserPageInteractResult
+	structuredResult         tools.BrowserStructuredDOMResult
+	structuredAttachedResult tools.BrowserStructuredDOMResult
+	attachResult             tools.BrowserAttachedPageResult
+	snapshotResult           tools.BrowserSnapshotResult
+	navigateResult           tools.BrowserNavigationResult
+	tabsResult               tools.BrowserTabsListResult
+	err                      error
 }
 
 func (s stubPlaywrightClient) ReadPage(_ context.Context, url string) (tools.BrowserPageReadResult, error) {
@@ -58,6 +69,21 @@ func (s stubPlaywrightClient) ReadPage(_ context.Context, url string) (tools.Bro
 	result := s.readResult
 	if result.URL == "" {
 		result.URL = url
+	}
+	return result, nil
+}
+
+func (s stubPlaywrightClient) ReadPageAttached(_ context.Context, url string, attach tools.BrowserAttachConfig) (tools.BrowserPageReadResult, error) {
+	if s.err != nil {
+		return tools.BrowserPageReadResult{}, s.err
+	}
+	result := s.readAttachedResult
+	if result.URL == "" {
+		result.URL = url
+	}
+	result.Attached = true
+	if result.BrowserKind == "" {
+		result.BrowserKind = attach.BrowserKind
 	}
 	return result, nil
 }
@@ -80,48 +106,11 @@ func (s stubPlaywrightClient) SearchPage(_ context.Context, url, query string, l
 	return result, nil
 }
 
-func (s stubPlaywrightClient) InteractPage(_ context.Context, url string, _ []map[string]any) (tools.BrowserPageInteractResult, error) {
-	if s.err != nil {
-		return tools.BrowserPageInteractResult{}, s.err
-	}
-	result := s.interactResult
-	if result.URL == "" {
-		result.URL = url
-	}
-	return result, nil
-}
-
-func (s stubPlaywrightClient) StructuredDOM(_ context.Context, url string) (tools.BrowserStructuredDOMResult, error) {
-	if s.err != nil {
-		return tools.BrowserStructuredDOMResult{}, s.err
-	}
-	result := s.structuredResult
-	if result.URL == "" {
-		result.URL = url
-	}
-	return result, nil
-}
-
-func (s stubPlaywrightClient) ReadPageAttached(_ context.Context, url string, attach tools.BrowserAttachConfig) (tools.BrowserPageReadResult, error) {
-	if s.err != nil {
-		return tools.BrowserPageReadResult{}, s.err
-	}
-	result := s.attachedRead
-	if result.URL == "" {
-		result.URL = url
-	}
-	result.Attached = true
-	if result.BrowserKind == "" {
-		result.BrowserKind = attach.BrowserKind
-	}
-	return result, nil
-}
-
 func (s stubPlaywrightClient) SearchPageAttached(_ context.Context, url, query string, limit int, attach tools.BrowserAttachConfig) (tools.BrowserPageSearchResult, error) {
 	if s.err != nil {
 		return tools.BrowserPageSearchResult{}, s.err
 	}
-	result := s.attachedSearch
+	result := s.searchAttachedResult
 	if result.URL == "" {
 		result.URL = url
 	}
@@ -139,11 +128,22 @@ func (s stubPlaywrightClient) SearchPageAttached(_ context.Context, url, query s
 	return result, nil
 }
 
+func (s stubPlaywrightClient) InteractPage(_ context.Context, url string, _ []map[string]any) (tools.BrowserPageInteractResult, error) {
+	if s.err != nil {
+		return tools.BrowserPageInteractResult{}, s.err
+	}
+	result := s.interactResult
+	if result.URL == "" {
+		result.URL = url
+	}
+	return result, nil
+}
+
 func (s stubPlaywrightClient) InteractPageAttached(_ context.Context, url string, _ []map[string]any, attach tools.BrowserAttachConfig) (tools.BrowserPageInteractResult, error) {
 	if s.err != nil {
 		return tools.BrowserPageInteractResult{}, s.err
 	}
-	result := s.attachedInteract
+	result := s.interactAttachedResult
 	if result.URL == "" {
 		result.URL = url
 	}
@@ -154,11 +154,22 @@ func (s stubPlaywrightClient) InteractPageAttached(_ context.Context, url string
 	return result, nil
 }
 
+func (s stubPlaywrightClient) StructuredDOM(_ context.Context, url string) (tools.BrowserStructuredDOMResult, error) {
+	if s.err != nil {
+		return tools.BrowserStructuredDOMResult{}, s.err
+	}
+	result := s.structuredResult
+	if result.URL == "" {
+		result.URL = url
+	}
+	return result, nil
+}
+
 func (s stubPlaywrightClient) StructuredDOMAttached(_ context.Context, url string, attach tools.BrowserAttachConfig) (tools.BrowserStructuredDOMResult, error) {
 	if s.err != nil {
 		return tools.BrowserStructuredDOMResult{}, s.err
 	}
-	result := s.attachedDOM
+	result := s.structuredAttachedResult
 	if result.URL == "" {
 		result.URL = url
 	}
@@ -261,6 +272,9 @@ func TestPlaywrightNoopClientAndValidators(t *testing.T) {
 	if err := NewStructuredDOMTool().Validate(map[string]any{"url": "https://example.com"}); err != nil {
 		t.Fatalf("expected structured_dom validate to pass, got %v", err)
 	}
+	if err := NewPageReadTool().Validate(map[string]any{"url": "https://example.com", "attach": map[string]any{"mode": "cdp", "browser_kind": "chrome", "endpoint_url": "http://example.com:9222"}}); err == nil {
+		t.Fatal("expected page_read validate to reject non-loopback attach endpoint")
+	}
 }
 
 func TestPageSearchToolExecuteSuccess(t *testing.T) {
@@ -319,29 +333,61 @@ func TestStructuredDOMToolExecuteSuccess(t *testing.T) {
 }
 
 func TestPageToolsExecuteAttachedBrowserSuccess(t *testing.T) {
-	client := stubPlaywrightClient{
-		attachedRead:     tools.BrowserPageReadResult{Title: "Attached Read", TextContent: "attached text", Source: "playwright_worker_cdp"},
-		attachedSearch:   tools.BrowserPageSearchResult{Matches: []string{"attached match"}, MatchCount: 1, Source: "playwright_worker_cdp"},
-		attachedInteract: tools.BrowserPageInteractResult{Title: "Attached Interact", TextContent: "clicked", ActionsApplied: 1, Source: "playwright_worker_cdp"},
-		attachedDOM:      tools.BrowserStructuredDOMResult{Title: "Attached DOM", Headings: []string{"Heading"}, Links: []string{"Docs"}, Buttons: []string{"Submit"}, Inputs: []string{"search"}, Source: "playwright_worker_cdp"},
-	}
-	execCtx := &tools.ToolExecuteContext{Playwright: client}
+	execCtx := &tools.ToolExecuteContext{Playwright: stubPlaywrightClient{
+		readAttachedResult: tools.BrowserPageReadResult{
+			BrowserExecutionMetadata: tools.BrowserExecutionMetadata{Attached: true, BrowserKind: "chrome"},
+			Title:                    "Attached Read",
+			TextContent:              "attached text",
+			MIMEType:                 "text/html",
+			TextType:                 "text/html",
+			Source:                   "playwright_worker_cdp",
+		},
+		searchAttachedResult: tools.BrowserPageSearchResult{
+			BrowserExecutionMetadata: tools.BrowserExecutionMetadata{Attached: true, BrowserKind: "chrome"},
+			Matches:                  []string{"attached match"},
+			MatchCount:               1,
+			Source:                   "playwright_worker_cdp",
+		},
+		interactAttachedResult: tools.BrowserPageInteractResult{
+			BrowserExecutionMetadata: tools.BrowserExecutionMetadata{Attached: true, BrowserKind: "chrome"},
+			Title:                    "Attached Interact",
+			TextContent:              "clicked",
+			ActionsApplied:           1,
+			Source:                   "playwright_worker_cdp",
+		},
+		structuredAttachedResult: tools.BrowserStructuredDOMResult{
+			BrowserExecutionMetadata: tools.BrowserExecutionMetadata{Attached: true, BrowserKind: "chrome"},
+			Title:                    "Attached DOM",
+			Headings:                 []string{"Heading"},
+			Links:                    []string{"Docs"},
+			Buttons:                  []string{"Submit"},
+			Inputs:                   []string{"search"},
+			Source:                   "playwright_worker_cdp",
+		},
+	}}
 
-	readResult, err := NewPageReadTool().Execute(context.Background(), execCtx, map[string]any{"url": "https://example.com/docs", "attach": attachedBrowserInput()["attach"]})
-	if err != nil || readResult.RawOutput["attached"] != true {
-		t.Fatalf("expected attached page_read result, got result=%+v err=%v", readResult, err)
+	readInput := map[string]any{"url": "https://example.com/docs", "attach": attachedBrowserInput()["attach"]}
+	readResult, err := NewPageReadTool().Execute(context.Background(), execCtx, readInput)
+	if err != nil || readResult.SummaryOutput["title"] != "Attached Read" {
+		t.Fatalf("unexpected attached page_read result=%+v err=%v", readResult, err)
 	}
-	searchResult, err := NewPageSearchTool().Execute(context.Background(), execCtx, map[string]any{"url": "https://example.com/docs", "query": "attached", "attach": attachedBrowserInput()["attach"]})
-	if err != nil || searchResult.RawOutput["attached"] != true {
-		t.Fatalf("expected attached page_search result, got result=%+v err=%v", searchResult, err)
+
+	searchInput := map[string]any{"url": "https://example.com/docs", "query": "attached", "attach": attachedBrowserInput()["attach"]}
+	searchResult, err := NewPageSearchTool().Execute(context.Background(), execCtx, searchInput)
+	if err != nil || searchResult.RawOutput["match_count"] != 1 {
+		t.Fatalf("unexpected attached page_search result=%+v err=%v", searchResult, err)
 	}
-	interactResult, err := NewPageInteractTool().Execute(context.Background(), execCtx, map[string]any{"url": "https://example.com/docs", "actions": []any{map[string]any{"type": "click", "selector": "button"}}, "attach": attachedBrowserInput()["attach"]})
-	if err != nil || interactResult.RawOutput["attached"] != true {
-		t.Fatalf("expected attached page_interact result, got result=%+v err=%v", interactResult, err)
+
+	interactInput := map[string]any{"url": "https://example.com/docs", "actions": []any{map[string]any{"type": "click", "selector": "button"}}, "attach": attachedBrowserInput()["attach"]}
+	interactResult, err := NewPageInteractTool().Execute(context.Background(), execCtx, interactInput)
+	if err != nil || interactResult.RawOutput["actions_applied"] != 1 {
+		t.Fatalf("unexpected attached page_interact result=%+v err=%v", interactResult, err)
 	}
-	domResult, err := NewStructuredDOMTool().Execute(context.Background(), execCtx, map[string]any{"url": "https://example.com/docs", "attach": attachedBrowserInput()["attach"]})
-	if err != nil || domResult.RawOutput["attached"] != true {
-		t.Fatalf("expected attached structured_dom result, got result=%+v err=%v", domResult, err)
+
+	domInput := map[string]any{"url": "https://example.com/docs", "attach": attachedBrowserInput()["attach"]}
+	domResult, err := NewStructuredDOMTool().Execute(context.Background(), execCtx, domInput)
+	if err != nil || domResult.SummaryOutput["heading_count"] != 1 {
+		t.Fatalf("unexpected attached structured_dom result=%+v err=%v", domResult, err)
 	}
 }
 
@@ -437,6 +483,9 @@ func TestBrowserAttachToolsValidateAttachContract(t *testing.T) {
 	if err := NewBrowserAttachCurrentTool().Validate(map[string]any{}); err == nil {
 		t.Fatal("expected browser_attach_current validate to fail without attach")
 	}
+	if err := NewBrowserAttachCurrentTool().Validate(attachedBrowserInputWithoutBrowserKind()); err != nil {
+		t.Fatalf("expected browser_attach_current validate to allow omitted browser_kind, got %v", err)
+	}
 	if err := NewBrowserSnapshotTool().Validate(attachedBrowserInputWithoutTarget()); err != nil {
 		t.Fatalf("expected browser_snapshot validate to allow attach without target filters, got %v", err)
 	}
@@ -464,8 +513,10 @@ func TestAttachConfigFromInputAllowsLoopbackEndpointsOnly(t *testing.T) {
 		{name: "ipv4 loopback endpoint", endpointURL: "http://127.0.0.1:9222", wantErr: false},
 		{name: "ipv4 loopback range endpoint", endpointURL: "http://127.1.2.3:9222", wantErr: false},
 		{name: "ipv6 loopback endpoint", endpointURL: "http://[::1]:9222", wantErr: false},
+		{name: "websocket loopback endpoint", endpointURL: "ws://127.0.0.1:9222/devtools/browser/demo", wantErr: false},
 		{name: "private network endpoint", endpointURL: "http://192.168.1.10:9222", wantErr: true},
 		{name: "public hostname endpoint", endpointURL: "http://example.com:9222", wantErr: true},
+		{name: "unsupported scheme endpoint", endpointURL: "ftp://127.0.0.1:9222", wantErr: true},
 		{name: "missing host endpoint", endpointURL: "http:///devtools/browser/demo", wantErr: true},
 		{name: "invalid endpoint", endpointURL: "://bad", wantErr: true},
 	}

--- a/services/local-service/internal/tools/sidecarclient/playwright_test.go
+++ b/services/local-service/internal/tools/sidecarclient/playwright_test.go
@@ -29,6 +29,12 @@ func attachedBrowserInputWithoutTarget() map[string]any {
 	}
 }
 
+func attachedBrowserInputWithEndpoint(endpointURL string) map[string]any {
+	input := attachedBrowserInputWithoutTarget()
+	input["attach"].(map[string]any)["endpoint_url"] = endpointURL
+	return input
+}
+
 type stubPlaywrightClient struct {
 	readResult       tools.BrowserPageReadResult
 	searchResult     tools.BrowserPageSearchResult
@@ -444,6 +450,40 @@ func TestBrowserAttachToolsValidateAttachContract(t *testing.T) {
 	interactInput["actions"] = []any{map[string]any{"selector": "a.next"}}
 	if err := NewBrowserInteractTool().Validate(interactInput); err == nil {
 		t.Fatal("expected browser_interact validate to require action type")
+	}
+}
+
+func TestAttachConfigFromInputAllowsLoopbackEndpointsOnly(t *testing.T) {
+	tests := []struct {
+		name        string
+		endpointURL string
+		wantErr     bool
+	}{
+		{name: "empty endpoint", endpointURL: "", wantErr: false},
+		{name: "localhost endpoint", endpointURL: "http://localhost:9222", wantErr: false},
+		{name: "ipv4 loopback endpoint", endpointURL: "http://127.0.0.1:9222", wantErr: false},
+		{name: "ipv4 loopback range endpoint", endpointURL: "http://127.1.2.3:9222", wantErr: false},
+		{name: "ipv6 loopback endpoint", endpointURL: "http://[::1]:9222", wantErr: false},
+		{name: "private network endpoint", endpointURL: "http://192.168.1.10:9222", wantErr: true},
+		{name: "public hostname endpoint", endpointURL: "http://example.com:9222", wantErr: true},
+		{name: "missing host endpoint", endpointURL: "http:///devtools/browser/demo", wantErr: true},
+		{name: "invalid endpoint", endpointURL: "://bad", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := attachedBrowserInputWithEndpoint(test.endpointURL)
+			if test.endpointURL == "" {
+				input = attachedBrowserInputWithoutTarget()
+			}
+			_, err := attachConfigFromInput(input)
+			if test.wantErr && err == nil {
+				t.Fatalf("expected endpoint %q to be rejected", test.endpointURL)
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("expected endpoint %q to be allowed, got %v", test.endpointURL, err)
+			}
+		})
 	}
 }
 

--- a/services/local-service/internal/tools/sidecarclient/playwright_test.go
+++ b/services/local-service/internal/tools/sidecarclient/playwright_test.go
@@ -34,6 +34,10 @@ type stubPlaywrightClient struct {
 	searchResult     tools.BrowserPageSearchResult
 	interactResult   tools.BrowserPageInteractResult
 	structuredResult tools.BrowserStructuredDOMResult
+	attachedRead     tools.BrowserPageReadResult
+	attachedSearch   tools.BrowserPageSearchResult
+	attachedInteract tools.BrowserPageInteractResult
+	attachedDOM      tools.BrowserStructuredDOMResult
 	attachResult     tools.BrowserAttachedPageResult
 	snapshotResult   tools.BrowserSnapshotResult
 	navigateResult   tools.BrowserNavigationResult
@@ -88,6 +92,73 @@ func (s stubPlaywrightClient) StructuredDOM(_ context.Context, url string) (tool
 	result := s.structuredResult
 	if result.URL == "" {
 		result.URL = url
+	}
+	return result, nil
+}
+
+func (s stubPlaywrightClient) ReadPageAttached(_ context.Context, url string, attach tools.BrowserAttachConfig) (tools.BrowserPageReadResult, error) {
+	if s.err != nil {
+		return tools.BrowserPageReadResult{}, s.err
+	}
+	result := s.attachedRead
+	if result.URL == "" {
+		result.URL = url
+	}
+	result.Attached = true
+	if result.BrowserKind == "" {
+		result.BrowserKind = attach.BrowserKind
+	}
+	return result, nil
+}
+
+func (s stubPlaywrightClient) SearchPageAttached(_ context.Context, url, query string, limit int, attach tools.BrowserAttachConfig) (tools.BrowserPageSearchResult, error) {
+	if s.err != nil {
+		return tools.BrowserPageSearchResult{}, s.err
+	}
+	result := s.attachedSearch
+	if result.URL == "" {
+		result.URL = url
+	}
+	if result.Query == "" {
+		result.Query = query
+	}
+	if limit > 0 && len(result.Matches) > limit {
+		result.Matches = result.Matches[:limit]
+		result.MatchCount = len(result.Matches)
+	}
+	result.Attached = true
+	if result.BrowserKind == "" {
+		result.BrowserKind = attach.BrowserKind
+	}
+	return result, nil
+}
+
+func (s stubPlaywrightClient) InteractPageAttached(_ context.Context, url string, _ []map[string]any, attach tools.BrowserAttachConfig) (tools.BrowserPageInteractResult, error) {
+	if s.err != nil {
+		return tools.BrowserPageInteractResult{}, s.err
+	}
+	result := s.attachedInteract
+	if result.URL == "" {
+		result.URL = url
+	}
+	result.Attached = true
+	if result.BrowserKind == "" {
+		result.BrowserKind = attach.BrowserKind
+	}
+	return result, nil
+}
+
+func (s stubPlaywrightClient) StructuredDOMAttached(_ context.Context, url string, attach tools.BrowserAttachConfig) (tools.BrowserStructuredDOMResult, error) {
+	if s.err != nil {
+		return tools.BrowserStructuredDOMResult{}, s.err
+	}
+	result := s.attachedDOM
+	if result.URL == "" {
+		result.URL = url
+	}
+	result.Attached = true
+	if result.BrowserKind == "" {
+		result.BrowserKind = attach.BrowserKind
 	}
 	return result, nil
 }
@@ -238,6 +309,33 @@ func TestStructuredDOMToolExecuteSuccess(t *testing.T) {
 	}
 	if result.SummaryOutput["heading_count"] != 1 {
 		t.Fatalf("expected heading count summary, got %+v", result.SummaryOutput)
+	}
+}
+
+func TestPageToolsExecuteAttachedBrowserSuccess(t *testing.T) {
+	client := stubPlaywrightClient{
+		attachedRead:     tools.BrowserPageReadResult{Title: "Attached Read", TextContent: "attached text", Source: "playwright_worker_cdp"},
+		attachedSearch:   tools.BrowserPageSearchResult{Matches: []string{"attached match"}, MatchCount: 1, Source: "playwright_worker_cdp"},
+		attachedInteract: tools.BrowserPageInteractResult{Title: "Attached Interact", TextContent: "clicked", ActionsApplied: 1, Source: "playwright_worker_cdp"},
+		attachedDOM:      tools.BrowserStructuredDOMResult{Title: "Attached DOM", Headings: []string{"Heading"}, Links: []string{"Docs"}, Buttons: []string{"Submit"}, Inputs: []string{"search"}, Source: "playwright_worker_cdp"},
+	}
+	execCtx := &tools.ToolExecuteContext{Playwright: client}
+
+	readResult, err := NewPageReadTool().Execute(context.Background(), execCtx, map[string]any{"url": "https://example.com/docs", "attach": attachedBrowserInput()["attach"]})
+	if err != nil || readResult.RawOutput["attached"] != true {
+		t.Fatalf("expected attached page_read result, got result=%+v err=%v", readResult, err)
+	}
+	searchResult, err := NewPageSearchTool().Execute(context.Background(), execCtx, map[string]any{"url": "https://example.com/docs", "query": "attached", "attach": attachedBrowserInput()["attach"]})
+	if err != nil || searchResult.RawOutput["attached"] != true {
+		t.Fatalf("expected attached page_search result, got result=%+v err=%v", searchResult, err)
+	}
+	interactResult, err := NewPageInteractTool().Execute(context.Background(), execCtx, map[string]any{"url": "https://example.com/docs", "actions": []any{map[string]any{"type": "click", "selector": "button"}}, "attach": attachedBrowserInput()["attach"]})
+	if err != nil || interactResult.RawOutput["attached"] != true {
+		t.Fatalf("expected attached page_interact result, got result=%+v err=%v", interactResult, err)
+	}
+	domResult, err := NewStructuredDOMTool().Execute(context.Background(), execCtx, map[string]any{"url": "https://example.com/docs", "attach": attachedBrowserInput()["attach"]})
+	if err != nil || domResult.RawOutput["attached"] != true {
+		t.Fatalf("expected attached structured_dom result, got result=%+v err=%v", domResult, err)
 	}
 }
 

--- a/services/local-service/internal/tools/sidecarclient/runtime.go
+++ b/services/local-service/internal/tools/sidecarclient/runtime.go
@@ -170,8 +170,39 @@ func (c runtimePlaywrightClient) ReadPage(ctx context.Context, url string) (tool
 	}, nil
 }
 
+func (c runtimePlaywrightClient) ReadPageAttached(ctx context.Context, url string, attach tools.BrowserAttachConfig) (tools.BrowserPageReadResult, error) {
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "page_read", URL: url, Attach: cloneAttachConfigPtr(&attach)})
+	if err != nil {
+		return tools.BrowserPageReadResult{}, err
+	}
+	return tools.BrowserPageReadResult{
+		BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+		URL:                      stringValue(response.Result, "url"),
+		Title:                    stringValue(response.Result, "title"),
+		TextContent:              stringValue(response.Result, "text_content"),
+		MIMEType:                 stringValue(response.Result, "mime_type"),
+		TextType:                 stringValue(response.Result, "text_type"),
+		Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+	}, nil
+}
+
 func (c runtimePlaywrightClient) SearchPage(ctx context.Context, url, query string, limit int) (tools.BrowserPageSearchResult, error) {
 	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "page_search", URL: url, Query: query, Limit: limit})
+	if err != nil {
+		return tools.BrowserPageSearchResult{}, err
+	}
+	return tools.BrowserPageSearchResult{
+		BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+		URL:                      stringValue(response.Result, "url"),
+		Query:                    stringValue(response.Result, "query"),
+		MatchCount:               intValue(response.Result, "match_count"),
+		Matches:                  stringSliceValue(response.Result, "matches"),
+		Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+	}, nil
+}
+
+func (c runtimePlaywrightClient) SearchPageAttached(ctx context.Context, url, query string, limit int, attach tools.BrowserAttachConfig) (tools.BrowserPageSearchResult, error) {
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "page_search", URL: url, Query: query, Limit: limit, Attach: cloneAttachConfigPtr(&attach)})
 	if err != nil {
 		return tools.BrowserPageSearchResult{}, err
 	}
@@ -200,8 +231,40 @@ func (c runtimePlaywrightClient) InteractPage(ctx context.Context, url string, a
 	}, nil
 }
 
+func (c runtimePlaywrightClient) InteractPageAttached(ctx context.Context, url string, actions []map[string]any, attach tools.BrowserAttachConfig) (tools.BrowserPageInteractResult, error) {
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "page_interact", URL: url, Actions: cloneActionSlice(actions), Attach: cloneAttachConfigPtr(&attach)})
+	if err != nil {
+		return tools.BrowserPageInteractResult{}, err
+	}
+	return tools.BrowserPageInteractResult{
+		BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+		URL:                      stringValue(response.Result, "url"),
+		Title:                    stringValue(response.Result, "title"),
+		TextContent:              stringValue(response.Result, "text_content"),
+		ActionsApplied:           intValue(response.Result, "actions_applied"),
+		Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+	}, nil
+}
+
 func (c runtimePlaywrightClient) StructuredDOM(ctx context.Context, url string) (tools.BrowserStructuredDOMResult, error) {
 	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "structured_dom", URL: url})
+	if err != nil {
+		return tools.BrowserStructuredDOMResult{}, err
+	}
+	return tools.BrowserStructuredDOMResult{
+		BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+		URL:                      stringValue(response.Result, "url"),
+		Title:                    stringValue(response.Result, "title"),
+		Headings:                 stringSliceValue(response.Result, "headings"),
+		Links:                    stringSliceValue(response.Result, "links"),
+		Buttons:                  stringSliceValue(response.Result, "buttons"),
+		Inputs:                   stringSliceValue(response.Result, "inputs"),
+		Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+	}, nil
+}
+
+func (c runtimePlaywrightClient) StructuredDOMAttached(ctx context.Context, url string, attach tools.BrowserAttachConfig) (tools.BrowserStructuredDOMResult, error) {
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "structured_dom", URL: url, Attach: cloneAttachConfigPtr(&attach)})
 	if err != nil {
 		return tools.BrowserStructuredDOMResult{}, err
 	}

--- a/services/local-service/internal/tools/sidecarclient/runtime.go
+++ b/services/local-service/internal/tools/sidecarclient/runtime.go
@@ -376,13 +376,11 @@ func (c runtimePlaywrightClient) InteractBrowser(ctx context.Context, request to
 	}, nil
 }
 
-// PlaywrightSidecarRuntime 是当前阶段的最小运行时骨架。
+// PlaywrightSidecarRuntime is the minimum viable runtime skeleton for the
+// Playwright sidecar.
 //
-// 它负责表达：
-// - 当前 sidecar 名称
-// - 当前 plugin 声明中是否存在该 sidecar
-// - 当前最小 transport 规格
-// - 当前 sidecar 是否已进入 ready 状态
+// It keeps track of the declared sidecar identity, transport availability, and
+// whether the current process has passed its readiness checks.
 type PlaywrightSidecarRuntime struct {
 	mu        sync.Mutex
 	plugins   *plugin.Service
@@ -394,7 +392,8 @@ type PlaywrightSidecarRuntime struct {
 	client    runtimePlaywrightClient
 }
 
-// NewPlaywrightSidecarRuntime 创建并返回最小运行时骨架。
+// NewPlaywrightSidecarRuntime constructs the minimum runtime skeleton used by
+// the local service to invoke the Playwright sidecar.
 func NewPlaywrightSidecarRuntime(pluginService *plugin.Service, osCapability platform.OSCapabilityAdapter) (*PlaywrightSidecarRuntime, error) {
 	spec, ok := pluginService.SidecarSpec("playwright_sidecar")
 	if !ok {
@@ -434,17 +433,17 @@ func NewUnavailablePlaywrightSidecarRuntime(pluginService *plugin.Service, osCap
 	return runtime
 }
 
-// Name 返回当前 sidecar 名称。
+// Name returns the declared sidecar runtime name.
 func (r *PlaywrightSidecarRuntime) Name() string {
 	return r.spec.Name
 }
 
-// PipeName 返回当前最小传输骨架使用的命名管道名。
+// PipeName returns the named pipe identifier used by the minimal transport.
 func (r *PlaywrightSidecarRuntime) PipeName() string {
 	return sidecarPipeName(r.spec.Name)
 }
 
-// Ready 返回当前 sidecar 是否已进入 ready 状态。
+// Ready reports whether the sidecar has passed readiness checks.
 func (r *PlaywrightSidecarRuntime) Ready() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -458,7 +457,7 @@ func (r *PlaywrightSidecarRuntime) Available() bool {
 	return r.available
 }
 
-// Start 进入当前阶段的最小 ready 状态。
+// Start moves the sidecar into its minimum ready state.
 func (r *PlaywrightSidecarRuntime) Start() error {
 	if !r.Available() {
 		markPluginRuntimeUnavailable(r.plugins, plugin.RuntimeKindSidecar, r.spec.Name, "playwright sidecar unavailable")
@@ -486,7 +485,7 @@ func (r *PlaywrightSidecarRuntime) Start() error {
 	return nil
 }
 
-// Stop 退出 ready 状态并关闭最小传输骨架。
+// Stop leaves the ready state and closes the minimal transport.
 func (r *PlaywrightSidecarRuntime) Stop() error {
 	if !r.Available() {
 		return nil
@@ -504,7 +503,7 @@ func (r *PlaywrightSidecarRuntime) Stop() error {
 	return nil
 }
 
-// Client 返回当前运行时关联的最小 client。
+// Client returns the runtime-bound Playwright sidecar client.
 func (r *PlaywrightSidecarRuntime) Client() tools.PlaywrightSidecarClient {
 	return r.client
 }

--- a/services/local-service/internal/tools/sidecarclient/runtime.go
+++ b/services/local-service/internal/tools/sidecarclient/runtime.go
@@ -28,17 +28,18 @@ type workerInvoker interface {
 }
 
 type sidecarRequest struct {
-	Action       string           `json:"action"`
-	URL          string           `json:"url,omitempty"`
-	Query        string           `json:"query,omitempty"`
-	Path         string           `json:"path,omitempty"`
-	Language     string           `json:"language,omitempty"`
-	OutputPath   string           `json:"output_path,omitempty"`
-	OutputDir    string           `json:"output_dir,omitempty"`
-	Format       string           `json:"format,omitempty"`
-	Limit        int              `json:"limit,omitempty"`
-	EverySeconds float64          `json:"every_seconds,omitempty"`
-	Actions      []map[string]any `json:"actions,omitempty"`
+	Action       string                     `json:"action"`
+	URL          string                     `json:"url,omitempty"`
+	Query        string                     `json:"query,omitempty"`
+	Attach       *tools.BrowserAttachConfig `json:"attach,omitempty"`
+	Path         string                     `json:"path,omitempty"`
+	Language     string                     `json:"language,omitempty"`
+	OutputPath   string                     `json:"output_path,omitempty"`
+	OutputDir    string                     `json:"output_dir,omitempty"`
+	Format       string                     `json:"format,omitempty"`
+	Limit        int                        `json:"limit,omitempty"`
+	EverySeconds float64                    `json:"every_seconds,omitempty"`
+	Actions      []map[string]any           `json:"actions,omitempty"`
 }
 
 type sidecarResponse struct {
@@ -136,98 +137,179 @@ type runtimePlaywrightClient struct {
 	runtime *PlaywrightSidecarRuntime
 }
 
-func (c runtimePlaywrightClient) ReadPage(ctx context.Context, url string) (tools.BrowserPageReadResult, error) {
+func (c runtimePlaywrightClient) invokeBrowserRequest(ctx context.Context, request sidecarRequest) (sidecarResponse, error) {
 	if c.runtime == nil || !c.runtime.Available() {
-		return tools.BrowserPageReadResult{}, tools.ErrPlaywrightSidecarFailed
+		return sidecarResponse{}, tools.ErrPlaywrightSidecarFailed
 	}
 	if !c.runtime.Ready() {
-		return tools.BrowserPageReadResult{}, tools.ErrPlaywrightSidecarFailed
+		return sidecarResponse{}, tools.ErrPlaywrightSidecarFailed
 	}
-	response, err := c.runtime.invoke(ctx, sidecarRequest{Action: "page_read", URL: url})
+	response, err := c.runtime.invoke(ctx, request)
 	if err != nil {
 		if shouldMarkRuntimeFailure(err) {
 			_ = c.runtime.markFailure()
 		}
-		return tools.BrowserPageReadResult{}, fmt.Errorf("%w: %v", tools.ErrPlaywrightSidecarFailed, err)
+		return sidecarResponse{}, fmt.Errorf("%w: %v", tools.ErrPlaywrightSidecarFailed, err)
+	}
+	return response, nil
+}
+
+func (c runtimePlaywrightClient) ReadPage(ctx context.Context, url string) (tools.BrowserPageReadResult, error) {
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "page_read", URL: url})
+	if err != nil {
+		return tools.BrowserPageReadResult{}, err
 	}
 	return tools.BrowserPageReadResult{
-		URL:         stringValue(response.Result, "url"),
-		Title:       stringValue(response.Result, "title"),
-		TextContent: stringValue(response.Result, "text_content"),
-		MIMEType:    stringValue(response.Result, "mime_type"),
-		TextType:    stringValue(response.Result, "text_type"),
-		Source:      firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+		BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+		URL:                      stringValue(response.Result, "url"),
+		Title:                    stringValue(response.Result, "title"),
+		TextContent:              stringValue(response.Result, "text_content"),
+		MIMEType:                 stringValue(response.Result, "mime_type"),
+		TextType:                 stringValue(response.Result, "text_type"),
+		Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
 	}, nil
 }
 
 func (c runtimePlaywrightClient) SearchPage(ctx context.Context, url, query string, limit int) (tools.BrowserPageSearchResult, error) {
-	if c.runtime == nil || !c.runtime.Available() {
-		return tools.BrowserPageSearchResult{}, tools.ErrPlaywrightSidecarFailed
-	}
-	if !c.runtime.Ready() {
-		return tools.BrowserPageSearchResult{}, tools.ErrPlaywrightSidecarFailed
-	}
-	response, err := c.runtime.invoke(ctx, sidecarRequest{Action: "page_search", URL: url, Query: query, Limit: limit})
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "page_search", URL: url, Query: query, Limit: limit})
 	if err != nil {
-		if shouldMarkRuntimeFailure(err) {
-			_ = c.runtime.markFailure()
-		}
-		return tools.BrowserPageSearchResult{}, fmt.Errorf("%w: %v", tools.ErrPlaywrightSidecarFailed, err)
+		return tools.BrowserPageSearchResult{}, err
 	}
 	return tools.BrowserPageSearchResult{
-		URL:        stringValue(response.Result, "url"),
-		Query:      stringValue(response.Result, "query"),
-		MatchCount: intValue(response.Result, "match_count"),
-		Matches:    stringSliceValue(response.Result, "matches"),
-		Source:     firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+		BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+		URL:                      stringValue(response.Result, "url"),
+		Query:                    stringValue(response.Result, "query"),
+		MatchCount:               intValue(response.Result, "match_count"),
+		Matches:                  stringSliceValue(response.Result, "matches"),
+		Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
 	}, nil
 }
 
 func (c runtimePlaywrightClient) InteractPage(ctx context.Context, url string, actions []map[string]any) (tools.BrowserPageInteractResult, error) {
-	if c.runtime == nil || !c.runtime.Available() {
-		return tools.BrowserPageInteractResult{}, tools.ErrPlaywrightSidecarFailed
-	}
-	if !c.runtime.Ready() {
-		return tools.BrowserPageInteractResult{}, tools.ErrPlaywrightSidecarFailed
-	}
-	response, err := c.runtime.invoke(ctx, sidecarRequest{Action: "page_interact", URL: url, Actions: cloneActionSlice(actions)})
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "page_interact", URL: url, Actions: cloneActionSlice(actions)})
 	if err != nil {
-		if shouldMarkRuntimeFailure(err) {
-			_ = c.runtime.markFailure()
-		}
-		return tools.BrowserPageInteractResult{}, fmt.Errorf("%w: %v", tools.ErrPlaywrightSidecarFailed, err)
+		return tools.BrowserPageInteractResult{}, err
 	}
 	return tools.BrowserPageInteractResult{
-		URL:            stringValue(response.Result, "url"),
-		Title:          stringValue(response.Result, "title"),
-		TextContent:    stringValue(response.Result, "text_content"),
-		ActionsApplied: intValue(response.Result, "actions_applied"),
-		Source:         firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+		BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+		URL:                      stringValue(response.Result, "url"),
+		Title:                    stringValue(response.Result, "title"),
+		TextContent:              stringValue(response.Result, "text_content"),
+		ActionsApplied:           intValue(response.Result, "actions_applied"),
+		Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
 	}, nil
 }
 
 func (c runtimePlaywrightClient) StructuredDOM(ctx context.Context, url string) (tools.BrowserStructuredDOMResult, error) {
-	if c.runtime == nil || !c.runtime.Available() {
-		return tools.BrowserStructuredDOMResult{}, tools.ErrPlaywrightSidecarFailed
-	}
-	if !c.runtime.Ready() {
-		return tools.BrowserStructuredDOMResult{}, tools.ErrPlaywrightSidecarFailed
-	}
-	response, err := c.runtime.invoke(ctx, sidecarRequest{Action: "structured_dom", URL: url})
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "structured_dom", URL: url})
 	if err != nil {
-		if shouldMarkRuntimeFailure(err) {
-			_ = c.runtime.markFailure()
-		}
-		return tools.BrowserStructuredDOMResult{}, fmt.Errorf("%w: %v", tools.ErrPlaywrightSidecarFailed, err)
+		return tools.BrowserStructuredDOMResult{}, err
 	}
 	return tools.BrowserStructuredDOMResult{
-		URL:      stringValue(response.Result, "url"),
-		Title:    stringValue(response.Result, "title"),
-		Headings: stringSliceValue(response.Result, "headings"),
-		Links:    stringSliceValue(response.Result, "links"),
-		Buttons:  stringSliceValue(response.Result, "buttons"),
-		Inputs:   stringSliceValue(response.Result, "inputs"),
-		Source:   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+		BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+		URL:                      stringValue(response.Result, "url"),
+		Title:                    stringValue(response.Result, "title"),
+		Headings:                 stringSliceValue(response.Result, "headings"),
+		Links:                    stringSliceValue(response.Result, "links"),
+		Buttons:                  stringSliceValue(response.Result, "buttons"),
+		Inputs:                   stringSliceValue(response.Result, "inputs"),
+		Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+	}, nil
+}
+
+func (c runtimePlaywrightClient) AttachCurrentPage(ctx context.Context, attach tools.BrowserAttachConfig) (tools.BrowserAttachedPageResult, error) {
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "browser_attach_current", Attach: cloneAttachConfigPtr(&attach)})
+	if err != nil {
+		return tools.BrowserAttachedPageResult{}, err
+	}
+	return tools.BrowserAttachedPageResult{
+		BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+		PageIndex:                intValue(response.Result, "page_index"),
+		Title:                    stringValue(response.Result, "title"),
+		URL:                      stringValue(response.Result, "url"),
+		Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+	}, nil
+}
+
+func (c runtimePlaywrightClient) SnapshotBrowser(ctx context.Context, attach tools.BrowserAttachConfig) (tools.BrowserSnapshotResult, error) {
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "browser_snapshot", Attach: cloneAttachConfigPtr(&attach)})
+	if err != nil {
+		return tools.BrowserSnapshotResult{}, err
+	}
+	return tools.BrowserSnapshotResult{
+		BrowserAttachedPageResult: tools.BrowserAttachedPageResult{
+			BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+			PageIndex:                intValue(response.Result, "page_index"),
+			Title:                    stringValue(response.Result, "title"),
+			URL:                      stringValue(response.Result, "url"),
+			Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+		},
+		TextContent: stringValue(response.Result, "text_content"),
+		Headings:    stringSliceValue(response.Result, "headings"),
+		Links:       stringSliceValue(response.Result, "links"),
+		Buttons:     stringSliceValue(response.Result, "buttons"),
+		Inputs:      stringSliceValue(response.Result, "inputs"),
+	}, nil
+}
+
+func (c runtimePlaywrightClient) NavigateBrowser(ctx context.Context, request tools.BrowserNavigateRequest) (tools.BrowserNavigationResult, error) {
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "browser_navigate", URL: strings.TrimSpace(request.URL), Attach: cloneAttachConfigPtr(&request.Attach)})
+	if err != nil {
+		return tools.BrowserNavigationResult{}, err
+	}
+	return tools.BrowserNavigationResult{
+		BrowserAttachedPageResult: tools.BrowserAttachedPageResult{
+			BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+			PageIndex:                intValue(response.Result, "page_index"),
+			Title:                    stringValue(response.Result, "title"),
+			URL:                      stringValue(response.Result, "url"),
+			Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+		},
+		TextContent: stringValue(response.Result, "text_content"),
+		MIMEType:    stringValue(response.Result, "mime_type"),
+		TextType:    stringValue(response.Result, "text_type"),
+	}, nil
+}
+
+func (c runtimePlaywrightClient) ListBrowserTabs(ctx context.Context, attach tools.BrowserAttachConfig) (tools.BrowserTabsListResult, error) {
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "browser_tabs_list", Attach: cloneAttachConfigPtr(&attach)})
+	if err != nil {
+		return tools.BrowserTabsListResult{}, err
+	}
+	return tools.BrowserTabsListResult{
+		BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+		TabCount:                 intValue(response.Result, "tab_count"),
+		Tabs:                     browserTabSliceValue(response.Result, "tabs"),
+		Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+	}, nil
+}
+
+func (c runtimePlaywrightClient) FocusBrowserTab(ctx context.Context, attach tools.BrowserAttachConfig) (tools.BrowserAttachedPageResult, error) {
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "browser_tab_focus", Attach: cloneAttachConfigPtr(&attach)})
+	if err != nil {
+		return tools.BrowserAttachedPageResult{}, err
+	}
+	return tools.BrowserAttachedPageResult{
+		BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+		PageIndex:                intValue(response.Result, "page_index"),
+		Title:                    stringValue(response.Result, "title"),
+		URL:                      stringValue(response.Result, "url"),
+		Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
+	}, nil
+}
+
+func (c runtimePlaywrightClient) InteractBrowser(ctx context.Context, request tools.BrowserInteractRequest) (tools.BrowserPageInteractResult, error) {
+	response, err := c.invokeBrowserRequest(ctx, sidecarRequest{Action: "browser_interact", Attach: cloneAttachConfigPtr(&request.Attach), Actions: cloneActionSlice(request.Actions)})
+	if err != nil {
+		return tools.BrowserPageInteractResult{}, err
+	}
+	return tools.BrowserPageInteractResult{
+		BrowserExecutionMetadata: browserExecutionMetadata(response.Result),
+		URL:                      stringValue(response.Result, "url"),
+		Title:                    stringValue(response.Result, "title"),
+		TextContent:              stringValue(response.Result, "text_content"),
+		ActionsApplied:           intValue(response.Result, "actions_applied"),
+		Source:                   firstNonEmptyString(stringValue(response.Result, "source"), "playwright_sidecar"),
 	}, nil
 }
 
@@ -412,6 +494,26 @@ func intValue(values map[string]any, key string) int {
 	}
 }
 
+func browserExecutionMetadata(values map[string]any) tools.BrowserExecutionMetadata {
+	if len(values) == 0 {
+		return tools.BrowserExecutionMetadata{}
+	}
+	return tools.BrowserExecutionMetadata{
+		Attached:         boolValue(values, "attached"),
+		BrowserKind:      stringValue(values, "browser_kind"),
+		BrowserTransport: stringValue(values, "browser_transport"),
+		EndpointURL:      stringValue(values, "endpoint_url"),
+	}
+}
+
+func boolValue(values map[string]any, key string) bool {
+	if len(values) == 0 {
+		return false
+	}
+	value, _ := values[key].(bool)
+	return value
+}
+
 func stringSliceValue(values map[string]any, key string) []string {
 	if len(values) == 0 {
 		return nil
@@ -430,6 +532,41 @@ func stringSliceValue(values map[string]any, key string) []string {
 		return append([]string(nil), typed...)
 	}
 	return nil
+}
+
+func browserTabSliceValue(values map[string]any, key string) []tools.BrowserTabInfo {
+	if len(values) == 0 {
+		return nil
+	}
+	rawItems, ok := values[key].([]any)
+	if !ok {
+		return nil
+	}
+	items := make([]tools.BrowserTabInfo, 0, len(rawItems))
+	for _, rawItem := range rawItems {
+		typed, ok := rawItem.(map[string]any)
+		if !ok {
+			continue
+		}
+		items = append(items, tools.BrowserTabInfo{
+			PageIndex: intValue(typed, "page_index"),
+			Title:     stringValue(typed, "title"),
+			URL:       stringValue(typed, "url"),
+		})
+	}
+	return items
+}
+
+func cloneAttachConfigPtr(input *tools.BrowserAttachConfig) *tools.BrowserAttachConfig {
+	if input == nil {
+		return nil
+	}
+	cloned := *input
+	if input.Target.PageIndex != nil {
+		pageIndex := *input.Target.PageIndex
+		cloned.Target.PageIndex = &pageIndex
+	}
+	return &cloned
 }
 
 func resolveWorkerEntryPath() (string, error) {

--- a/services/local-service/internal/tools/sidecarclient/runtime_test.go
+++ b/services/local-service/internal/tools/sidecarclient/runtime_test.go
@@ -296,6 +296,165 @@ func TestPlaywrightSidecarRuntimeInvokeTimeoutKeepsReadyState(t *testing.T) {
 	}
 }
 
+func TestPlaywrightSidecarRuntimeClientSupportsAttachedBrowserActions(t *testing.T) {
+	osCapability := platform.NewLocalOSCapabilityAdapter()
+	runtime, err := NewPlaywrightSidecarRuntime(plugin.NewService(), osCapability)
+	if err != nil {
+		t.Fatalf("NewPlaywrightSidecarRuntime returned error: %v", err)
+	}
+	invoker := &stubWorkerInvoker{response: sidecarResponse{OK: true, Result: map[string]any{"status": "ok"}}}
+	runtime.invoker = invoker
+	if err := runtime.Start(); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	pageIndex := 1
+	attach := tools.BrowserAttachConfig{
+		Mode:        tools.BrowserAttachModeCDP,
+		BrowserKind: "chrome",
+		EndpointURL: "http://127.0.0.1:9222",
+		Target: tools.BrowserAttachTarget{
+			URL:           "https://example.com/docs",
+			TitleContains: "docs",
+			PageIndex:     &pageIndex,
+		},
+	}
+
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{
+		"attached":          true,
+		"browser_kind":      "chrome",
+		"browser_transport": "cdp",
+		"endpoint_url":      "http://127.0.0.1:9222",
+		"page_index":        1,
+		"title":             "Docs",
+		"url":               "https://example.com/docs",
+		"source":            "playwright_worker_cdp",
+	}}
+	attachResult, err := runtime.Client().AttachCurrentPage(t.Context(), attach)
+	if err != nil {
+		t.Fatalf("AttachCurrentPage returned error: %v", err)
+	}
+	if !attachResult.Attached || attachResult.PageIndex != 1 || attachResult.URL != "https://example.com/docs" {
+		t.Fatalf("unexpected attach result: %+v", attachResult)
+	}
+
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{
+		"attached":          true,
+		"browser_kind":      "chrome",
+		"browser_transport": "cdp",
+		"endpoint_url":      "http://127.0.0.1:9222",
+		"page_index":        1,
+		"title":             "Docs",
+		"url":               "https://example.com/docs",
+		"text_content":      "Installation guide",
+		"headings":          []any{"Install"},
+		"links":             []any{"Guide"},
+		"buttons":           []any{"Next"},
+		"inputs":            []any{"search"},
+		"source":            "playwright_worker_cdp",
+	}}
+	snapshotResult, err := runtime.Client().SnapshotBrowser(t.Context(), attach)
+	if err != nil {
+		t.Fatalf("SnapshotBrowser returned error: %v", err)
+	}
+	if snapshotResult.TextContent != "Installation guide" || len(snapshotResult.Headings) != 1 {
+		t.Fatalf("unexpected snapshot result: %+v", snapshotResult)
+	}
+
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{
+		"attached":          true,
+		"browser_kind":      "chrome",
+		"browser_transport": "cdp",
+		"endpoint_url":      "http://127.0.0.1:9222",
+		"tab_count":         2,
+		"tabs": []any{
+			map[string]any{"page_index": 0, "title": "Home", "url": "https://example.com"},
+			map[string]any{"page_index": 1, "title": "Docs", "url": "https://example.com/docs"},
+		},
+		"source": "playwright_worker_cdp",
+	}}
+	tabsResult, err := runtime.Client().ListBrowserTabs(t.Context(), attach)
+	if err != nil {
+		t.Fatalf("ListBrowserTabs returned error: %v", err)
+	}
+	if tabsResult.TabCount != 2 || len(tabsResult.Tabs) != 2 {
+		t.Fatalf("unexpected tabs result: %+v", tabsResult)
+	}
+
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{
+		"attached":          true,
+		"browser_kind":      "chrome",
+		"browser_transport": "cdp",
+		"endpoint_url":      "http://127.0.0.1:9222",
+		"page_index":        1,
+		"title":             "Docs",
+		"url":               "https://example.com/docs/start",
+		"text_content":      "Getting started",
+		"mime_type":         "text/html",
+		"text_type":         "text/html",
+		"source":            "playwright_worker_cdp",
+	}}
+	navigateResult, err := runtime.Client().NavigateBrowser(t.Context(), tools.BrowserNavigateRequest{Attach: attach, URL: "https://example.com/docs/start"})
+	if err != nil {
+		t.Fatalf("NavigateBrowser returned error: %v", err)
+	}
+	if navigateResult.URL != "https://example.com/docs/start" || navigateResult.PageIndex != 1 {
+		t.Fatalf("unexpected navigate result: %+v", navigateResult)
+	}
+
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{
+		"attached":          true,
+		"browser_kind":      "chrome",
+		"browser_transport": "cdp",
+		"endpoint_url":      "http://127.0.0.1:9222",
+		"page_index":        1,
+		"title":             "Docs",
+		"url":               "https://example.com/docs/start",
+		"source":            "playwright_worker_cdp",
+	}}
+	focusResult, err := runtime.Client().FocusBrowserTab(t.Context(), attach)
+	if err != nil {
+		t.Fatalf("FocusBrowserTab returned error: %v", err)
+	}
+	if focusResult.PageIndex != 1 {
+		t.Fatalf("unexpected focus result: %+v", focusResult)
+	}
+
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{
+		"attached":          true,
+		"browser_kind":      "chrome",
+		"browser_transport": "cdp",
+		"endpoint_url":      "http://127.0.0.1:9222",
+		"title":             "Docs",
+		"url":               "https://example.com/docs/start",
+		"text_content":      "Action applied",
+		"actions_applied":   1,
+		"source":            "playwright_worker_cdp",
+	}}
+	interactResult, err := runtime.Client().InteractBrowser(t.Context(), tools.BrowserInteractRequest{Attach: attach, Actions: []map[string]any{{"type": "click", "selector": "a.next"}}})
+	if err != nil {
+		t.Fatalf("InteractBrowser returned error: %v", err)
+	}
+	if interactResult.ActionsApplied != 1 || !interactResult.Attached {
+		t.Fatalf("unexpected browser interact result: %+v", interactResult)
+	}
+
+	if len(invoker.requests) != 7 {
+		t.Fatalf("expected health plus six attached browser requests, got %+v", invoker.requests)
+	}
+	if invoker.requests[1].Action != "browser_attach_current" || invoker.requests[1].Attach == nil || invoker.requests[1].Attach.Target.PageIndex == nil || *invoker.requests[1].Attach.Target.PageIndex != 1 {
+		t.Fatalf("unexpected attach request: %+v", invoker.requests[1])
+	}
+	if invoker.requests[4].Action != "browser_navigate" || invoker.requests[4].URL != "https://example.com/docs/start" {
+		t.Fatalf("unexpected navigate request: %+v", invoker.requests[4])
+	}
+	if invoker.requests[6].Action != "browser_interact" || len(invoker.requests[6].Actions) != 1 {
+		t.Fatalf("unexpected browser interact request: %+v", invoker.requests[6])
+	}
+	if invoker.requests[6].Actions[0]["selector"] != "a.next" {
+		t.Fatalf("expected cloned browser interact action payload, got %+v", invoker.requests[6].Actions)
+	}
+}
+
 func TestResolveRelativePathFromRootsFindsWorkerEntry(t *testing.T) {
 	root := t.TempDir()
 	entryPath := filepath.Join(root, "workers", "playwright-worker", "src", "index.js")

--- a/services/local-service/internal/tools/sidecarclient/runtime_test.go
+++ b/services/local-service/internal/tools/sidecarclient/runtime_test.go
@@ -193,6 +193,42 @@ func TestPlaywrightSidecarRuntimeClientInteractsAndReadsStructuredDOM(t *testing
 	}
 }
 
+func TestPlaywrightSidecarRuntimeClientForwardsAttachForPageActions(t *testing.T) {
+	osCapability := platform.NewLocalOSCapabilityAdapter()
+	runtime, err := NewPlaywrightSidecarRuntime(plugin.NewService(), osCapability)
+	if err != nil {
+		t.Fatalf("NewPlaywrightSidecarRuntime returned error: %v", err)
+	}
+	invoker := &stubWorkerInvoker{response: sidecarResponse{OK: true, Result: map[string]any{"status": "ok"}}}
+	runtime.invoker = invoker
+	if err := runtime.Start(); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	attach := tools.BrowserAttachConfig{Mode: tools.BrowserAttachModeCDP, BrowserKind: "chrome", Target: tools.BrowserAttachTarget{URL: "https://example.com/docs"}}
+
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{"url": "https://example.com/docs", "title": "Docs", "text_content": "attached text", "source": "playwright_worker_cdp", "attached": true, "browser_kind": "chrome"}}
+	if _, err := runtime.client.ReadPageAttached(t.Context(), "https://example.com/docs", attach); err != nil {
+		t.Fatalf("ReadPageAttached returned error: %v", err)
+	}
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{"url": "https://example.com/docs", "query": "install", "match_count": 1, "matches": []any{"install guide"}, "source": "playwright_worker_cdp", "attached": true, "browser_kind": "chrome"}}
+	if _, err := runtime.client.SearchPageAttached(t.Context(), "https://example.com/docs", "install", 2, attach); err != nil {
+		t.Fatalf("SearchPageAttached returned error: %v", err)
+	}
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{"url": "https://example.com/docs", "title": "Docs", "text_content": "clicked", "actions_applied": 1, "source": "playwright_worker_cdp", "attached": true, "browser_kind": "chrome"}}
+	if _, err := runtime.client.InteractPageAttached(t.Context(), "https://example.com/docs", []map[string]any{{"type": "click", "selector": "button"}}, attach); err != nil {
+		t.Fatalf("InteractPageAttached returned error: %v", err)
+	}
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{"url": "https://example.com/docs", "title": "Docs", "headings": []any{"Install"}, "links": []any{"Guide"}, "buttons": []any{"Next"}, "inputs": []any{"search"}, "source": "playwright_worker_cdp", "attached": true, "browser_kind": "chrome"}}
+	if _, err := runtime.client.StructuredDOMAttached(t.Context(), "https://example.com/docs", attach); err != nil {
+		t.Fatalf("StructuredDOMAttached returned error: %v", err)
+	}
+	for _, request := range invoker.requests[1:] {
+		if request.Attach == nil || request.Attach.BrowserKind != "chrome" {
+			t.Fatalf("expected attached request metadata, got %+v", request)
+		}
+	}
+}
+
 func TestPlaywrightSidecarRuntimeStartFailsHealthCheck(t *testing.T) {
 	osCapability := platform.NewLocalOSCapabilityAdapter()
 	pluginService := plugin.NewService()

--- a/services/local-service/internal/tools/sidecarclient/runtime_test.go
+++ b/services/local-service/internal/tools/sidecarclient/runtime_test.go
@@ -590,6 +590,42 @@ func TestPlaywrightSidecarRuntimeClientSupportsAttachedPageActions(t *testing.T)
 	}
 }
 
+func TestPlaywrightSidecarRuntimeClientSupportsAttachWithoutBrowserKind(t *testing.T) {
+	osCapability := platform.NewLocalOSCapabilityAdapter()
+	runtime, err := NewPlaywrightSidecarRuntime(plugin.NewService(), osCapability)
+	if err != nil {
+		t.Fatalf("NewPlaywrightSidecarRuntime returned error: %v", err)
+	}
+	invoker := &stubWorkerInvoker{response: sidecarResponse{OK: true, Result: map[string]any{"status": "ok"}}}
+	runtime.invoker = invoker
+	if err := runtime.Start(); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	attach := tools.BrowserAttachConfig{
+		Mode:        tools.BrowserAttachModeCDP,
+		EndpointURL: "http://127.0.0.1:9222",
+		Target: tools.BrowserAttachTarget{
+			URL: "https://example.com/docs",
+		},
+	}
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{
+		"attached":          true,
+		"browser_transport": "cdp",
+		"url":               "https://example.com/docs",
+		"title":             "Docs",
+		"text_content":      "Installation guide",
+		"mime_type":         "text/html",
+		"text_type":         "text/html",
+		"source":            "playwright_worker_cdp",
+	}}
+	if _, err := runtime.Client().ReadPageAttached(t.Context(), "https://example.com/docs", attach); err != nil {
+		t.Fatalf("ReadPageAttached returned error: %v", err)
+	}
+	if got := invoker.requests[1].Attach.BrowserKind; got != "" {
+		t.Fatalf("expected empty browser kind to pass through unchanged, got %q", got)
+	}
+}
+
 func TestResolveRelativePathFromRootsFindsWorkerEntry(t *testing.T) {
 	root := t.TempDir()
 	entryPath := filepath.Join(root, "workers", "playwright-worker", "src", "index.js")

--- a/services/local-service/internal/tools/sidecarclient/runtime_test.go
+++ b/services/local-service/internal/tools/sidecarclient/runtime_test.go
@@ -491,6 +491,105 @@ func TestPlaywrightSidecarRuntimeClientSupportsAttachedBrowserActions(t *testing
 	}
 }
 
+func TestPlaywrightSidecarRuntimeClientSupportsAttachedPageActions(t *testing.T) {
+	osCapability := platform.NewLocalOSCapabilityAdapter()
+	runtime, err := NewPlaywrightSidecarRuntime(plugin.NewService(), osCapability)
+	if err != nil {
+		t.Fatalf("NewPlaywrightSidecarRuntime returned error: %v", err)
+	}
+	invoker := &stubWorkerInvoker{response: sidecarResponse{OK: true, Result: map[string]any{"status": "ok"}}}
+	runtime.invoker = invoker
+	if err := runtime.Start(); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	pageIndex := 1
+	attach := tools.BrowserAttachConfig{
+		Mode:        tools.BrowserAttachModeCDP,
+		BrowserKind: "chrome",
+		EndpointURL: "http://127.0.0.1:9222",
+		Target: tools.BrowserAttachTarget{
+			URL:           "https://example.com/docs",
+			TitleContains: "docs",
+			PageIndex:     &pageIndex,
+		},
+	}
+
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{
+		"attached":          true,
+		"browser_kind":      "chrome",
+		"browser_transport": "cdp",
+		"endpoint_url":      "http://127.0.0.1:9222",
+		"url":               "https://example.com/docs",
+		"title":             "Docs",
+		"text_content":      "Installation guide",
+		"mime_type":         "text/html",
+		"text_type":         "text/html",
+		"source":            "playwright_worker_cdp",
+	}}
+	if _, err := runtime.Client().ReadPageAttached(t.Context(), "https://example.com/docs", attach); err != nil {
+		t.Fatalf("ReadPageAttached returned error: %v", err)
+	}
+
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{
+		"attached":          true,
+		"browser_kind":      "chrome",
+		"browser_transport": "cdp",
+		"endpoint_url":      "http://127.0.0.1:9222",
+		"url":               "https://example.com/docs",
+		"query":             "install",
+		"match_count":       1,
+		"matches":           []any{"install guide"},
+		"source":            "playwright_worker_cdp",
+	}}
+	if _, err := runtime.Client().SearchPageAttached(t.Context(), "https://example.com/docs", "install", 2, attach); err != nil {
+		t.Fatalf("SearchPageAttached returned error: %v", err)
+	}
+
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{
+		"attached":          true,
+		"browser_kind":      "chrome",
+		"browser_transport": "cdp",
+		"endpoint_url":      "http://127.0.0.1:9222",
+		"url":               "https://example.com/docs",
+		"title":             "Docs",
+		"text_content":      "Action applied",
+		"actions_applied":   1,
+		"source":            "playwright_worker_cdp",
+	}}
+	if _, err := runtime.Client().InteractPageAttached(t.Context(), "https://example.com/docs", []map[string]any{{"type": "click", "selector": "a.next"}}, attach); err != nil {
+		t.Fatalf("InteractPageAttached returned error: %v", err)
+	}
+
+	invoker.response = sidecarResponse{OK: true, Result: map[string]any{
+		"attached":          true,
+		"browser_kind":      "chrome",
+		"browser_transport": "cdp",
+		"endpoint_url":      "http://127.0.0.1:9222",
+		"url":               "https://example.com/docs",
+		"title":             "Docs",
+		"headings":          []any{"Install"},
+		"links":             []any{"Guide"},
+		"buttons":           []any{"Next"},
+		"inputs":            []any{"search"},
+		"source":            "playwright_worker_cdp",
+	}}
+	if _, err := runtime.Client().StructuredDOMAttached(t.Context(), "https://example.com/docs", attach); err != nil {
+		t.Fatalf("StructuredDOMAttached returned error: %v", err)
+	}
+
+	if len(invoker.requests) != 5 {
+		t.Fatalf("expected health plus four attached page requests, got %+v", invoker.requests)
+	}
+	for _, request := range invoker.requests[1:] {
+		if request.Attach == nil || request.Attach.EndpointURL != "http://127.0.0.1:9222" {
+			t.Fatalf("expected attached page request metadata, got %+v", request)
+		}
+	}
+	if invoker.requests[1].Action != "page_read" || invoker.requests[2].Action != "page_search" || invoker.requests[3].Action != "page_interact" || invoker.requests[4].Action != "structured_dom" {
+		t.Fatalf("unexpected attached page request sequence: %+v", invoker.requests)
+	}
+}
+
 func TestResolveRelativePathFromRootsFindsWorkerEntry(t *testing.T) {
 	root := t.TempDir()
 	entryPath := filepath.Join(root, "workers", "playwright-worker", "src", "index.js")

--- a/services/local-service/internal/tools/types.go
+++ b/services/local-service/internal/tools/types.go
@@ -526,12 +526,17 @@ type ScreenCleanupResult struct {
 	SkippedCount    int
 }
 
-// PlaywrightSidecarClient 是 Playwright sidecar 的最小客户端边界。
+// PlaywrightSidecarClient defines the minimal browser-facing boundary exposed
+// by the Playwright sidecar runtime.
 type PlaywrightSidecarClient interface {
 	ReadPage(ctx context.Context, url string) (BrowserPageReadResult, error)
+	ReadPageAttached(ctx context.Context, url string, attach BrowserAttachConfig) (BrowserPageReadResult, error)
 	SearchPage(ctx context.Context, url, query string, limit int) (BrowserPageSearchResult, error)
+	SearchPageAttached(ctx context.Context, url, query string, limit int, attach BrowserAttachConfig) (BrowserPageSearchResult, error)
 	InteractPage(ctx context.Context, url string, actions []map[string]any) (BrowserPageInteractResult, error)
+	InteractPageAttached(ctx context.Context, url string, actions []map[string]any, attach BrowserAttachConfig) (BrowserPageInteractResult, error)
 	StructuredDOM(ctx context.Context, url string) (BrowserStructuredDOMResult, error)
+	StructuredDOMAttached(ctx context.Context, url string, attach BrowserAttachConfig) (BrowserStructuredDOMResult, error)
 	AttachCurrentPage(ctx context.Context, attach BrowserAttachConfig) (BrowserAttachedPageResult, error)
 	SnapshotBrowser(ctx context.Context, attach BrowserAttachConfig) (BrowserSnapshotResult, error)
 	NavigateBrowser(ctx context.Context, request BrowserNavigateRequest) (BrowserNavigationResult, error)

--- a/services/local-service/internal/tools/types.go
+++ b/services/local-service/internal/tools/types.go
@@ -246,8 +246,45 @@ type CommandExecutionResult struct {
 	Interrupted      bool
 }
 
+// BrowserAttachMode classifies how one real-browser request attaches to a
+// user-owned browser session.
+type BrowserAttachMode string
+
+const (
+	// BrowserAttachModeCDP routes browser control through a local Chromium CDP
+	// endpoint that the user has already enabled.
+	BrowserAttachModeCDP BrowserAttachMode = "cdp"
+)
+
+// BrowserAttachTarget describes the minimum target filters that keep one
+// attach request scoped to the user's current browser state.
+type BrowserAttachTarget struct {
+	URL           string `json:"url,omitempty"`
+	TitleContains string `json:"title_contains,omitempty"`
+	PageIndex     *int   `json:"page_index,omitempty"`
+}
+
+// BrowserAttachConfig carries the normalized attach contract shared by page_*
+// attach flows and browser_* actions.
+type BrowserAttachConfig struct {
+	Mode        BrowserAttachMode   `json:"mode,omitempty"`
+	BrowserKind string              `json:"browser_kind,omitempty"`
+	EndpointURL string              `json:"endpoint_url,omitempty"`
+	Target      BrowserAttachTarget `json:"target,omitempty"`
+}
+
+// BrowserExecutionMetadata captures the transport details that explain whether
+// a browser result came from a fresh launch or a user-owned attached session.
+type BrowserExecutionMetadata struct {
+	Attached         bool
+	BrowserKind      string
+	BrowserTransport string
+	EndpointURL      string
+}
+
 // BrowserPageReadResult 描述浏览器页面读取的最小结果。
 type BrowserPageReadResult struct {
+	BrowserExecutionMetadata
 	URL         string
 	Title       string
 	TextContent string
@@ -258,6 +295,7 @@ type BrowserPageReadResult struct {
 
 // BrowserPageSearchResult 描述页面内基础搜索的最小结果。
 type BrowserPageSearchResult struct {
+	BrowserExecutionMetadata
 	URL        string
 	Query      string
 	MatchCount int
@@ -267,6 +305,7 @@ type BrowserPageSearchResult struct {
 
 // BrowserPageInteractResult describes one page interaction run.
 type BrowserPageInteractResult struct {
+	BrowserExecutionMetadata
 	URL            string
 	Title          string
 	TextContent    string
@@ -276,6 +315,7 @@ type BrowserPageInteractResult struct {
 
 // BrowserStructuredDOMResult describes a structured DOM snapshot.
 type BrowserStructuredDOMResult struct {
+	BrowserExecutionMetadata
 	URL      string
 	Title    string
 	Headings []string
@@ -283,6 +323,64 @@ type BrowserStructuredDOMResult struct {
 	Buttons  []string
 	Inputs   []string
 	Source   string
+}
+
+// BrowserAttachedPageResult identifies one attached browser tab selection.
+type BrowserAttachedPageResult struct {
+	BrowserExecutionMetadata
+	PageIndex int
+	Title     string
+	URL       string
+	Source    string
+}
+
+// BrowserTabInfo is the minimal attached tab summary returned by list calls.
+type BrowserTabInfo struct {
+	PageIndex int
+	Title     string
+	URL       string
+}
+
+// BrowserTabsListResult describes the visible tabs on one attached browser.
+type BrowserTabsListResult struct {
+	BrowserExecutionMetadata
+	TabCount int
+	Tabs     []BrowserTabInfo
+	Source   string
+}
+
+// BrowserSnapshotResult describes a text-rich snapshot of the currently
+// attached browser tab.
+type BrowserSnapshotResult struct {
+	BrowserAttachedPageResult
+	TextContent string
+	Headings    []string
+	Links       []string
+	Buttons     []string
+	Inputs      []string
+}
+
+// BrowserNavigateRequest is the normalized request shape for attached browser
+// navigation.
+type BrowserNavigateRequest struct {
+	Attach BrowserAttachConfig
+	URL    string
+}
+
+// BrowserNavigationResult describes the loaded page after an attached browser
+// navigation succeeds.
+type BrowserNavigationResult struct {
+	BrowserAttachedPageResult
+	TextContent string
+	MIMEType    string
+	TextType    string
+}
+
+// BrowserInteractRequest is the normalized request shape for attached browser
+// interactions.
+type BrowserInteractRequest struct {
+	Attach  BrowserAttachConfig
+	Actions []map[string]any
 }
 
 // OCRTextResult describes OCR or plain text extraction output.
@@ -434,6 +532,12 @@ type PlaywrightSidecarClient interface {
 	SearchPage(ctx context.Context, url, query string, limit int) (BrowserPageSearchResult, error)
 	InteractPage(ctx context.Context, url string, actions []map[string]any) (BrowserPageInteractResult, error)
 	StructuredDOM(ctx context.Context, url string) (BrowserStructuredDOMResult, error)
+	AttachCurrentPage(ctx context.Context, attach BrowserAttachConfig) (BrowserAttachedPageResult, error)
+	SnapshotBrowser(ctx context.Context, attach BrowserAttachConfig) (BrowserSnapshotResult, error)
+	NavigateBrowser(ctx context.Context, request BrowserNavigateRequest) (BrowserNavigationResult, error)
+	ListBrowserTabs(ctx context.Context, attach BrowserAttachConfig) (BrowserTabsListResult, error)
+	FocusBrowserTab(ctx context.Context, attach BrowserAttachConfig) (BrowserAttachedPageResult, error)
+	InteractBrowser(ctx context.Context, request BrowserInteractRequest) (BrowserPageInteractResult, error)
 }
 
 // OCRWorkerClient is the minimal OCR worker client boundary.


### PR DESCRIPTION
## Summary

This PR delivers the 3b slice of the browser-agent rollout.

It makes real-browser attach usable from the execution path by:

- persisting browser attach hints in `TaskContextSnapshot`
- carrying those hints through run/task snapshot handling
- injecting attach hints into `page_read`, `page_search`, `page_interact`, and `structured_dom` when the current page snapshot matches the requested URL
- tightening the trust boundary so attach metadata comes from desktop snapshot context, not model-provided browser overrides

It also brings in the required 3a compatibility fixes for this flow to work end-to-end:

- forward attached `page_*` requests to the Playwright sidecar
- restrict attach endpoints to loopback
- allow `browser_kind` to be omitted and detected by the worker

## Why

Before this PR, attached-browser support existed at the tool/runtime layer, but the execution pipeline could not reliably use it.

That caused two main problems:

- browser attach hints were not preserved in task/run snapshots
- `page_*` tools could not automatically reuse the current real browser page, even when the snapshot already identified it

## Scope

Included:

- snapshot/browser hint persistence
- execution-layer attach injection for `page_*` tools
- attached `page_*` request plumbing required by execution

Not included:

- planner/browser tool exposure
- browser governance policy expansion
- `result_page` / frontend delivery finalization

## Key Files

- `services/local-service/internal/context/service.go`
- `services/local-service/internal/runengine/engine.go`
- `services/local-service/internal/execution/service.go`
- `services/local-service/internal/execution/service_test.go`
- `services/local-service/internal/tools/sidecarclient/playwright.go`
- `services/local-service/internal/tools/sidecarclient/playwright_browser.go`
- `services/local-service/internal/tools/sidecarclient/runtime.go`

## Testing

Executed:

- `go test -cover ./services/local-service/internal/tools/sidecarclient`
- `go test -cover ./services/local-service/internal/tools`
- `go test -cover ./services/local-service/internal/context`
- `go test -cover ./services/local-service/internal/runengine`
- `go test -cover ./services/local-service/internal/storage`
- `go test -cover ./services/local-service/internal/execution`
- `go test -cover ./services/local-service/internal/orchestrator`
- `go vet ./services/local-service/internal/tools/sidecarclient ./services/local-service/internal/tools ./services/local-service/internal/context ./services/local-service/internal/runengine ./services/local-service/internal/storage ./services/local-service/internal/execution ./services/local-service/internal/orchestrator`

Not executed:

- `staticcheck` (not available in the current environment)

Closing #410 