### PR TITLE
Fix runtime approval pauses for agent loop tool calls

### DIFF
--- a/docs/module-design.md
+++ b/docs/module-design.md
@@ -2683,7 +2683,7 @@ sequenceDiagram
 **关键结果**：在执行前形成 `approval_request` 和 `recovery_point`，在执行后形成 `authorization_record` 和 `audit_record`。  
 **异常分支**：执行失败或用户中断时，必须显式回滚或保留可恢复信息。  
 **实现说明**：此链路是治理链的最小闭环，凡是跨工作区、命令执行、联网下载、删除/覆盖等动作，都必须从这里经过。
-补充边界：`agent_loop` 在运行中若某轮工具命中 `approval_required`，也必须立刻把该次真实工具输入回写为 `approval_request / pending_execution`，把任务切回 `waiting_auth`，并且在获批前不得伪造 `delivery_result`。
+补充边界：`agent_loop` 在运行中若某轮工具命中 `approval_required`，也必须立刻把该次真实工具输入回写为 `approval_request / pending_execution`，并把精确 `tool input` 固化到恢复计划中；把任务切回 `waiting_auth`，并且在获批前不得伪造 `delivery_result`。
 
 设计约束：对于 `exec_command` 这类高风险执行，默认应优先进入 Docker Sandbox，并且支持上下文中断后的容器清理；仅在 Windows shell 命令入口上允许走受控宿主路径，其他失败情形不能静默回退到宿主直接执行。
 

--- a/docs/module-design.md
+++ b/docs/module-design.md
@@ -2683,6 +2683,7 @@ sequenceDiagram
 **关键结果**：在执行前形成 `approval_request` 和 `recovery_point`，在执行后形成 `authorization_record` 和 `audit_record`。  
 **异常分支**：执行失败或用户中断时，必须显式回滚或保留可恢复信息。  
 **实现说明**：此链路是治理链的最小闭环，凡是跨工作区、命令执行、联网下载、删除/覆盖等动作，都必须从这里经过。
+补充边界：`agent_loop` 在运行中若某轮工具命中 `approval_required`，也必须立刻把该次真实工具输入回写为 `approval_request / pending_execution`，把任务切回 `waiting_auth`，并且在获批前不得伪造 `delivery_result`。
 
 设计约束：对于 `exec_command` 这类高风险执行，默认应优先进入 Docker Sandbox，并且支持上下文中断后的容器清理；仅在 Windows shell 命令入口上允许走受控宿主路径，其他失败情形不能静默回退到宿主直接执行。
 

--- a/docs/protocol-design.md
+++ b/docs/protocol-design.md
@@ -229,7 +229,7 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
 ### 5.1 任务状态 `task_status`
 
 - `processing`：任务正在执行。
-- `waiting_auth`：命中高风险动作，等待授权。
+- `waiting_auth`：命中高风险动作，等待授权；既包括执行前的治理预检，也包括 `agent_loop` 在运行中选中具体工具后触发的正式授权暂停。
 - `waiting_input`：等待用户补充必要输入。
 - `confirming_intent`：系统已识别出候选意图，等待用户确认或纠偏。
 - `paused`：任务被用户或系统主动暂停。
@@ -4333,7 +4333,7 @@ Notification 只负责“状态变化推送”，不承载复杂业务命令。
 
 - `task.updated`：任务主状态或关键摘要变化；通知参数至少包含 `task_id`、`session_id`、`status`
 - `delivery.ready`：正式交付已可被前端承接
-- `approval.pending`：出现待授权动作
+- `approval.pending`：出现待授权动作；既可来自执行前治理预检，也可来自 `agent_loop` 运行中命中的具体工具调用
 - `task.steered`：运行中补充要求已经写入任务链
 - `task.session_queued`：同一 `session` 下的新任务进入串行等待
 - `task.session_resumed`：队列中的任务重新恢复执行

--- a/services/local-service/internal/agentloop/runtime.go
+++ b/services/local-service/internal/agentloop/runtime.go
@@ -490,6 +490,36 @@ func (r *Runtime) Run(ctx context.Context, request Request) (Result, bool, error
 					StopReason:      StopReasonToolRetryExhausted,
 				}, true, nil
 			}
+			if toolCallNeedsAuthorization(record) {
+				round.Status = "completed"
+				round.CompletedAt = request.Now()
+				round.StopReason = StopReasonNeedAuthorization
+				round.Observation = truncateText(singleLineSummary(observation), 240)
+				round.OutputSummary = truncateText(singleLineSummary(observation), 160)
+				rounds = append(rounds, round)
+				events = appendEvent(events, request, newEventForRound(round, "loop.round.completed", map[string]any{"attempt_index": round.AttemptIndex, "segment_kind": round.SegmentKind, "loop_round": round.LoopRound, "stop_reason": string(StopReasonNeedAuthorization)}))
+				if request.Hook != nil {
+					if err := request.Hook.AfterTool(ctx, round, record, observation); err != nil {
+						return Result{}, true, err
+					}
+					if err := request.Hook.AfterRound(ctx, round); err != nil {
+						return Result{}, true, err
+					}
+				}
+				auditRecord, auditErr := request.BuildAuditRecord(ctx, latestInvocation)
+				if auditErr != nil {
+					return Result{}, true, auditErr
+				}
+				return Result{
+					OutputText:      observation,
+					ToolCalls:       allToolCalls,
+					ModelInvocation: invocationRecordMap(latestInvocation),
+					AuditRecord:     auditRecord,
+					Events:          events,
+					Rounds:          rounds,
+					StopReason:      StopReasonNeedAuthorization,
+				}, true, nil
+			}
 			observations = append(observations, observation)
 			round.Observation = truncateText(singleLineSummary(observation), 240)
 			events = appendEvent(events, request, newEventForRound(round, "tool_call.observed", map[string]any{
@@ -1479,6 +1509,17 @@ func plannerRetryReason(err error) string {
 
 func shouldRetryToolRecord(record tools.ToolCallRecord) bool {
 	return toolRetryReason(record) == "timeout"
+}
+
+func toolCallNeedsAuthorization(record tools.ToolCallRecord) bool {
+	if record.ErrorCode != nil && *record.ErrorCode == tools.ToolErrorCodeApprovalRequired {
+		return true
+	}
+	if record.Status != tools.ToolCallStatusFailed {
+		return false
+	}
+	value, ok := record.Output["approval_required"].(bool)
+	return ok && value
 }
 
 func toolRetryReason(record tools.ToolCallRecord) string {

--- a/services/local-service/internal/agentloop/runtime_test.go
+++ b/services/local-service/internal/agentloop/runtime_test.go
@@ -99,6 +99,57 @@ func TestRunMergesSteeringMessagesIntoLaterPlannerRounds(t *testing.T) {
 	}
 }
 
+func TestRunStopsWhenToolRequiresAuthorization(t *testing.T) {
+	runtime := NewRuntime()
+	request := testRuntimeRequest()
+	request.ToolDefinitions = []model.ToolDefinition{{Name: "page_read"}}
+	request.GenerateToolCalls = func(_ context.Context, _ model.ToolCallRequest) (model.ToolCallResult, error) {
+		return model.ToolCallResult{
+			RequestID: "req_auth_tool",
+			Provider:  "openai_responses",
+			ModelID:   "gpt-5.4",
+			ToolCalls: []model.ToolInvocation{{Name: "page_read", Arguments: map[string]any{"url": "https://example.com"}}},
+		}, nil
+	}
+	approvalCode := tools.ToolErrorCodeApprovalRequired
+	request.ExecuteTool = func(_ context.Context, call model.ToolInvocation, _ int) (string, tools.ToolCallRecord) {
+		return "Tool page_read failed with error: approval required", tools.ToolCallRecord{
+			ToolCallID: "tool_call_auth",
+			TaskID:     request.TaskID,
+			RunID:      request.RunID,
+			ToolName:   call.Name,
+			Status:     tools.ToolCallStatusFailed,
+			Input:      cloneMap(call.Arguments),
+			Output: map[string]any{
+				"approval_required": true,
+				"risk_level":        tools.RiskLevelYellow,
+				"reason":            "webpage_requires_approval",
+			},
+			ErrorCode: &approvalCode,
+		}
+	}
+
+	result, handled, err := runtime.Run(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected agent loop request to be handled")
+	}
+	if result.StopReason != StopReasonNeedAuthorization {
+		t.Fatalf("expected need_authorization stop reason, got %s", result.StopReason)
+	}
+	if len(result.ToolCalls) != 1 || result.ToolCalls[0].ToolName != "page_read" {
+		t.Fatalf("expected approval-blocked tool call to be preserved, got %+v", result.ToolCalls)
+	}
+	if len(result.Rounds) != 1 || result.Rounds[0].StopReason != StopReasonNeedAuthorization {
+		t.Fatalf("expected round to stop for authorization, got %+v", result.Rounds)
+	}
+	if !hasEventType(result.Events, "loop.round.completed") {
+		t.Fatalf("expected loop.round.completed event, got %+v", result.Events)
+	}
+}
+
 func TestRunCompactsHistoryBeforeLaterPlannerRounds(t *testing.T) {
 	runtime := NewRuntime()
 	plannerInputs := []string{}

--- a/services/local-service/internal/execution/service.go
+++ b/services/local-service/internal/execution/service.go
@@ -3338,11 +3338,18 @@ func recoveryPointMap(point checkpoint.RecoveryPoint) map[string]any {
 	}
 }
 
-func governanceTargetObject(toolName string, toolInput map[string]any, execCtx *tools.ToolExecuteContext) string {
+// GovernanceTargetObject derives the stable approval boundary for a concrete
+// tool invocation. Orchestrator runtime-approval recovery reuses the same
+// target-object rules so resumed approval checks match the executor's
+// preflight and replay behavior.
+func GovernanceTargetObject(toolName string, toolInput map[string]any, execCtx *tools.ToolExecuteContext) string {
 	switch toolName {
 	case "write_file":
 		return stringValue(toolInput, "path", "")
 	case "exec_command":
+		if execCtx == nil {
+			return stringValue(toolInput, "working_dir", "")
+		}
 		return firstNonEmpty(stringValue(toolInput, "working_dir", ""), execCtx.WorkspacePath)
 	case "page_read", "page_search", "page_interact", "structured_dom":
 		return stringValue(toolInput, "url", "")
@@ -3360,6 +3367,10 @@ func governanceTargetObject(toolName string, toolInput map[string]any, execCtx *
 		}
 		return ""
 	}
+}
+
+func governanceTargetObject(toolName string, toolInput map[string]any, execCtx *tools.ToolExecuteContext) string {
+	return GovernanceTargetObject(toolName, toolInput, execCtx)
 }
 
 func approvedTargetObject(intent map[string]any, workspacePath string) string {

--- a/services/local-service/internal/execution/service.go
+++ b/services/local-service/internal/execution/service.go
@@ -146,6 +146,7 @@ type Request struct {
 	ApprovalGranted      bool
 	ApprovedOperation    string
 	ApprovedTargetObject string
+	ApprovedToolInput    map[string]any
 	BudgetDowngrade      map[string]any
 }
 
@@ -3293,6 +3294,7 @@ func (s *Service) toolExecutionContext(workspacePath string, request Request) *t
 		ApprovalGranted:      request.ApprovalGranted,
 		ApprovedOperation:    approvedOperation,
 		ApprovedTargetObject: approvedTargetObject,
+		ApprovedToolInput:    cloneMap(request.ApprovedToolInput),
 		Platform:             s.fileSystem,
 		Execution:            s.execution,
 		Playwright:           s.playwright,

--- a/services/local-service/internal/execution/service.go
+++ b/services/local-service/internal/execution/service.go
@@ -417,6 +417,20 @@ func (s *Service) Execute(ctx context.Context, request Request) (Result, error) 
 	if err != nil {
 		return Result{}, err
 	}
+	if trace.LoopStopReason == string(agentloop.StopReasonNeedAuthorization) {
+		latestCall := latestToolCall(trace.ToolCalls)
+		return Result{
+			Content:         trace.OutputText,
+			DurationMS:      time.Since(startedAt).Milliseconds(),
+			ModelInvocation: cloneMap(trace.ModelInvocation),
+			AuditRecord:     cloneMap(trace.AuditRecord),
+			ToolCalls:       append([]tools.ToolCallRecord(nil), trace.ToolCalls...),
+			LoopStopReason:  trace.LoopStopReason,
+			ToolName:        latestCall.ToolName,
+			ToolInput:       cloneMap(latestCall.Input),
+			ToolOutput:      cloneMap(latestCall.Output),
+		}, nil
+	}
 
 	deliveryType := firstNonEmpty(request.DeliveryType, "workspace_document")
 	targetPath := targetPathFromIntent(request.Intent)

--- a/services/local-service/internal/execution/service_test.go
+++ b/services/local-service/internal/execution/service_test.go
@@ -3918,6 +3918,9 @@ func TestToolBubbleTextAndGovernanceHelpersSupportNewWorkerFlows(t *testing.T) {
 	if governanceTargetObject("page_interact", map[string]any{"url": "https://example.com"}, &tools.ToolExecuteContext{WorkspacePath: "/workspace"}) != "https://example.com" {
 		t.Fatalf("expected page_interact governance target url")
 	}
+	if GovernanceTargetObject("browser_attach_current", map[string]any{"attach": map[string]any{"browser_kind": "chrome", "target": map[string]any{"title_contains": "Pinned Tab"}}}, nil) != "Pinned Tab" {
+		t.Fatalf("expected exported governance target helper to preserve browser title selectors")
+	}
 	if governanceTargetObject("browser_snapshot", map[string]any{"attach": map[string]any{"browser_kind": "chrome", "target": map[string]any{"url": "https://example.com/docs"}}}, &tools.ToolExecuteContext{WorkspacePath: "/workspace"}) != "https://example.com/docs" {
 		t.Fatalf("expected browser_snapshot governance target url")
 	}

--- a/services/local-service/internal/orchestrator/execution.go
+++ b/services/local-service/internal/orchestrator/execution.go
@@ -275,7 +275,7 @@ func (s *Service) executeTaskAttempt(previousTask, task runengine.TaskRecord, sn
 		return updatedTask, resultBubble, deliveryResult, artifacts, nil
 	}
 
-	approvedOperation, approvedTargetObject := approvedExecutionFromTask(processingTask)
+	approvedOperation, approvedTargetObject, approvedToolInput := approvedExecutionFromTask(processingTask)
 	executionCtx := context.Background()
 	if shouldBoundTaskExecution(processingTask, snapshot, taskIntent, deliveryType) {
 		executionTimeout := s.executionTimeout
@@ -303,6 +303,7 @@ func (s *Service) executeTaskAttempt(previousTask, task runengine.TaskRecord, sn
 		ApprovalGranted:      processingTask.Authorization != nil,
 		ApprovedOperation:    approvedOperation,
 		ApprovedTargetObject: approvedTargetObject,
+		ApprovedToolInput:    approvedToolInput,
 		BudgetDowngrade: map[string]any{
 			"enabled":         budgetDecision.Enabled,
 			"applied":         budgetDecision.Applied,
@@ -1012,11 +1013,11 @@ func (s *Service) activeExecutionStepName(taskIntent map[string]any) string {
 	return "generate_output"
 }
 
-func approvedExecutionFromTask(task runengine.TaskRecord) (string, string) {
+func approvedExecutionFromTask(task runengine.TaskRecord) (string, string, map[string]any) {
 	if len(task.PendingExecution) == 0 {
-		return "", ""
+		return "", "", nil
 	}
-	return stringValue(task.PendingExecution, "operation_name", ""), stringValue(task.PendingExecution, "target_object", "")
+	return stringValue(task.PendingExecution, "operation_name", ""), stringValue(task.PendingExecution, "target_object", ""), cloneMap(mapValue(task.PendingExecution, "approved_tool_input"))
 }
 
 func toolCallErrorCode(toolCall tools.ToolCallRecord) any {

--- a/services/local-service/internal/orchestrator/execution.go
+++ b/services/local-service/internal/orchestrator/execution.go
@@ -313,7 +313,7 @@ func (s *Service) executeTaskAttempt(previousTask, task runengine.TaskRecord, sn
 			"trace":           cloneMap(budgetDecision.Trace),
 		},
 	})
-	if err == nil {
+	if err == nil && executionResult.LoopStopReason != string(agentloop.StopReasonNeedAuthorization) {
 		executionResult = s.normalizeExecutionFormalDeliveryResult(processingTask.TaskID, deliveryType, resultTitle, executionResult)
 	}
 	processingTask = s.recordExecutionToolCalls(processingTask, executionResult.ToolCalls)
@@ -337,6 +337,9 @@ func (s *Service) executeTaskAttempt(previousTask, task runengine.TaskRecord, sn
 	if traceErr != nil {
 		failedTask, failureBubble := s.failExecutionTask(processingTask, taskIntent, executionResult, traceErr)
 		return failedTask, failureBubble, nil, nil, nil
+	}
+	if waitingTask, waitingBubble, ok, approvalErr := s.maybePauseForRuntimeApproval(processingTask, taskIntent, executionResult); approvalErr != nil || ok {
+		return waitingTask, waitingBubble, nil, nil, approvalErr
 	}
 	if escalatedTask, escalatedBubble, ok := s.maybeEscalateHumanLoop(processingTask, traceCapture, executionResult); ok {
 		return escalatedTask, escalatedBubble, nil, nil, nil

--- a/services/local-service/internal/orchestrator/governance.go
+++ b/services/local-service/internal/orchestrator/governance.go
@@ -139,6 +139,9 @@ func (s *Service) maybePauseForRuntimeApproval(task runengine.TaskRecord, taskIn
 		assessment = s.fallbackRuntimeApprovalAssessment(result)
 	}
 	pendingExecution := s.applyGovernanceAssessment(s.buildPendingExecution(task, taskIntent), assessment)
+	if blockedToolCall, found := latestApprovalRequiredToolCall(result.ToolCalls); found {
+		pendingExecution = applyRuntimeApprovedToolInput(pendingExecution, blockedToolCall.Input)
+	}
 	approvalRequest := buildApprovalRequest(task.TaskID, taskIntent, assessment)
 	bubble := s.delivery.BuildBubbleMessage(task.TaskID, "status", presentation.Text(presentation.MessageBubbleGovernancePending, nil), task.UpdatedAt.Format(dateTimeLayout))
 	updatedTask, changed := s.runEngine.MarkWaitingApprovalWithPlan(task.TaskID, approvalRequest, pendingExecution, bubble)
@@ -242,6 +245,23 @@ func runtimeApprovalTargetObject(toolCall tools.ToolCallRecord) string {
 		return apps[0]
 	}
 	return impactScopeTarget(impactScope, execution.GovernanceTargetObject(toolCall.ToolName, toolCall.Input, nil))
+}
+
+// applyRuntimeApprovedToolInput persists the exact blocked tool payload onto the
+// waiting-auth resume plan. Resume execution may still replay agent_loop, but
+// governance bypass is then restricted to this concrete input instead of any
+// later tool call that only shares the same target object.
+func applyRuntimeApprovedToolInput(plan map[string]any, toolInput map[string]any) map[string]any {
+	updatedPlan := cloneMap(plan)
+	if updatedPlan == nil {
+		updatedPlan = map[string]any{}
+	}
+	if len(toolInput) == 0 {
+		delete(updatedPlan, "approved_tool_input")
+		return updatedPlan
+	}
+	updatedPlan["approved_tool_input"] = cloneMap(toolInput)
+	return updatedPlan
 }
 
 func (s *Service) fallbackGovernanceAssessment(task runengine.TaskRecord, taskIntent map[string]any) (execution.GovernanceAssessment, bool) {

--- a/services/local-service/internal/orchestrator/governance.go
+++ b/services/local-service/internal/orchestrator/governance.go
@@ -241,10 +241,7 @@ func runtimeApprovalTargetObject(toolCall tools.ToolCallRecord) string {
 	if apps := stringSliceValue(impactScope["apps"]); len(apps) > 0 {
 		return apps[0]
 	}
-	return impactScopeTarget(impactScope, firstNonEmptyString(
-		firstNonEmptyString(stringValue(toolCall.Input, "url", ""), stringValue(toolCall.Input, "target_url", "")),
-		firstNonEmptyString(stringValue(toolCall.Input, "path", ""), stringValue(toolCall.Input, "working_dir", "")),
-	))
+	return impactScopeTarget(impactScope, execution.GovernanceTargetObject(toolCall.ToolName, toolCall.Input, nil))
 }
 
 func (s *Service) fallbackGovernanceAssessment(task runengine.TaskRecord, taskIntent map[string]any) (execution.GovernanceAssessment, bool) {

--- a/services/local-service/internal/orchestrator/governance.go
+++ b/services/local-service/internal/orchestrator/governance.go
@@ -3,13 +3,16 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/agentloop"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/audit"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/execution"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/presentation"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/runengine"
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/tools"
 )
 
 var approvalIDSequence atomic.Uint64
@@ -117,6 +120,131 @@ func (s *Service) handleTaskGovernanceDecision(task runengine.TaskRecord, taskIn
 		"bubble_message":  bubble,
 		"delivery_result": nil,
 	}, true, nil
+}
+
+func (s *Service) maybePauseForRuntimeApproval(task runengine.TaskRecord, taskIntent map[string]any, result execution.Result) (runengine.TaskRecord, map[string]any, bool, error) {
+	if result.LoopStopReason != string(agentloop.StopReasonNeedAuthorization) {
+		return task, nil, false, nil
+	}
+	// Runtime tool approval differs from preflight approval: the model selected
+	// the concrete tool and input during the Agent Loop, so the approval anchor
+	// must be rebuilt from the recorded tool call instead of the broad task
+	// intent. This keeps the paused task resumable without accepting unrelated
+	// follow-up tool choices.
+	assessment, ok, err := s.runtimeApprovalAssessment(task, result)
+	if err != nil {
+		return task, nil, false, err
+	}
+	if !ok {
+		assessment = s.fallbackRuntimeApprovalAssessment(result)
+	}
+	pendingExecution := s.applyGovernanceAssessment(s.buildPendingExecution(task, taskIntent), assessment)
+	approvalRequest := buildApprovalRequest(task.TaskID, taskIntent, assessment)
+	bubble := s.delivery.BuildBubbleMessage(task.TaskID, "status", presentation.Text(presentation.MessageBubbleGovernancePending, nil), task.UpdatedAt.Format(dateTimeLayout))
+	updatedTask, changed := s.runEngine.MarkWaitingApprovalWithPlan(task.TaskID, approvalRequest, pendingExecution, bubble)
+	if !changed {
+		return task, nil, false, ErrTaskNotFound
+	}
+	if err := s.persistApprovalRequestState(updatedTask.TaskID, approvalRequest, assessment.ImpactScope); err != nil {
+		return task, nil, false, err
+	}
+	return updatedTask, map[string]any{
+		"task":            taskMap(updatedTask),
+		"bubble_message":  bubble,
+		"delivery_result": nil,
+	}, true, nil
+}
+
+// runtimeApprovalAssessment reconstructs the formal approval_request boundary
+// from the tool call that stopped the Agent Loop. The executor is asked to
+// re-assess the exact operation/input pair so approval replay uses the same
+// target matching rules as normal preflight governance.
+func (s *Service) runtimeApprovalAssessment(task runengine.TaskRecord, result execution.Result) (execution.GovernanceAssessment, bool, error) {
+	toolCall, ok := latestApprovalRequiredToolCall(result.ToolCalls)
+	if !ok {
+		return execution.GovernanceAssessment{}, false, nil
+	}
+	runtimeIntent := map[string]any{
+		"name":      toolCall.ToolName,
+		"arguments": cloneMap(toolCall.Input),
+	}
+	if s.executor == nil {
+		return normalizeRuntimeApprovalAssessment(execution.GovernanceAssessment{}, toolCall), true, nil
+	}
+	resultTitle, _, _ := resultSpecFromIntent(runtimeIntent)
+	assessment, ok, err := s.executor.AssessGovernance(context.Background(), execution.Request{
+		TaskID:       task.TaskID,
+		RunID:        task.RunID,
+		SourceType:   task.SourceType,
+		Title:        task.Title,
+		Intent:       runtimeIntent,
+		Snapshot:     snapshotFromTask(task),
+		DeliveryType: deliveryTypeFromIntent(runtimeIntent),
+		ResultTitle:  resultTitle,
+	})
+	if err != nil {
+		return execution.GovernanceAssessment{}, false, err
+	}
+	if !ok {
+		return normalizeRuntimeApprovalAssessment(execution.GovernanceAssessment{}, toolCall), true, nil
+	}
+	return normalizeRuntimeApprovalAssessment(assessment, toolCall), true, nil
+}
+
+func (s *Service) fallbackRuntimeApprovalAssessment(result execution.Result) execution.GovernanceAssessment {
+	toolCall, _ := latestApprovalRequiredToolCall(result.ToolCalls)
+	return normalizeRuntimeApprovalAssessment(execution.GovernanceAssessment{}, toolCall)
+}
+
+func normalizeRuntimeApprovalAssessment(assessment execution.GovernanceAssessment, toolCall tools.ToolCallRecord) execution.GovernanceAssessment {
+	assessment.ApprovalRequired = true
+	if strings.TrimSpace(assessment.OperationName) == "" {
+		assessment.OperationName = firstNonEmptyString(toolCall.ToolName, "agent_loop")
+	}
+	if strings.TrimSpace(assessment.TargetObject) == "" {
+		assessment.TargetObject = runtimeApprovalTargetObject(toolCall)
+	}
+	if strings.TrimSpace(assessment.RiskLevel) == "" || assessment.RiskLevel == tools.RiskLevelGreen {
+		assessment.RiskLevel = firstNonEmptyString(stringValue(toolCall.Output, "risk_level", ""), tools.RiskLevelYellow)
+	}
+	if strings.TrimSpace(assessment.Reason) == "" {
+		assessment.Reason = firstNonEmptyString(stringValue(toolCall.Output, "reason", ""), firstNonEmptyString(stringValue(toolCall.Output, "deny_reason", ""), "policy_requires_authorization"))
+	}
+	if len(assessment.ImpactScope) == 0 {
+		assessment.ImpactScope = cloneMap(mapValue(toolCall.Output, "impact_scope"))
+	}
+	return assessment
+}
+
+func latestApprovalRequiredToolCall(toolCalls []tools.ToolCallRecord) (tools.ToolCallRecord, bool) {
+	for index := len(toolCalls) - 1; index >= 0; index-- {
+		toolCall := toolCalls[index]
+		if toolCallRequiresApproval(toolCall) {
+			return toolCall, true
+		}
+	}
+	return tools.ToolCallRecord{}, false
+}
+
+func toolCallRequiresApproval(toolCall tools.ToolCallRecord) bool {
+	if toolCall.ErrorCode != nil && *toolCall.ErrorCode == tools.ToolErrorCodeApprovalRequired {
+		return true
+	}
+	return toolCall.Status == tools.ToolCallStatusFailed && boolValue(toolCall.Output, "approval_required", false)
+}
+
+func runtimeApprovalTargetObject(toolCall tools.ToolCallRecord) string {
+	impactScope := mapValue(toolCall.Output, "impact_scope")
+	if webpages := stringSliceValue(impactScope["webpages"]); len(webpages) > 0 {
+		return webpages[0]
+	}
+	if apps := stringSliceValue(impactScope["apps"]); len(apps) > 0 {
+		return apps[0]
+	}
+	return impactScopeTarget(impactScope, firstNonEmptyString(
+		firstNonEmptyString(stringValue(toolCall.Input, "url", ""), stringValue(toolCall.Input, "target_url", "")),
+		firstNonEmptyString(stringValue(toolCall.Input, "path", ""), stringValue(toolCall.Input, "working_dir", "")),
+	))
 }
 
 func (s *Service) fallbackGovernanceAssessment(task runengine.TaskRecord, taskIntent map[string]any) (execution.GovernanceAssessment, bool) {

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -4740,6 +4740,9 @@ func TestServiceAgentLoopToolApprovalPausesWaitingAuth(t *testing.T) {
 	if stringValue(record.PendingExecution, "operation_name", "") != "page_read" || stringValue(record.PendingExecution, "target_object", "") != "https://example.com" {
 		t.Fatalf("expected pending execution to preserve runtime tool target, got %+v", record.PendingExecution)
 	}
+	if !reflect.DeepEqual(mapValue(record.PendingExecution, "approved_tool_input"), map[string]any{"url": "https://example.com"}) {
+		t.Fatalf("expected pending execution to preserve exact runtime tool input, got %+v", record.PendingExecution)
+	}
 	notifications, ok := service.runEngine.PendingNotifications(taskID)
 	if !ok {
 		t.Fatal("expected waiting task notifications")
@@ -4753,6 +4756,100 @@ func TestServiceAgentLoopToolApprovalPausesWaitingAuth(t *testing.T) {
 	}
 	if !hasApprovalPending {
 		t.Fatalf("expected approval.pending notification, got %+v", notifications)
+	}
+}
+
+func TestServiceRuntimeApprovalResumeRejectsChangedToolInput(t *testing.T) {
+	modelClient := &stubToolCallingModelClient{
+		toolCalls: []model.ToolCallResult{
+			{
+				RequestID: "req_agent_loop_search_first",
+				Provider:  "openai_responses",
+				ModelID:   "gpt-5.4",
+				ToolCalls: []model.ToolInvocation{{
+					Name: "page_search",
+					Arguments: map[string]any{
+						"url":   "https://example.com",
+						"query": "billing",
+						"limit": 3,
+					},
+				}},
+			},
+			{
+				RequestID: "req_agent_loop_search_second",
+				Provider:  "openai_responses",
+				ModelID:   "gpt-5.4",
+				ToolCalls: []model.ToolInvocation{{
+					Name: "page_search",
+					Arguments: map[string]any{
+						"url":   "https://example.com",
+						"query": "security",
+						"limit": 3,
+					},
+				}},
+			},
+		},
+	}
+	service, _ := newTestServiceWithModelClient(t, modelClient)
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_agent_loop_exec_auth",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "先看看当前仓库状态",
+		},
+		"intent": map[string]any{
+			"name":      "agent_loop",
+			"arguments": map[string]any{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+	if startResult["task"].(map[string]any)["status"] != "waiting_auth" {
+		t.Fatalf("expected first runtime approval to enter waiting_auth, got %+v", startResult["task"])
+	}
+
+	taskID := startResult["task"].(map[string]any)["task_id"].(string)
+	firstRecord, ok := service.runEngine.GetTask(taskID)
+	if !ok {
+		t.Fatal("expected first waiting_auth task record")
+	}
+	firstApprovedInput := map[string]any{
+		"url":   "https://example.com",
+		"query": "billing",
+		"limit": 3,
+	}
+	if !reflect.DeepEqual(mapValue(firstRecord.PendingExecution, "approved_tool_input"), firstApprovedInput) {
+		t.Fatalf("expected first runtime approval to preserve exact tool input, got %+v", firstRecord.PendingExecution)
+	}
+
+	respondResult, err := service.SecurityRespond(map[string]any{
+		"task_id":     taskID,
+		"approval_id": activeApprovalIDForTask(t, service, taskID),
+		"decision":    "allow_once",
+	})
+	if err != nil {
+		t.Fatalf("security respond allow_once failed: %v", err)
+	}
+
+	respondTask := respondResult["task"].(map[string]any)
+	if respondTask["status"] != "waiting_auth" {
+		t.Fatalf("expected changed replay input to require fresh approval, got %+v", respondTask)
+	}
+	secondRecord, ok := service.runEngine.GetTask(taskID)
+	if !ok {
+		t.Fatal("expected second waiting_auth task record")
+	}
+	secondApprovedInput := map[string]any{
+		"url":   "https://example.com",
+		"query": "security",
+		"limit": 3,
+	}
+	if !reflect.DeepEqual(mapValue(secondRecord.PendingExecution, "approved_tool_input"), secondApprovedInput) {
+		t.Fatalf("expected renewed approval to track second tool input, got %+v", secondRecord.PendingExecution)
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cialloclaw/cialloclaw/services/local-service/internal/agentloop"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/audit"
 	"github.com/cialloclaw/cialloclaw/services/local-service/internal/checkpoint"
 	serviceconfig "github.com/cialloclaw/cialloclaw/services/local-service/internal/config"
@@ -4684,6 +4685,74 @@ func TestServiceStartTaskWaitingAuthDoesNotSetFinishedAt(t *testing.T) {
 	}
 	if record.FinishedAt != nil {
 		t.Fatal("expected runtime waiting_auth task to keep finished_at nil")
+	}
+}
+
+func TestServiceAgentLoopToolApprovalPausesWaitingAuth(t *testing.T) {
+	modelClient := &stubToolCallingModelClient{
+		toolCalls: []model.ToolCallResult{{
+			RequestID: "req_agent_loop_page_read",
+			Provider:  "openai_responses",
+			ModelID:   "gpt-5.4",
+			ToolCalls: []model.ToolInvocation{{
+				Name:      "page_read",
+				Arguments: map[string]any{"url": "https://example.com"},
+			}},
+		}},
+	}
+	service, _ := newTestServiceWithModelClient(t, modelClient)
+
+	startResult, err := service.StartTask(map[string]any{
+		"session_id": "sess_agent_loop_auth",
+		"source":     "floating_ball",
+		"trigger":    "hover_text_input",
+		"input": map[string]any{
+			"type": "text",
+			"text": "去 https://example.com 看一下页面内容",
+		},
+		"intent": map[string]any{
+			"name":      "agent_loop",
+			"arguments": map[string]any{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("start task failed: %v", err)
+	}
+
+	startedTask := startResult["task"].(map[string]any)
+	if startedTask["status"] != "waiting_auth" || startedTask["current_step"] != "waiting_authorization" {
+		t.Fatalf("expected runtime approval to enter waiting_auth, got %+v", startedTask)
+	}
+	if startResult["delivery_result"] != nil {
+		t.Fatalf("expected runtime approval pause not to produce delivery_result, got %+v", startResult["delivery_result"])
+	}
+	taskID := startedTask["task_id"].(string)
+	record, ok := service.runEngine.GetTask(taskID)
+	if !ok {
+		t.Fatal("expected task to remain in runtime")
+	}
+	if record.LoopStopReason != string(agentloop.StopReasonNeedAuthorization) {
+		t.Fatalf("expected loop stop reason need_authorization, got %q", record.LoopStopReason)
+	}
+	if record.ApprovalRequest == nil || stringValue(record.ApprovalRequest, "operation_name", "") != "page_read" {
+		t.Fatalf("expected page_read approval request, got %+v", record.ApprovalRequest)
+	}
+	if stringValue(record.PendingExecution, "operation_name", "") != "page_read" || stringValue(record.PendingExecution, "target_object", "") != "https://example.com" {
+		t.Fatalf("expected pending execution to preserve runtime tool target, got %+v", record.PendingExecution)
+	}
+	notifications, ok := service.runEngine.PendingNotifications(taskID)
+	if !ok {
+		t.Fatal("expected waiting task notifications")
+	}
+	hasApprovalPending := false
+	for _, notification := range notifications {
+		if notification.Method == "approval.pending" {
+			hasApprovalPending = true
+			break
+		}
+	}
+	if !hasApprovalPending {
+		t.Fatalf("expected approval.pending notification, got %+v", notifications)
 	}
 }
 

--- a/services/local-service/internal/orchestrator/service_test.go
+++ b/services/local-service/internal/orchestrator/service_test.go
@@ -4756,6 +4756,34 @@ func TestServiceAgentLoopToolApprovalPausesWaitingAuth(t *testing.T) {
 	}
 }
 
+func TestRuntimeApprovalTargetObjectPreservesBrowserSelectors(t *testing.T) {
+	titleTarget := runtimeApprovalTargetObject(tools.ToolCallRecord{
+		ToolName: "browser_attach_current",
+		Input: map[string]any{
+			"attach": map[string]any{
+				"browser_kind": "chrome",
+				"target":       map[string]any{"title_contains": "Pinned Tab"},
+			},
+		},
+	})
+	if titleTarget != "Pinned Tab" {
+		t.Fatalf("expected browser title selector target, got %q", titleTarget)
+	}
+
+	tabTarget := runtimeApprovalTargetObject(tools.ToolCallRecord{
+		ToolName: "browser_tab_focus",
+		Input: map[string]any{
+			"attach": map[string]any{
+				"browser_kind": "chrome",
+				"target":       map[string]any{"page_index": 2},
+			},
+		},
+	})
+	if tabTarget != "browser_tab:2" {
+		t.Fatalf("expected browser tab selector target, got %q", tabTarget)
+	}
+}
+
 // TestServiceConfirmCanEnterWaitingAuth verifies confirm flows can enter
 // waiting_auth.
 func TestServiceConfirmCanEnterWaitingAuth(t *testing.T) {

--- a/services/local-service/internal/tools/executor.go
+++ b/services/local-service/internal/tools/executor.go
@@ -3,6 +3,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -342,7 +343,13 @@ func approvalBypassAllowed(execCtx *ToolExecuteContext, toolName string, prechec
 		return false
 	}
 	workspaceRoot := strings.TrimSpace(precheckInput.Workspace.WorkspacePath)
-	return normalizeApprovalTarget(execCtx.ApprovedTargetObject, workspaceRoot) == normalizeApprovalTarget(target, workspaceRoot)
+	if normalizeApprovalTarget(execCtx.ApprovedTargetObject, workspaceRoot) != normalizeApprovalTarget(target, workspaceRoot) {
+		return false
+	}
+	if len(execCtx.ApprovedToolInput) == 0 {
+		return true
+	}
+	return sameApprovedToolInput(execCtx.ApprovedToolInput, precheckInput.Input)
 }
 
 func normalizeApprovalTarget(target, workspaceRoot string) string {
@@ -363,6 +370,18 @@ func normalizeApprovalTarget(target, workspaceRoot string) string {
 		return "."
 	}
 	return strings.Trim(path.Clean(normalized), "/")
+}
+
+// sameApprovedToolInput compares the exact approved payload with the replayed
+// tool input. Runtime agent-loop approvals persist the blocked tool input so a
+// later allow_once decision only bypasses governance for the same payload.
+func sameApprovedToolInput(approved, current map[string]any) bool {
+	approvedJSON, approvedErr := json.Marshal(approved)
+	currentJSON, currentErr := json.Marshal(current)
+	if approvedErr != nil || currentErr != nil {
+		return false
+	}
+	return string(approvedJSON) == string(currentJSON)
 }
 
 func normalizeDuration(duration time.Duration) time.Duration {

--- a/services/local-service/internal/tools/executor_test.go
+++ b/services/local-service/internal/tools/executor_test.go
@@ -236,8 +236,10 @@ func TestApprovalBypassAllowedUsesStoredOperationAndTarget(t *testing.T) {
 		ApprovalGranted:      true,
 		ApprovedOperation:    "write_file",
 		ApprovedTargetObject: "workspace/notes/a.md",
+		ApprovedToolInput:    map[string]any{"path": "notes/a.md", "content": "hello"},
 	}
 	precheckInput := RiskPrecheckInput{
+		Input: map[string]any{"path": "notes/a.md", "content": "hello"},
 		Workspace: WorkspaceBoundaryInfo{
 			WorkspacePath: "D:/repo/workspace",
 			TargetPath:    "D:/repo/workspace/notes/a.md",
@@ -249,9 +251,14 @@ func TestApprovalBypassAllowedUsesStoredOperationAndTarget(t *testing.T) {
 	if approvalBypassAllowed(execCtx, "exec_command", precheckInput) {
 		t.Fatal("expected approval bypass to reject mismatched operation")
 	}
+	precheckInput.Input["content"] = "changed"
+	if approvalBypassAllowed(execCtx, "write_file", precheckInput) {
+		t.Fatal("expected approval bypass to reject mismatched approved tool input")
+	}
 
 	execCtx.ApprovedOperation = ""
 	execCtx.ApprovedTargetObject = ""
+	execCtx.ApprovedToolInput = nil
 	if !approvalBypassAllowed(execCtx, "write_file", precheckInput) {
 		t.Fatal("expected blank approved target to allow granted approval")
 	}

--- a/services/local-service/internal/tools/types.go
+++ b/services/local-service/internal/tools/types.go
@@ -590,6 +590,7 @@ type ToolExecuteContext struct {
 	ApprovalGranted      bool
 	ApprovedOperation    string
 	ApprovedTargetObject string
+	ApprovedToolInput    map[string]any
 
 	Storage    StorageCapability
 	Platform   PlatformCapability


### PR DESCRIPTION
## Summary
- Stop Agent Loop execution with `need_authorization` when a selected tool is blocked by approval.
- Convert runtime approval stops into formal `approval_request`, `waiting_auth`, and `approval.pending` state.
- Add regression coverage for agent-loop `page_read` approval pauses.

## Testing
- go test ./internal/agentloop
- go test ./internal/execution
- go test ./internal/orchestrator
- go test ./...
- go run ./scripts/ci/local-service-style