### PR TITLE
fix(desktop): open external links in system browser

### DIFF
--- a/apps/desktop/src-tauri/src/local_path.rs
+++ b/apps/desktop/src-tauri/src/local_path.rs
@@ -59,6 +59,12 @@ pub fn open_local_path(raw_path: &str, roots: &LocalPathRoots) -> Result<(), Str
     open_with_system_handler(&target)
 }
 
+/// Opens an external web url through the operating system's default browser.
+pub fn open_external_url(raw_url: &str) -> Result<(), String> {
+    let url = normalize_external_url(raw_url)?;
+    open_url_with_system_handler(&url)
+}
+
 /// Reveals a local file in the system file manager, or opens the directory
 /// directly when the target already points at a folder.
 pub fn reveal_local_path(raw_path: &str, roots: &LocalPathRoots) -> Result<(), String> {
@@ -220,10 +226,50 @@ fn ensure_path_within_allowed_roots(target: &Path, roots: &LocalPathRoots) -> Re
     ))
 }
 
+fn normalize_external_url(raw_url: &str) -> Result<String, String> {
+    let trimmed = raw_url.trim();
+    if trimmed.is_empty() {
+        return Err("external url is empty".to_string());
+    }
+
+    if !(trimmed.starts_with("https://") || trimmed.starts_with("http://")) {
+        return Err("external url must use http or https".to_string());
+    }
+
+    if trimmed.chars().any(char::is_whitespace) {
+        return Err("external url must not contain whitespace".to_string());
+    }
+
+    Ok(trimmed.to_string())
+}
+
 #[cfg(windows)]
 fn open_with_system_handler(target: &Path) -> Result<(), String> {
     let operation = encode_wide(OsStr::new("open"));
     let target_wide = encode_wide(target.as_os_str());
+    let result = unsafe {
+        ShellExecuteW(
+            None,
+            PCWSTR(operation.as_ptr()),
+            PCWSTR(target_wide.as_ptr()),
+            PCWSTR::null(),
+            PCWSTR::null(),
+            SW_SHOWNORMAL,
+        )
+    };
+
+    let code = result.0 as isize;
+    if code <= 32 {
+        return Err(format!("shell open failed with code {code}"));
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn open_url_with_system_handler(target: &str) -> Result<(), String> {
+    let operation = encode_wide(OsStr::new("open"));
+    let target_wide = encode_wide(OsStr::new(target));
     let result = unsafe {
         ShellExecuteW(
             None,
@@ -268,6 +314,20 @@ fn open_with_system_handler(target: &Path) -> Result<(), String> {
 }
 
 #[cfg(target_os = "macos")]
+fn open_url_with_system_handler(target: &str) -> Result<(), String> {
+    let status = Command::new("open")
+        .arg(target)
+        .status()
+        .map_err(|error| format!("failed to open external url {target}: {error}"))?;
+
+    if !status.success() {
+        return Err(format!("failed to open external url {target}: exit status {status}"));
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
 fn reveal_with_system_handler(target: &Path) -> Result<(), String> {
     run_platform_command(
         "open",
@@ -283,6 +343,20 @@ fn open_with_system_handler(target: &Path) -> Result<(), String> {
         &[target],
         &format!("open local target {}", target.display()),
     )
+}
+
+#[cfg(all(not(windows), not(target_os = "macos")))]
+fn open_url_with_system_handler(target: &str) -> Result<(), String> {
+    let status = Command::new("xdg-open")
+        .arg(target)
+        .status()
+        .map_err(|error| format!("failed to open external url {target}: {error}"))?;
+
+    if !status.success() {
+        return Err(format!("failed to open external url {target}: exit status {status}"));
+    }
+
+    Ok(())
 }
 
 #[cfg(all(not(windows), not(target_os = "macos")))]

--- a/apps/desktop/src-tauri/src/local_path.rs
+++ b/apps/desktop/src-tauri/src/local_path.rs
@@ -232,8 +232,16 @@ fn normalize_external_url(raw_url: &str) -> Result<String, String> {
         return Err("external url is empty".to_string());
     }
 
-    if !(trimmed.starts_with("https://") || trimmed.starts_with("http://")) {
+    let Some((scheme, remainder)) = trimmed.split_once(':') else {
+        return Err("external url is missing a scheme".to_string());
+    };
+
+    if !scheme.eq_ignore_ascii_case("https") && !scheme.eq_ignore_ascii_case("http") {
         return Err("external url must use http or https".to_string());
+    }
+
+    if !remainder.starts_with("//") {
+        return Err("external url must include // after the scheme".to_string());
     }
 
     if trimmed.chars().any(char::is_whitespace) {
@@ -400,8 +408,8 @@ fn run_platform_command(program: &str, args: &[&Path], description: &str) -> Res
 #[cfg(test)]
 mod tests {
     use super::{
-        open_trusted_directory, prepare_trusted_directory_target, resolve_existing_local_path,
-        resolve_path_candidate, LocalPathRoots,
+        normalize_external_url, open_trusted_directory, prepare_trusted_directory_target,
+        resolve_existing_local_path, resolve_path_candidate, LocalPathRoots,
     };
     use std::env;
     use std::fs;
@@ -411,6 +419,22 @@ mod tests {
     #[test]
     fn resolve_path_candidate_rejects_empty_input() {
         assert!(resolve_path_candidate("   ", &LocalPathRoots::new(None, None, None)).is_err());
+    }
+
+    #[test]
+    fn normalize_external_url_accepts_uppercase_http_schemes() {
+        let normalized = normalize_external_url("HTTPS://example.com/path")
+            .expect("uppercase https scheme should pass validation");
+
+        assert_eq!(normalized, "HTTPS://example.com/path");
+    }
+
+    #[test]
+    fn normalize_external_url_rejects_schemes_without_double_slash() {
+        let error = normalize_external_url("https:example.com")
+            .expect_err("scheme without double slash should fail");
+
+        assert!(error.contains("include //"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -446,6 +446,13 @@ async fn desktop_open_local_path(
 }
 
 #[tauri::command]
+async fn desktop_open_external_url(url: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || local_path::open_external_url(&url))
+        .await
+        .map_err(|error| format!("desktop external url task failed: {error}"))?
+}
+
+#[tauri::command]
 async fn desktop_reveal_local_path(
     bridge_state: tauri::State<'_, Arc<NamedPipeBridgeState>>,
     settings_snapshot_state: tauri::State<'_, Arc<DesktopSettingsSnapshotState>>,
@@ -2337,6 +2344,7 @@ fn main() {
             desktop_open_or_focus_onboarding,
             desktop_promote_onboarding,
             desktop_open_local_path,
+            desktop_open_external_url,
             desktop_reveal_local_path,
             desktop_open_runtime_data_path,
             desktop_sync_settings_snapshot,

--- a/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
+++ b/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
@@ -5898,6 +5898,7 @@ test("conversation session reuse expires after the backend freshness window", ()
 test("note page consumes note query helpers instead of inlining note bucket contracts", () => {
   const notePageSource = readFileSync(resolve(desktopRoot, "src/features/dashboard/notes/NotePage.tsx"), "utf8");
   const noteServiceSource = readFileSync(resolve(desktopRoot, "src/features/dashboard/notes/notePage.service.ts"), "utf8");
+  const externalUrlSource = readFileSync(resolve(desktopRoot, "src/platform/desktopExternalUrl.ts"), "utf8");
 
   assert.match(notePageSource, /buildDashboardNoteBucketQueryKey/);
   assert.match(notePageSource, /buildDashboardNoteBucketInvalidateKeys/);
@@ -5906,6 +5907,9 @@ test("note page consumes note query helpers instead of inlining note bucket cont
   assert.match(noteServiceSource, /isAllowedNoteOpenUrl/);
   assert.match(noteServiceSource, /if \(payload\?\.url\) \{/);
   assert.match(noteServiceSource, /mode === "open_url"/);
+  assert.match(noteServiceSource, /await openDesktopExternalUrl\(plan\.url\)/);
+  assert.match(noteServiceSource, /copyPreparedUrl\(localPathExecutionFailure\("无法直接打开便签资源链接，已准备复制地址"/);
+  assert.match(externalUrlSource, /desktop_open_external_url/);
 });
 
 test("source-note fallback cards stay local instead of inferring formal todo bucket and due status", () => {
@@ -6244,6 +6248,8 @@ test("task rpc service builds protocol-only experience instead of reusing mock t
   assert.doesNotMatch(taskServiceSource, /getMockTaskDetail\(/);
   assert.doesNotMatch(taskServiceSource, /runMockTaskControl\(/);
   assert.doesNotMatch(taskOutputSource, /getMockTaskDetail\(/);
+   assert.match(taskOutputSource, /await openDesktopExternalUrl\(plan\.url\)/);
+   assert.match(taskOutputSource, /copyPreparedUrl\(localPathExecutionFailure\("无法直接打开结果链接，已准备复制地址"/);
 });
 
 test("note rpc service keeps transport failures visible instead of switching to mock data", async () => {

--- a/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
+++ b/apps/desktop/src/features/dashboard/dashboard.contract.test.ts
@@ -5545,6 +5545,8 @@ test("task workspace routes formal delivery through a dedicated page and keeps l
   assert.match(taskDeliverySource, /buildDashboardTaskDetailRouteState/);
   assert.match(taskDeliverySource, /isAllowedTaskOpenUrl/);
   assert.match(taskDeliverySource, /formalDeliveryUrlIsAllowed/);
+  assert.match(taskDeliverySource, /handleFormalDeliveryUrlClick/);
+  assert.match(taskDeliverySource, /performTaskOpenExecution\(\{/);
   assert.doesNotMatch(taskDeliverySource, /href=\{formalDeliveryResult\.payload\.url\}/);
   assert.match(taskDeliverySource, /当前正式结果已经在交付页中展示/);
 

--- a/apps/desktop/src/features/dashboard/notes/notePage.service.ts
+++ b/apps/desktop/src/features/dashboard/notes/notePage.service.ts
@@ -813,6 +813,19 @@ function localPathExecutionFailure(message: string, error: unknown) {
   return `${message}（${detail}）`;
 }
 
+async function copyPreparedUrl(feedback: string, url: string) {
+  if (globalThis.navigator?.clipboard?.writeText) {
+    try {
+      await globalThis.navigator.clipboard.writeText(url);
+      return `${feedback} 已复制链接。`;
+    } catch {
+      return `${feedback} 链接：${url}`;
+    }
+  }
+
+  return `${feedback} 链接：${url}`;
+}
+
 /**
  * Executes a note resource open plan while preserving task-detail routing and
  * copy-path fallback inside the same renderer entry.
@@ -841,8 +854,12 @@ export async function performNoteResourceOpenExecution(
       return "已拦截不受支持的便签资源链接。";
     }
 
-    await openDesktopExternalUrl(plan.url);
-    return plan.feedback;
+    try {
+      await openDesktopExternalUrl(plan.url);
+      return plan.feedback;
+    } catch (error) {
+      return copyPreparedUrl(localPathExecutionFailure("无法直接打开便签资源链接，已准备复制地址", error), plan.url);
+    }
   }
 
   if (plan.mode === "open_local_path" && plan.path) {

--- a/apps/desktop/src/features/dashboard/notes/notePage.service.ts
+++ b/apps/desktop/src/features/dashboard/notes/notePage.service.ts
@@ -9,6 +9,7 @@ import type {
   TodoBucket,
   TodoItem,
 } from "@cialloclaw/protocol";
+import { openDesktopExternalUrl } from "@/platform/desktopExternalUrl";
 import { openDesktopLocalPath, revealDesktopLocalPath } from "@/platform/desktopLocalPath";
 import { convertNotepadToTask, listNotepad, updateNotepad } from "@/rpc/methods";
 import type { NoteConvertOutcome, NoteDetailExperience, NoteListItem, NoteResource, NoteUpdateOutcome, SourceNoteDocument } from "./notePage.types";
@@ -840,7 +841,7 @@ export async function performNoteResourceOpenExecution(
       return "已拦截不受支持的便签资源链接。";
     }
 
-    window.open(plan.url, "_blank", "noopener,noreferrer");
+    await openDesktopExternalUrl(plan.url);
     return plan.feedback;
   }
 

--- a/apps/desktop/src/features/dashboard/tasks/TaskDeliveryPage.tsx
+++ b/apps/desktop/src/features/dashboard/tasks/TaskDeliveryPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { CSSProperties } from "react";
+import type { CSSProperties, MouseEvent } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, ArrowLeft, ArrowUpRight, FolderOutput, Link2, RefreshCcw } from "lucide-react";
 import { Link, NavLink, Navigate, useNavigate, useParams } from "react-router-dom";
@@ -238,6 +238,27 @@ export function TaskDeliveryPage() {
     });
   }
 
+  async function handleFormalDeliveryUrlClick(event: MouseEvent<HTMLAnchorElement>) {
+    event.preventDefault();
+
+    if (!formalDeliveryUrl) {
+      return;
+    }
+
+    if (!formalDeliveryUrlIsAllowed) {
+      showFeedback("已拦截不受支持的结果链接。");
+      return;
+    }
+
+    showFeedback(await performTaskOpenExecution({
+      feedback: "已打开结果链接。",
+      mode: "open_url",
+      path: formalDeliveryResult?.payload.path ?? null,
+      taskId,
+      url: formalDeliveryUrl,
+    }));
+  }
+
   async function handleResolvedOpen(result: TaskDeliveryOpenResult) {
     const plan = resolveTaskOpenExecutionPlan(result);
 
@@ -436,7 +457,14 @@ export function TaskDeliveryPage() {
                 <dd>
                   {formalDeliveryUrl ? (
                     formalDeliveryUrlIsAllowed ? (
-                      <a href={formalDeliveryUrl} rel="noreferrer noopener" target="_blank">
+                      <a
+                        href={formalDeliveryUrl}
+                        rel="noreferrer noopener"
+                        target="_blank"
+                        onClick={(event) => {
+                          void handleFormalDeliveryUrlClick(event);
+                        }}
+                      >
                         {formalDeliveryUrl}
                       </a>
                     ) : (

--- a/apps/desktop/src/features/dashboard/tasks/taskOutput.service.ts
+++ b/apps/desktop/src/features/dashboard/tasks/taskOutput.service.ts
@@ -8,6 +8,7 @@ import type {
   DeliveryPayload,
   RequestMeta,
 } from "@cialloclaw/protocol";
+import { openDesktopExternalUrl } from "@/platform/desktopExternalUrl";
 import { openDesktopLocalPath, revealDesktopLocalPath } from "@/platform/desktopLocalPath";
 import { listTaskArtifacts, openDelivery, openTaskArtifact } from "@/rpc/methods";
 
@@ -173,7 +174,7 @@ export async function performTaskOpenExecution(plan: TaskOpenExecutionPlan, opti
       return "已拦截不受支持的结果链接。";
     }
 
-    window.open(plan.url, "_blank", "noopener,noreferrer");
+    await openDesktopExternalUrl(plan.url);
     return plan.feedback;
   }
 

--- a/apps/desktop/src/features/dashboard/tasks/taskOutput.service.ts
+++ b/apps/desktop/src/features/dashboard/tasks/taskOutput.service.ts
@@ -149,6 +149,19 @@ function localPathExecutionFailure(message: string, error: unknown) {
   return `${message}（${detail}）`;
 }
 
+async function copyPreparedUrl(feedback: string, url: string) {
+  if (globalThis.navigator?.clipboard?.writeText) {
+    try {
+      await globalThis.navigator.clipboard.writeText(url);
+      return `${feedback} 已复制链接。`;
+    } catch {
+      return `${feedback} 链接：${url}`;
+    }
+  }
+
+  return `${feedback} 链接：${url}`;
+}
+
 /**
  * Executes a renderer-side open plan while keeping task-detail routing and
  * copy-path fallback inside the same formal execution entry.
@@ -174,8 +187,12 @@ export async function performTaskOpenExecution(plan: TaskOpenExecutionPlan, opti
       return "已拦截不受支持的结果链接。";
     }
 
-    await openDesktopExternalUrl(plan.url);
-    return plan.feedback;
+    try {
+      await openDesktopExternalUrl(plan.url);
+      return plan.feedback;
+    } catch (error) {
+      return copyPreparedUrl(localPathExecutionFailure("无法直接打开结果链接，已准备复制地址", error), plan.url);
+    }
   }
 
   if (plan.mode === "open_local_path" && plan.path) {

--- a/apps/desktop/src/features/shell-ball/ShellBallPinnedBubbleWindow.tsx
+++ b/apps/desktop/src/features/shell-ball/ShellBallPinnedBubbleWindow.tsx
@@ -9,6 +9,7 @@ import {
   emitShellBallPinnedWindowDetached,
   useShellBallPinnedBubbleSnapshot,
 } from "./useShellBallCoordinator";
+import { ShellBallMarkdown } from "./components/ShellBallMarkdown";
 
 export function ShellBallPinnedBubbleWindow() {
   const windowLabel = getShellBallCurrentWindow().label;
@@ -70,7 +71,7 @@ export function ShellBallPinnedBubbleWindow() {
         >
           Drag
         </button>
-        <p className="shell-ball-bubble-message__text">{pinnedItem.bubble.text}</p>
+        <ShellBallMarkdown text={pinnedItem.bubble.text} />
       </div>
     </div>
   );

--- a/apps/desktop/src/features/shell-ball/components/ShellBallMarkdown.tsx
+++ b/apps/desktop/src/features/shell-ball/components/ShellBallMarkdown.tsx
@@ -220,11 +220,17 @@ function matchAutoLink(text: string): InlineMatch | null {
 
 function trimTrailingUrlPunctuation(value: string) {
   let href = value;
-  while (/[.,!?;:'"，。！？；：】》〉」』、】【>\]]$/.test(href)) {
+  while (/[.,!?;:'"，。！？；：】》〉」』、】【>\]）]$/.test(href)) {
     href = href.slice(0, -1);
   }
 
   while (href.endsWith(")") && countUrlCharacters(href, "(") < countUrlCharacters(href, ")")) {
+    href = href.slice(0, -1);
+  }
+
+  // Trim full-width closing parentheses only when they are unbalanced so
+  // Chinese wrapping like （https://example.com） still preserves valid hrefs.
+  while (href.endsWith("）") && countUrlCharacters(href, "（") < countUrlCharacters(href, "）")) {
     href = href.slice(0, -1);
   }
 

--- a/apps/desktop/src/features/shell-ball/components/ShellBallMarkdown.tsx
+++ b/apps/desktop/src/features/shell-ball/components/ShellBallMarkdown.tsx
@@ -185,18 +185,63 @@ function findFirstInlineMatch(text: string): InlineMatch | null {
 }
 
 function matchLink(text: string): InlineMatch | null {
-  const match = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/.exec(text);
+  const match = /\[([^\]]+)\]\(/.exec(text);
   if (match === null || match.index === undefined) {
+    return null;
+  }
+
+  const hrefStart = match.index + match[0].length;
+  const href = extractBalancedMarkdownHref(text, hrefStart);
+  if (href === null) {
     return null;
   }
 
   return {
     kind: "link",
     index: match.index,
-    length: match[0].length,
+    length: hrefStart + href.length + 1 - match.index,
     label: match[1],
-    href: match[2],
+    href,
   };
+}
+
+/**
+ * Keeps markdown-link parsing aligned with common browser URL handling by
+ * allowing balanced parentheses inside the href while still stopping at the
+ * markdown link's closing `)`.
+ */
+function extractBalancedMarkdownHref(text: string, hrefStart: number) {
+  let nestedParentheses = 0;
+
+  for (let index = hrefStart; index < text.length; index += 1) {
+    const character = text[index];
+    if (character === undefined) {
+      return null;
+    }
+
+    if (/\s/.test(character)) {
+      return null;
+    }
+
+    if (character === "(") {
+      nestedParentheses += 1;
+      continue;
+    }
+
+    if (character !== ")") {
+      continue;
+    }
+
+    if (nestedParentheses > 0) {
+      nestedParentheses -= 1;
+      continue;
+    }
+
+    const href = text.slice(hrefStart, index);
+    return /^https?:\/\//i.test(href) && href !== "" ? href : null;
+  }
+
+  return null;
 }
 
 function matchAutoLink(text: string): InlineMatch | null {

--- a/apps/desktop/src/features/shell-ball/components/ShellBallMarkdown.tsx
+++ b/apps/desktop/src/features/shell-ball/components/ShellBallMarkdown.tsx
@@ -14,6 +14,7 @@ type MarkdownBlock =
 
 type InlineMatch =
   | { kind: "link"; index: number; length: number; label: string; href: string }
+  | { kind: "auto-link"; index: number; length: number; href: string }
   | { kind: "code"; index: number; length: number; text: string }
   | { kind: "strong"; index: number; length: number; text: string }
   | { kind: "emphasis"; index: number; length: number; text: string };
@@ -112,6 +113,18 @@ function renderInline(text: string, keyPrefix: string): ReactNode[] {
           </a>,
         );
         break;
+      case "auto-link":
+        nodes.push(
+          <a
+            key={matchKey}
+            href={match.href}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {match.href}
+          </a>,
+        );
+        break;
       case "code":
         nodes.push(<code key={matchKey}>{match.text}</code>);
         break;
@@ -133,6 +146,7 @@ function renderInline(text: string, keyPrefix: string): ReactNode[] {
 function findFirstInlineMatch(text: string): InlineMatch | null {
   const matches = [
     matchLink(text),
+    matchAutoLink(text),
     matchInlineCode(text),
     matchStrong(text),
     matchEmphasis(text),
@@ -166,6 +180,33 @@ function matchLink(text: string): InlineMatch | null {
     label: match[1],
     href: match[2],
   };
+}
+
+function matchAutoLink(text: string): InlineMatch | null {
+  const match = new RegExp("https?:\\/\\/[^\\s<>()\\[\\]{}\"']+", "i").exec(text);
+  if (match === null || match.index === undefined) {
+    return null;
+  }
+
+  const href = trimTrailingUrlPunctuation(match[0]);
+  if (href === "") {
+    return null;
+  }
+
+  return {
+    kind: "auto-link",
+    index: match.index,
+    length: href.length,
+    href,
+  };
+}
+
+function trimTrailingUrlPunctuation(value: string) {
+  let href = value;
+  while (/[.,!?;:'"，。！？；：）】》〉」』、】【)>\]]$/.test(href)) {
+    href = href.slice(0, -1);
+  }
+  return href;
 }
 
 function matchInlineCode(text: string): InlineMatch | null {

--- a/apps/desktop/src/features/shell-ball/components/ShellBallMarkdown.tsx
+++ b/apps/desktop/src/features/shell-ball/components/ShellBallMarkdown.tsx
@@ -1,4 +1,5 @@
-import { Fragment, type ReactNode } from "react";
+import { Fragment, type MouseEvent, type ReactNode } from "react";
+import { openDesktopExternalUrl } from "@/platform/desktopExternalUrl";
 
 type ShellBallMarkdownProps = {
   text: string;
@@ -31,6 +32,14 @@ export function ShellBallMarkdown({ text }: ShellBallMarkdownProps) {
       {blocks.map((block) => renderMarkdownBlock(block, createBlockKey(block)))}
     </div>
   );
+}
+
+function handleShellBallLinkClick(event: MouseEvent<HTMLAnchorElement>, href: string) {
+  event.preventDefault();
+  event.stopPropagation();
+  void openDesktopExternalUrl(href).catch((error) => {
+    console.warn("shell-ball external link open failed", error);
+  });
 }
 
 function renderMarkdownBlock(block: MarkdownBlock, key: string) {
@@ -105,9 +114,13 @@ function renderInline(text: string, keyPrefix: string): ReactNode[] {
         nodes.push(
           <a
             key={matchKey}
+            data-shell-ball-interactive="true"
             href={match.href}
             target="_blank"
             rel="noreferrer"
+            onClick={(event) => {
+              handleShellBallLinkClick(event, match.href);
+            }}
           >
             {renderInline(match.label, `${matchKey}-label`)}
           </a>,
@@ -117,9 +130,13 @@ function renderInline(text: string, keyPrefix: string): ReactNode[] {
         nodes.push(
           <a
             key={matchKey}
+            data-shell-ball-interactive="true"
             href={match.href}
             target="_blank"
             rel="noreferrer"
+            onClick={(event) => {
+              handleShellBallLinkClick(event, match.href);
+            }}
           >
             {match.href}
           </a>,

--- a/apps/desktop/src/features/shell-ball/components/ShellBallMarkdown.tsx
+++ b/apps/desktop/src/features/shell-ball/components/ShellBallMarkdown.tsx
@@ -200,7 +200,7 @@ function matchLink(text: string): InlineMatch | null {
 }
 
 function matchAutoLink(text: string): InlineMatch | null {
-  const match = new RegExp("https?:\\/\\/[^\\s<>()\\[\\]{}\"']+", "i").exec(text);
+  const match = new RegExp("https?:\\/\\/[^\\s<>\\[\\]{}\"']+", "i").exec(text);
   if (match === null || match.index === undefined) {
     return null;
   }
@@ -220,10 +220,25 @@ function matchAutoLink(text: string): InlineMatch | null {
 
 function trimTrailingUrlPunctuation(value: string) {
   let href = value;
-  while (/[.,!?;:'"，。！？；：）】》〉」』、】【)>\]]$/.test(href)) {
+  while (/[.,!?;:'"，。！？；：】》〉」』、】【>\]]$/.test(href)) {
     href = href.slice(0, -1);
   }
+
+  while (href.endsWith(")") && countUrlCharacters(href, "(") < countUrlCharacters(href, ")")) {
+    href = href.slice(0, -1);
+  }
+
   return href;
+}
+
+function countUrlCharacters(value: string, target: string) {
+  let count = 0;
+  for (const rune of value) {
+    if (rune === target) {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 function matchInlineCode(text: string): InlineMatch | null {

--- a/apps/desktop/src/features/shell-ball/components/floating-pet/FloatingPet.tsx
+++ b/apps/desktop/src/features/shell-ball/components/floating-pet/FloatingPet.tsx
@@ -28,6 +28,21 @@ type FloatingPetProps = {
 
 type FloatingPetEffectName = "sparkle" | "bubbleAlert" | "bubbleSafe" | "bubbleThinking" | "bubbleListening";
 
+type FloatingPetBubbleAnimation = {
+  animate:
+    | { opacity: number[]; scale: number[] }
+    | { opacity: number[]; scaleX: number[]; scaleY: number[] };
+  assetName: FloatingPetAssetName;
+  duration: number;
+  initial?:
+    | { opacity: number; scale: number }
+    | { opacity: number; scaleX: number; scaleY: number };
+  layout: FloatingPetLayerTransform;
+  repeat: number;
+  repeatType: undefined;
+  times: readonly number[];
+};
+
 const HAPPY_FACE_TIMES = [0, 10 / 120, 15 / 120, 105 / 120, 110 / 120, 1] as const;
 const HAPPY_FACE_CLOSED_EYE_ROTATE = [180, 180, 180, 180, 180, 180] as const;
 const BREATH_EYE_TIMES = [0, 30 / 300, 40 / 300, 50 / 300, 1] as const;
@@ -125,7 +140,7 @@ function toPingPongKeyframes(values: readonly number[], times: readonly number[]
   };
 }
 
-function renderBubbleAnimation(effectName: FloatingPetEffectName, phase: "active" | "exit") {
+function renderBubbleAnimation(effectName: FloatingPetEffectName, phase: "active" | "exit"): FloatingPetBubbleAnimation {
   const layout = effectName === "sparkle" ? floatingPetInitialLayout.sparkle : floatingPetInitialLayout.bubble.effects[effectName];
   const assetName = EFFECT_TO_ASSET[effectName];
   const alertOpacity = toPingPongKeyframes([0, 1, 1, 1], EFFECT_LOOP_TIMES);

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -5082,6 +5082,33 @@ test("shell-ball agent bubbles keep markdown links clickable", () => {
   assert.match(markup, /data-shell-ball-interactive="true"/);
 });
 
+test("shell-ball bare urls keep balanced parentheses inside the linked href", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ShellBallBubbleZone, {
+      visualState: "processing",
+      bubbleItems: [
+        {
+          bubble: {
+            bubble_id: "msg-agent-paren-link-1",
+            task_id: "task-agent-paren-link-1",
+            type: "result",
+            text: "参考链接：https://en.wikipedia.org/wiki/Function_(mathematics)",
+            pinned: false,
+            hidden: false,
+            created_at: "2026-05-10T10:09:05.000Z",
+          },
+          role: "agent",
+          desktop: {
+            lifecycleState: "visible",
+          },
+        },
+      ] satisfies ShellBallBubbleItem[],
+    }),
+  );
+
+  assert.match(markup, /href="https:\/\/en\.wikipedia\.org\/wiki\/Function_\(mathematics\)"/);
+});
+
 test("shell-ball markdown links open through the desktop external-url bridge", () => {
   const markdownSource = readFileSync(
     resolve(desktopRoot, "src/features/shell-ball/components/ShellBallMarkdown.tsx"),

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -5109,6 +5109,34 @@ test("shell-ball bare urls keep balanced parentheses inside the linked href", ()
   assert.match(markup, /href="https:\/\/en\.wikipedia\.org\/wiki\/Function_\(mathematics\)"/);
 });
 
+test("shell-ball bare urls trim unbalanced full-width closing parentheses", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ShellBallBubbleZone, {
+      visualState: "processing",
+      bubbleItems: [
+        {
+          bubble: {
+            bubble_id: "msg-agent-fullwidth-paren-link-1",
+            task_id: "task-agent-fullwidth-paren-link-1",
+            type: "result",
+            text: "参考链接：（https://github.com/1024XEngineer/CialloClaw）",
+            pinned: false,
+            hidden: false,
+            created_at: "2026-05-10T12:09:05.000Z",
+          },
+          role: "agent",
+          desktop: {
+            lifecycleState: "visible",
+          },
+        },
+      ] satisfies ShellBallBubbleItem[],
+    }),
+  );
+
+  assert.match(markup, /href="https:\/\/github\.com\/1024XEngineer\/CialloClaw"/);
+  assert.doesNotMatch(markup, /href="https:\/\/github\.com\/1024XEngineer\/CialloClaw）"/);
+});
+
 test("shell-ball markdown links open through the desktop external-url bridge", () => {
   const markdownSource = readFileSync(
     resolve(desktopRoot, "src/features/shell-ball/components/ShellBallMarkdown.tsx"),

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -5109,6 +5109,34 @@ test("shell-ball bare urls keep balanced parentheses inside the linked href", ()
   assert.match(markup, /href="https:\/\/en\.wikipedia\.org\/wiki\/Function_\(mathematics\)"/);
 });
 
+test("shell-ball markdown links keep balanced parentheses inside the linked href", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ShellBallBubbleZone, {
+      visualState: "processing",
+      bubbleItems: [
+        {
+          bubble: {
+            bubble_id: "msg-agent-markdown-paren-link-1",
+            task_id: "task-agent-markdown-paren-link-1",
+            type: "result",
+            text: "[wiki](https://en.wikipedia.org/wiki/Function_(mathematics))",
+            pinned: false,
+            hidden: false,
+            created_at: "2026-05-10T10:12:05.000Z",
+          },
+          role: "agent",
+          desktop: {
+            lifecycleState: "visible",
+          },
+        },
+      ] satisfies ShellBallBubbleItem[],
+    }),
+  );
+
+  assert.match(markup, /href="https:\/\/en\.wikipedia\.org\/wiki\/Function_\(mathematics\)"/);
+  assert.match(markup, />wiki<\/a>/);
+});
+
 test("shell-ball bare urls trim unbalanced full-width closing parentheses", () => {
   const markup = renderToStaticMarkup(
     createElement(ShellBallBubbleZone, {

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -5023,6 +5023,63 @@ test("shell-ball bubble zone renders per-bubble pin and delete controls", () => 
   assert.equal(markup.match(/data-bubble-action="delete"/g)?.length, 2);
 });
 
+test("shell-ball agent bubbles auto-link bare https urls without trailing punctuation", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ShellBallBubbleZone, {
+      visualState: "processing",
+      bubbleItems: [
+        {
+          bubble: {
+            bubble_id: "msg-agent-link-1",
+            task_id: "task-agent-link-1",
+            type: "result",
+            text: "项目地址是 https://github.com/1024XEngineer/CialloClaw。",
+            pinned: false,
+            hidden: false,
+            created_at: "2026-05-08T10:09:00.000Z",
+          },
+          role: "agent",
+          desktop: {
+            lifecycleState: "visible",
+          },
+        },
+      ] satisfies ShellBallBubbleItem[],
+    }),
+  );
+
+  assert.match(markup, /href="https:\/\/github\.com\/1024XEngineer\/CialloClaw"/);
+  assert.doesNotMatch(markup, /href="https:\/\/github\.com\/1024XEngineer\/CialloClaw。"/);
+  assert.match(markup, /target="_blank"/);
+});
+
+test("shell-ball agent bubbles keep markdown links clickable", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ShellBallBubbleZone, {
+      visualState: "processing",
+      bubbleItems: [
+        {
+          bubble: {
+            bubble_id: "msg-agent-markdown-link-1",
+            task_id: "task-agent-markdown-link-1",
+            type: "result",
+            text: "[项目地址](https://github.com/1024XEngineer/CialloClaw)",
+            pinned: false,
+            hidden: false,
+            created_at: "2026-05-08T10:09:05.000Z",
+          },
+          role: "agent",
+          desktop: {
+            lifecycleState: "visible",
+          },
+        },
+      ] satisfies ShellBallBubbleItem[],
+    }),
+  );
+
+  assert.match(markup, />项目地址<\/a>/);
+  assert.match(markup, /href="https:\/\/github\.com\/1024XEngineer\/CialloClaw"/);
+});
+
 test("shell-ball pending-approval bubbles render inline allow and deny controls", () => {
   const markup = renderToStaticMarkup(
     createElement(ShellBallBubbleZone, {
@@ -7762,7 +7819,7 @@ test("shell-ball pinned bubble windows render one coordinator-owned pinned item 
           bubble_id: "msg-pinned-1",
           task_id: "task-pinned-1",
           type: "status",
-          text: "Keep this pinned.",
+          text: "Keep this pinned. https://github.com/1024XEngineer/CialloClaw",
           pinned: true,
           hidden: false,
           created_at: "2026-04-11T10:12:00.000Z",
@@ -7796,7 +7853,7 @@ test("shell-ball pinned bubble windows render one coordinator-owned pinned item 
     {
       react: require("react"),
       "./useShellBallCoordinator": {
-        useShellBallHelperWindowSnapshot() {
+        useShellBallPinnedBubbleSnapshot() {
           return helperSnapshot;
         },
         emitShellBallBubbleAction(action: string, bubbleId: string, source?: string) {
@@ -7825,6 +7882,7 @@ test("shell-ball pinned bubble windows render one coordinator-owned pinned item 
   const markup = renderToStaticMarkup(createElement(RuntimeShellBallPinnedBubbleWindow, null));
 
   assert.match(markup, /Keep this pinned\./);
+  assert.match(markup, /href="https:\/\/github\.com\/1024XEngineer\/CialloClaw"/);
   assert.doesNotMatch(markup, /Leave this in the region\./);
   assert.match(markup, /Unpin/);
   assert.match(markup, /Delete/);

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -5050,6 +5050,7 @@ test("shell-ball agent bubbles auto-link bare https urls without trailing punctu
   assert.match(markup, /href="https:\/\/github\.com\/1024XEngineer\/CialloClaw"/);
   assert.doesNotMatch(markup, /href="https:\/\/github\.com\/1024XEngineer\/CialloClaw。"/);
   assert.match(markup, /target="_blank"/);
+  assert.match(markup, /data-shell-ball-interactive="true"/);
 });
 
 test("shell-ball agent bubbles keep markdown links clickable", () => {
@@ -5078,6 +5079,22 @@ test("shell-ball agent bubbles keep markdown links clickable", () => {
 
   assert.match(markup, />项目地址<\/a>/);
   assert.match(markup, /href="https:\/\/github\.com\/1024XEngineer\/CialloClaw"/);
+  assert.match(markup, /data-shell-ball-interactive="true"/);
+});
+
+test("shell-ball markdown links open through the desktop external-url bridge", () => {
+  const markdownSource = readFileSync(
+    resolve(desktopRoot, "src/features/shell-ball/components/ShellBallMarkdown.tsx"),
+    "utf8",
+  );
+  const externalUrlSource = readFileSync(
+    resolve(desktopRoot, "src/platform/desktopExternalUrl.ts"),
+    "utf8",
+  );
+
+  assert.match(markdownSource, /openDesktopExternalUrl\(href\)/);
+  assert.doesNotMatch(markdownSource, /window\.open\(/);
+  assert.match(externalUrlSource, /invoke<void>\("desktop_open_external_url", \{ url \}\)/);
 });
 
 test("shell-ball pending-approval bubbles render inline allow and deny controls", () => {

--- a/apps/desktop/src/platform/desktopExternalUrl.ts
+++ b/apps/desktop/src/platform/desktopExternalUrl.ts
@@ -1,0 +1,9 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Opens an external web url through the desktop host so the system default
+ * browser, not the embedded WebView, owns the navigation.
+ */
+export async function openDesktopExternalUrl(url: string) {
+  await invoke<void>("desktop_open_external_url", { url });
+}


### PR DESCRIPTION
solve #483 
## Summary
- linkify shell-ball reply urls and route clicks through a desktop host bridge instead of the embedded WebView
- add a new `desktop_open_external_url` Tauri command so `http/https` links open in the system default browser
- reuse the same desktop external-url open flow for shell-ball, task delivery links, and note resource links
## Verification
- `pnpm --dir apps/desktop typecheck`
- `pnpm --dir apps/desktop lint`
- `cargo check` in `apps/desktop/src-tauri`
## Notes
- shell-ball link rendering keeps existing markdown-link support and adds bare-url linkification
- pinned shell-ball bubbles now share the same markdown link rendering path
- lint still reports the repository's pre-existing fast-refresh warnings