### PR TITLE
chore(ci): raise local-service file size guard to 4000 lines

### DIFF
--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -17,7 +17,7 @@ go test ./services/local-service/...
 `local-service-style` verifies that `goimports` has been applied to changed Go
 files under `services/local-service`, rejects newly added Chinese Go comments in
 local-service diffs, and scans all current `services/local-service` Go comments
-so historical comment debt cannot silently return, and enforces a 2,000-line
+so historical comment debt cannot silently return, and enforces a 4,000-line
 ceiling for changed non-test Go files. The file-size guard only reports files
 that both exceed the ceiling and grow relative to the base or local pre-change
 snapshot, so historical oversized files can still receive focused fixes without

--- a/scripts/ci/local-service-style/main.go
+++ b/scripts/ci/local-service-style/main.go
@@ -22,7 +22,7 @@ const (
 	styleToolPath    = "scripts/ci/local-service-style"
 	goimportsTool    = "golang.org/x/tools/cmd/goimports"
 	goimportsRunCmd  = "go run " + goimportsTool
-	maxGoFileLines   = 2000
+	maxGoFileLines   = 4000
 )
 
 var hunkHeaderPattern = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@`)


### PR DESCRIPTION
- 暂时放宽文件行数判定