### PR TITLE
fix(desktop): stabilize shell-ball during auth waits

### DIFF
--- a/apps/desktop/src/features/shell-ball/components/ShellBallBubbleMessage.tsx
+++ b/apps/desktop/src/features/shell-ball/components/ShellBallBubbleMessage.tsx
@@ -34,8 +34,8 @@ export function ShellBallBubbleMessage({
   const measureRef = useRef<HTMLParagraphElement>(null);
   const userToggledCollapseRef = useRef(false);
   const bubbleId = item.bubble.bubble_id;
-  const taskId = item.bubble.task_id.trim();
-  const bubbleText = item.bubble.text;
+  const taskId = typeof item.bubble.task_id === "string" ? item.bubble.task_id.trim() : "";
+  const bubbleText = typeof item.bubble.text === "string" ? item.bubble.text : "";
   const showMarkdown = item.role === "agent" && item.bubble.type !== "intent_confirm";
   const showLoadingState = item.desktop.presentationHint === "loading";
   const inlineApproval = item.role === "agent" ? item.desktop.inlineApproval : undefined;

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -9032,6 +9032,7 @@ test("intent confirm cancel action is wired to formal task cancellation", () => 
   assert.match(bubbleMessageSource, />取消任务</);
   assert.match(bubbleMessageSource, /data-bubble-action="cancel_task"/);
   assert.match(coordinatorSource, /function normalizeShellBallBackendBubbleMessage\(/);
+  assert.match(coordinatorSource, /task_id: typeof bubbleMessage\.task_id === "string" && bubbleMessage\.task_id\.trim\(\) !== ""[\s\S]*\? bubbleMessage\.task_id[\s\S]*: fallback\.taskId,/);
   assert.match(coordinatorSource, /const decisionText = payload\.decision === "confirm" \? "确认" : "取消任务";/);
   assert.match(
     coordinatorSource,

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -4444,6 +4444,10 @@ test("shell-ball dashboard gesture policy stays task-2 explicit", () => {
     true,
   );
   assert.equal(
+    getShellBallDashboardOpenGesturePolicy({ gesture: "double_click", state: "waiting_auth", interactionConsumed: false }),
+    true,
+  );
+  assert.equal(
     getShellBallDashboardOpenGesturePolicy({ gesture: "double_click", state: "hover_input", interactionConsumed: true }),
     false,
   );
@@ -8951,6 +8955,10 @@ test("shell-ball app dashboard-open gate stays blocked for consumed or non-resti
   );
   assert.equal(
     getShellBallDashboardOpenGesturePolicy({ gesture: "double_click", state: "hover_input", interactionConsumed: false }),
+    true,
+  );
+  assert.equal(
+    getShellBallDashboardOpenGesturePolicy({ gesture: "double_click", state: "waiting_auth", interactionConsumed: false }),
     true,
   );
   assert.equal(

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -25,7 +25,6 @@ import {
   SHELL_BALL_PRESS_DRIFT_TOLERANCE_PX,
   SHELL_BALL_PROCESSING_MS,
   SHELL_BALL_VERTICAL_PRIORITY_RATIO,
-  SHELL_BALL_WAITING_AUTH_MS,
 } from "./shellBall.interaction";
 import { getShellBallMotionConfig } from "./shellBall.motion";
 import { collectShellBallSpeechTranscript, composeShellBallSpeechDraft } from "./shellBall.speech";
@@ -313,6 +312,7 @@ function withWindowControllerRuntime<T>(runtime: {
 function withHideOnCloseRequestRuntime<T>(
   currentWindow: {
     __calls__?: string[];
+    __transitionResult__?: boolean;
     destroy?: () => Promise<void> | void;
     label?: string;
     hide: () => Promise<void> | void;
@@ -340,7 +340,7 @@ function withHideOnCloseRequestRuntime<T>(
       return {
         requestShellBallDashboardCloseTransition() {
           (currentWindow as { __calls__?: string[] }).__calls__?.push("requestShellBallDashboardCloseTransition");
-          return Promise.resolve(true);
+          return Promise.resolve((currentWindow as { __transitionResult__?: boolean }).__transitionResult__ ?? true);
         },
       };
     }
@@ -1227,10 +1227,12 @@ test("hide-on-close helper waits for the dashboard close transition only in the 
   for (const scenario of [
     {
       label: "dashboard",
+      transitionResult: true,
       expectedCalls: ["onCloseRequested", "preventDefault", "requestShellBallDashboardCloseTransition", "hide"],
     },
     {
       label: "control-panel",
+      transitionResult: true,
       expectedCalls: ["onCloseRequested", "preventDefault", "destroy"],
     },
   ] as const) {
@@ -1239,6 +1241,7 @@ test("hide-on-close helper waits for the dashboard close transition only in the 
 
     await withHideOnCloseRequestRuntime({
       __calls__: calls,
+      __transitionResult__: scenario.transitionResult,
       label: scenario.label,
       onCloseRequested(handler) {
         calls.push("onCloseRequested");
@@ -1262,6 +1265,34 @@ test("hide-on-close helper waits for the dashboard close transition only in the 
 
     assert.deepEqual(calls, scenario.expectedCalls);
   }
+});
+
+test("hide-on-close helper still hides dashboard when the shell-ball close transition fails", async () => {
+  const calls: string[] = [];
+  let closeHandler: ((event: { preventDefault: () => void }) => Promise<void> | void) | null = null;
+
+  await withHideOnCloseRequestRuntime({
+    __calls__: calls,
+    __transitionResult__: false,
+    label: "dashboard",
+    onCloseRequested(handler) {
+      calls.push("onCloseRequested");
+      closeHandler = handler;
+      return "unlisten";
+    },
+    async hide() {
+      calls.push("hide");
+    },
+  }, async ({ installHideOnCloseRequest }) => {
+    installHideOnCloseRequest();
+    await closeHandler?.({
+      preventDefault() {
+        calls.push("preventDefault");
+      },
+    });
+  });
+
+  assert.deepEqual(calls, ["onCloseRequested", "preventDefault", "requestShellBallDashboardCloseTransition", "hide"]);
 });
 
 test("hide-on-close helper lets a destroy-triggered second close continue without prevention", async () => {
@@ -3785,16 +3816,7 @@ test("shell-ball text drop target only arms during eligible text drags", () => {
   );
 });
 
-test("shell-ball interaction contract auto-advances waiting auth and processing states", () => {
-  assert.deepEqual(
-    resolveShellBallTransition({
-      current: "waiting_auth",
-      event: "auto_advance",
-      regionActive: true,
-    }),
-    { next: "processing" },
-  );
-
+test("shell-ball interaction contract keeps waiting auth stable while processing still auto-advances", () => {
   assert.deepEqual(
     resolveShellBallTransition({
       current: "processing",
@@ -3865,14 +3887,10 @@ test("shell-ball controller schedules confirm, auth, and processing auto-advance
 
   authController.dispatch("attach_file", { regionActive: false });
   assert.equal(authController.getState(), "waiting_auth");
-  assert.equal(authScheduler.size, 1);
+  assert.equal(authScheduler.size, 0);
 
   authScheduler.flush();
-  assert.equal(authController.getState(), "processing");
-  assert.equal(authScheduler.size, 1);
-
-  authScheduler.flush();
-  assert.equal(authController.getState(), "idle");
+  assert.equal(authController.getState(), "waiting_auth");
   authController.dispose();
 });
 
@@ -8738,6 +8756,9 @@ test("shell-ball coordinator subscribes to formal task, approval, and runtime up
 
   assert.match(coordinatorSource, /subscribeTaskUpdated\(\(payload\) => \{/);
   assert.match(coordinatorSource, /subscribeApprovalPending\(\(payload\) => \{/);
+  assert.match(coordinatorSource, /const operationName = typeof approvalRequest\.operation_name === "string" \? approvalRequest\.operation_name\.trim\(\) : "";/);
+  assert.match(coordinatorSource, /const targetObject = typeof approvalRequest\.target_object === "string" \? approvalRequest\.target_object\.trim\(\) : "";/);
+  assert.match(coordinatorSource, /const reason = typeof approvalRequest\.reason === "string" \? approvalRequest\.reason\.trim\(\) : "";/);
   assert.match(coordinatorSource, /subscribeAllTaskRuntime\(\(payload\) => \{/);
   assert.match(coordinatorSource, /const queuedRuntimeNotificationsRef = useRef\(new Map<string, QueuedRuntimeNotification\[]>\(\)\);/);
   assert.match(coordinatorSource, /queuedRuntimeNotifications\.forEach\(\(notification\) => \{\s*appendRuntimeObservationBubble\(notification\.taskId, notification\.payload\);/);
@@ -8997,8 +9018,11 @@ test("intent confirm cancel action is wired to formal task cancellation", () => 
   const bubbleMessageSource = readFileSync(resolve(desktopRoot, "src/features/shell-ball/components/ShellBallBubbleMessage.tsx"), "utf8");
   const coordinatorSource = readFileSync(resolve(desktopRoot, "src/features/shell-ball/useShellBallCoordinator.ts"), "utf8");
 
+  assert.match(bubbleMessageSource, /const taskId = typeof item\.bubble\.task_id === "string" \? item\.bubble\.task_id\.trim\(\) : "";/);
+  assert.match(bubbleMessageSource, /const bubbleText = typeof item\.bubble\.text === "string" \? item\.bubble\.text : "";/);
   assert.match(bubbleMessageSource, />取消任务</);
   assert.match(bubbleMessageSource, /data-bubble-action="cancel_task"/);
+  assert.match(coordinatorSource, /function normalizeShellBallBackendBubbleMessage\(/);
   assert.match(coordinatorSource, /const decisionText = payload\.decision === "confirm" \? "确认" : "取消任务";/);
   assert.match(
     coordinatorSource,
@@ -9035,7 +9059,6 @@ test("shell-ball interaction timing constants stay frozen", () => {
   assert.equal(SHELL_BALL_CANCEL_DELTA_PX, 48);
   assert.equal(SHELL_BALL_VERTICAL_PRIORITY_RATIO, 1.25);
   assert.equal(SHELL_BALL_CONFIRMING_MS, 600);
-  assert.equal(SHELL_BALL_WAITING_AUTH_MS, 700);
   assert.equal(SHELL_BALL_PROCESSING_MS, 1200);
 });
 

--- a/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.contract.test.ts
@@ -8763,6 +8763,7 @@ test("shell-ball coordinator subscribes to formal task, approval, and runtime up
   assert.match(coordinatorSource, /const operationName = typeof approvalRequest\.operation_name === "string" \? approvalRequest\.operation_name\.trim\(\) : "";/);
   assert.match(coordinatorSource, /const targetObject = typeof approvalRequest\.target_object === "string" \? approvalRequest\.target_object\.trim\(\) : "";/);
   assert.match(coordinatorSource, /const reason = typeof approvalRequest\.reason === "string" \? approvalRequest\.reason\.trim\(\) : "";/);
+  assert.match(coordinatorSource, /if \(result\.task\?\.status === "waiting_auth"\) \{[\s\S]*仪表盘的安全页完成授权/);
   assert.match(coordinatorSource, /subscribeAllTaskRuntime\(\(payload\) => \{/);
   assert.match(coordinatorSource, /const queuedRuntimeNotificationsRef = useRef\(new Map<string, QueuedRuntimeNotification\[]>\(\)\);/);
   assert.match(coordinatorSource, /queuedRuntimeNotifications\.forEach\(\(notification\) => \{\s*appendRuntimeObservationBubble\(notification\.taskId, notification\.payload\);/);

--- a/apps/desktop/src/features/shell-ball/shellBall.interaction.ts
+++ b/apps/desktop/src/features/shell-ball/shellBall.interaction.ts
@@ -16,7 +16,6 @@ export const SHELL_BALL_LOCK_DELTA_PX = 48;
 export const SHELL_BALL_CANCEL_DELTA_PX = 48;
 export const SHELL_BALL_VERTICAL_PRIORITY_RATIO = 1.25;
 export const SHELL_BALL_CONFIRMING_MS = 600;
-export const SHELL_BALL_WAITING_AUTH_MS = 700;
 export const SHELL_BALL_PROCESSING_MS = 1200;
 
 export type ShellBallVoicePreview = "lock" | "cancel" | null;
@@ -265,8 +264,6 @@ export function resolveShellBallTransition(input: {
       if (current === "hover_input") {
         return {
           next: "waiting_auth",
-          autoAdvanceTo: "processing",
-          autoAdvanceMs: SHELL_BALL_WAITING_AUTH_MS,
         };
       }
       return { next: current };
@@ -294,7 +291,7 @@ export function resolveShellBallTransition(input: {
       };
 
     case "auto_advance":
-      if (current === "confirming_intent" || current === "waiting_auth") {
+      if (current === "confirming_intent") {
         return { next: "processing" };
       }
 

--- a/apps/desktop/src/features/shell-ball/useShellBallCoordinator.ts
+++ b/apps/desktop/src/features/shell-ball/useShellBallCoordinator.ts
@@ -889,6 +889,18 @@ export function createShellBallAgentBubbleItem(
     });
   }
 
+  if (result.task?.status === "waiting_auth") {
+    return createShellBallTextBubbleItem({
+      role: "agent",
+      text: "此任务需要授权，请双击悬浮球后前往仪表盘的安全页完成授权。",
+      bubbleType: "status",
+      createdAt: fallbackCreatedAt,
+      taskId,
+      turnIndex: turnOrder.turnIndex,
+      turnPhase: turnOrder.turnPhase,
+    });
+  }
+
   return createShellBallTextBubbleItem({
     role: "agent",
     text: "已收到，正在处理。",

--- a/apps/desktop/src/features/shell-ball/useShellBallCoordinator.ts
+++ b/apps/desktop/src/features/shell-ball/useShellBallCoordinator.ts
@@ -502,7 +502,15 @@ function isShellBallInputSubmitResult(value: ShellBallInputSubmitResult | null |
 }
 
 function getShellBallResultTaskId(result: ShellBallInputSubmitResult) {
-  return result.task?.task_id ?? result.bubble_message?.task_id ?? "";
+  if (typeof result.task?.task_id === "string") {
+    return result.task.task_id;
+  }
+
+  if (typeof result.bubble_message?.task_id === "string") {
+    return result.bubble_message.task_id;
+  }
+
+  return "";
 }
 
 export function createShellBallFinalizedSpeechBubbleItem(input: {
@@ -551,6 +559,35 @@ function createShellBallTextBubbleItem(input: {
     role: input.role,
     desktop: createShellBallBubbleDesktopState(input),
   } satisfies ShellBallBubbleItem;
+}
+
+/**
+ * Backend bubble payloads can travel through runtime and compatibility paths.
+ * Normalize them once at the shell-ball boundary so incomplete payloads do not
+ * crash the floating window renderer.
+ */
+function normalizeShellBallBackendBubbleMessage(
+  bubbleMessage: BubbleMessage,
+  fallback: {
+    createdAt: string;
+    taskId: string;
+  },
+): BubbleMessage {
+  const bubbleId = typeof bubbleMessage.bubble_id === "string" && bubbleMessage.bubble_id.trim() !== ""
+    ? bubbleMessage.bubble_id
+    : `shell-ball-backend-bubble-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+
+  return {
+    bubble_id: bubbleId,
+    task_id: typeof bubbleMessage.task_id === "string" ? bubbleMessage.task_id : fallback.taskId,
+    type: bubbleMessage.type,
+    text: typeof bubbleMessage.text === "string" ? bubbleMessage.text : "",
+    pinned: false,
+    hidden: false,
+    created_at: typeof bubbleMessage.created_at === "string" && bubbleMessage.created_at.trim() !== ""
+      ? bubbleMessage.created_at
+      : fallback.createdAt,
+  };
 }
 
 function getShellBallPendingFileName(filePath: string) {
@@ -658,9 +695,11 @@ function syncShellBallVisualStateFromTaskStatus(status: Parameters<typeof getShe
 }
 
 function createShellBallApprovalPendingReply(approvalRequest: ApprovalRequest) {
-  const operationName = approvalRequest.operation_name.trim();
-  const targetObject = approvalRequest.target_object.trim();
-  const reason = approvalRequest.reason.trim();
+  // approval.pending runs through the shell-ball's local realtime path, so the
+  // fallback copy must tolerate malformed payloads instead of crashing the host.
+  const operationName = typeof approvalRequest.operation_name === "string" ? approvalRequest.operation_name.trim() : "";
+  const targetObject = typeof approvalRequest.target_object === "string" ? approvalRequest.target_object.trim() : "";
+  const reason = typeof approvalRequest.reason === "string" ? approvalRequest.reason.trim() : "";
 
   if (operationName !== "" && targetObject !== "" && reason !== "") {
     return `Waiting for approval: ${operationName} on ${targetObject}. ${reason}`;
@@ -749,12 +788,18 @@ function createShellBallApprovalResponseBubbleItem(input: {
   turnPhase?: number;
 }) {
   const bubbleMessage = input.response.bubble_message;
-  const bubbleText = bubbleMessage?.text.trim() ?? "";
+  const normalizedBubbleMessage = bubbleMessage === null
+    ? null
+    : normalizeShellBallBackendBubbleMessage(bubbleMessage, {
+        createdAt: input.createdAt,
+        taskId: input.taskId,
+      });
+  const bubbleText = normalizedBubbleMessage?.text.trim() ?? "";
 
-  if (bubbleMessage !== null && bubbleText !== "") {
+  if (normalizedBubbleMessage !== null && bubbleText !== "") {
     return {
       bubble: {
-        ...bubbleMessage,
+        ...normalizedBubbleMessage,
         task_id: input.taskId,
         hidden: false,
         pinned: false,
@@ -786,18 +831,24 @@ export function createShellBallAgentBubbleItem(
   turnOrder: ShellBallBubbleTurnOrder = {},
 ) {
   const bubbleMessage = result.bubble_message;
-  const bubbleText = bubbleMessage?.text.trim() ?? "";
+  const normalizedBubbleMessage = bubbleMessage === null
+    ? null
+    : normalizeShellBallBackendBubbleMessage(bubbleMessage, {
+        createdAt: fallbackCreatedAt,
+        taskId: getShellBallResultTaskId(result),
+      });
+  const bubbleText = normalizedBubbleMessage?.text.trim() ?? "";
   const deliveryPreview = result.delivery_result?.preview_text?.trim() ?? "";
   const taskId = getShellBallResultTaskId(result);
 
-  if (bubbleMessage !== null && bubbleText !== "") {
-    const bubbleType = bubbleMessage.type;
+  if (normalizedBubbleMessage !== null && bubbleText !== "") {
+    const bubbleType = normalizedBubbleMessage.type;
 
     if (bubbleType === "result" && result.delivery_result !== null) {
       return createShellBallDeliveryResultBubbleItem({
         taskId,
         deliveryResult: result.delivery_result,
-        createdAt: bubbleMessage.created_at || fallbackCreatedAt,
+        createdAt: normalizedBubbleMessage.created_at || fallbackCreatedAt,
         turnIndex: turnOrder.turnIndex,
         turnPhase: turnOrder.turnPhase,
         textOverride: bubbleText,
@@ -814,7 +865,7 @@ export function createShellBallAgentBubbleItem(
 
     return {
       bubble: {
-        ...bubbleMessage,
+        ...normalizedBubbleMessage,
         hidden: false,
         pinned: false,
       },
@@ -831,7 +882,7 @@ export function createShellBallAgentBubbleItem(
       role: "agent",
       text: deliveryPreview,
       bubbleType: "result",
-      createdAt: result.delivery_result?.payload?.task_id ? fallbackCreatedAt : bubbleMessage?.created_at ?? fallbackCreatedAt,
+      createdAt: result.delivery_result?.payload?.task_id ? fallbackCreatedAt : normalizedBubbleMessage?.created_at ?? fallbackCreatedAt,
       taskId,
       turnIndex: turnOrder.turnIndex,
       turnPhase: turnOrder.turnPhase,
@@ -857,12 +908,18 @@ function createShellBallSteerBubbleItem(
   turnOrder: ShellBallBubbleTurnOrder = {},
 ) {
   const bubbleMessage = result.bubble_message;
-  const bubbleText = bubbleMessage?.text.trim() ?? "";
+  const normalizedBubbleMessage = bubbleMessage === null
+    ? null
+    : normalizeShellBallBackendBubbleMessage(bubbleMessage, {
+        createdAt: fallbackCreatedAt,
+        taskId: result.task.task_id,
+      });
+  const bubbleText = normalizedBubbleMessage?.text.trim() ?? "";
 
-  if (bubbleMessage !== null && bubbleText !== "") {
+  if (normalizedBubbleMessage !== null && bubbleText !== "") {
     return {
       bubble: {
-        ...bubbleMessage,
+        ...normalizedBubbleMessage,
         hidden: false,
         pinned: false,
       },
@@ -890,12 +947,18 @@ function createShellBallTaskControlBubbleItem(
   turnOrder: ShellBallBubbleTurnOrder = {},
 ) {
   const bubbleMessage = result.bubble_message;
-  const bubbleText = bubbleMessage?.text.trim() ?? "";
+  const normalizedBubbleMessage = bubbleMessage === null
+    ? null
+    : normalizeShellBallBackendBubbleMessage(bubbleMessage, {
+        createdAt: fallbackCreatedAt,
+        taskId: result.task.task_id,
+      });
+  const bubbleText = normalizedBubbleMessage?.text.trim() ?? "";
 
-  if (bubbleMessage !== null && bubbleText !== "") {
+  if (normalizedBubbleMessage !== null && bubbleText !== "") {
     return {
       bubble: {
-        ...bubbleMessage,
+        ...normalizedBubbleMessage,
         hidden: false,
         pinned: false,
       },

--- a/apps/desktop/src/features/shell-ball/useShellBallCoordinator.ts
+++ b/apps/desktop/src/features/shell-ball/useShellBallCoordinator.ts
@@ -579,7 +579,9 @@ function normalizeShellBallBackendBubbleMessage(
 
   return {
     bubble_id: bubbleId,
-    task_id: typeof bubbleMessage.task_id === "string" ? bubbleMessage.task_id : fallback.taskId,
+    task_id: typeof bubbleMessage.task_id === "string" && bubbleMessage.task_id.trim() !== ""
+      ? bubbleMessage.task_id
+      : fallback.taskId,
     type: bubbleMessage.type,
     text: typeof bubbleMessage.text === "string" ? bubbleMessage.text : "",
     pinned: false,

--- a/apps/desktop/src/features/shell-ball/useShellBallInteraction.ts
+++ b/apps/desktop/src/features/shell-ball/useShellBallInteraction.ts
@@ -52,7 +52,7 @@ function canStartShellBallVoiceEntry(state: ShellBallVisualState | undefined) {
 }
 
 function canOpenShellBallDashboardFromDoubleClick(state: ShellBallVisualState) {
-  return state === "idle" || state === "hover_input" || state === "confirming_intent";
+  return state === "idle" || state === "hover_input" || state === "confirming_intent" || state === "waiting_auth";
 }
 
 const SHELL_BALL_NON_RECOVERABLE_VOICE_ERRORS = new Set([

--- a/apps/desktop/src/platform/dashboardWindowTransition.ts
+++ b/apps/desktop/src/platform/dashboardWindowTransition.ts
@@ -18,6 +18,8 @@ export type ShellBallDashboardTransitionComplete = {
   requestId?: string;
 };
 
+const SHELL_BALL_DASHBOARD_CLOSE_TRANSITION_TIMEOUT_MS = 1_200;
+
 async function getShellBallWindowHandle() {
   const currentWindow = getCurrentWindow();
 
@@ -68,6 +70,26 @@ export async function requestShellBallDashboardCloseTransition() {
   return new Promise<boolean>((resolve) => {
     let settled = false;
     let cleanup: (() => void) | null = null;
+    const timeoutHandle = globalThis.setTimeout(() => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup?.();
+      resolve(false);
+    }, SHELL_BALL_DASHBOARD_CLOSE_TRANSITION_TIMEOUT_MS);
+
+    function finalize(result: boolean) {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      globalThis.clearTimeout(timeoutHandle);
+      cleanup?.();
+      resolve(result);
+    }
 
     void currentWindow
       .listen<ShellBallDashboardTransitionComplete>(shellBallDashboardTransitionEvents.complete, ({ payload }) => {
@@ -75,9 +97,7 @@ export async function requestShellBallDashboardCloseTransition() {
           return;
         }
 
-        settled = true;
-        cleanup?.();
-        resolve(true);
+        finalize(true);
       })
       .then((unlisten) => {
         if (settled) {
@@ -100,13 +120,7 @@ export async function requestShellBallDashboardCloseTransition() {
         void currentWindow.emitTo(shellBallWindowLabels.ball, shellBallDashboardTransitionEvents.request, payload);
       })
       .catch(() => {
-        if (settled) {
-          return;
-        }
-
-        settled = true;
-        cleanup?.();
-        resolve(false);
+        finalize(false);
       });
   });
 }


### PR DESCRIPTION
solve #516 
## Summary
- keep the shell-ball visible when a task enters `waiting_auth` instead of auto-advancing it back through transient local states
- allow the dashboard to close even when the shell-ball transition callback is unavailable, and let users reopen the dashboard while the shell-ball is waiting for approval
- harden shell-ball bubble rendering against malformed `bubble_message` / approval payload fields so auth-wait flows do not collapse the floating window
## Why
The floating shell-ball could disappear or become hard to recover once a task entered the approval path. In the same flow, dashboard close depended on a shell-ball callback with no fallback, so the dashboard could get stuck open if the shell-ball was already in a bad local state.
## What changed
- removed the local `waiting_auth -> processing` auto-advance in the shell-ball interaction state machine
- added a timeout fallback for dashboard close transitions so the dashboard can still hide when shell-ball does not respond
- allowed shell-ball double-click to reopen the dashboard while the current task is waiting for approval
- normalized shell-ball backend bubble payloads before rendering approval / submit / control feedback bubbles
- added contract coverage for:
  - stable `waiting_auth` behavior
  - dashboard close fallback
  - reopening the dashboard during auth wait
  - defensive handling of backend bubble payload fields
## Validation
- `pnpm --dir apps/desktop typecheck`
- `pnpm --dir apps/desktop lint`
## Follow-up
- shell-ball still appears to have a separate stale-state issue where `waiting_auth` can remain latched even after the formal task has already completed; that should be handled in a follow-up fix focused on active task state reconciliation