### PR TITLE
fix(local-service): add missing json import in agentloop runtime

### DIFF
--- a/services/local-service/internal/agentloop/runtime.go
+++ b/services/local-service/internal/agentloop/runtime.go
@@ -2,6 +2,7 @@ package agentloop
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"


### PR DESCRIPTION
## Summary

This PR fixes a CI failure in `services/local-service/internal/agentloop/runtime.go` by adding the missing `encoding/json` import used by `json.Marshal`.

## Root Cause

`toolInvocationSignature` calls `json.Marshal(call.Arguments)`, but `encoding/json` was not imported.
This caused:

- `pnpm build:service` to fail with `undefined: json`
- `go run ./scripts/ci/local-service-style` to fail because `goimports` detected the missing import

## Changes

- Add `encoding/json` to `services/local-service/internal/agentloop/runtime.go`

## Verification

The following checks passed locally:

- `node scripts/ci/build-service.mjs`
- `go run ./scripts/ci/local-service-style`
- `go vet ./services/local-service/...`
- `go run honnef.co/go/tools/cmd/staticcheck ./services/local-service/...`

## Notes

This is a minimal functional fix with no behavior changes beyond restoring the intended buildable state.
